### PR TITLE
feat: log success metrics and cover shadow failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ This repository showcases small, complete automation pipelines and PoCs for inte
    - CIの信頼性を高めるため、flaky test を自動処理する仕組み。
    - _Analyze CI logs to detect flaky tests, auto-rerun, tag, or create tickets automatically._
 
+4. **LLM Adapter — Shadow Execution & Error Handling (Minimal)**
+   - プライマリ結果はそのまま採用しつつ、影（shadow）実行で別プロバイダを並走 → 差分をメトリクスに記録して可視化。
+   - _Minimal adapter showcasing shadow execution (metrics-only background run) and deterministic error-case fallbacks._
+
 ### 1. 仕様書テキスト → 構造化テストケース → CLIで自動実行
 
 - `projects/01-spec2cases/spec.sample.md` のような Markdown からテストケース JSON を生成。
@@ -69,11 +73,28 @@ This repository showcases small, complete automation pipelines and PoCs for inte
   ```
   - Node.js のみで動作する軽量 XML パーサーを実装し、外部依存なしでレポートを吸収。
   - 直近 5 件の実行から fail→pass を検知すると flaky として表示。
-- 直近で fail→pass したテストを Markdown で出力し、Issue 化に利用。
+  - 直近で fail→pass したテストを Markdown で出力し、Issue 化に利用。
   ```bash
   npm run ci:issue
   ```
   - 失敗率や平均時間、直近 10 実行のタイムラインを含むレポートを生成。
+
+### 4. LLM Adapter — Shadow Execution & Error Handling (Minimal)
+
+- プライマリ結果をそのまま使いながら、裏で別プロバイダを**影（shadow）実行**して差分メトリクスを蓄積。
+- `[TIMEOUT]` / `[RATELIMIT]` / `[INVALID_JSON]` を含むプロンプトで異常系を明示的に再現し、フォールバックの挙動を検証。
+
+```bash
+cd projects/04-llm-adapter-shadow
+python3 -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+python demo_shadow.py  # => artifacts/runs-metrics.jsonl に shadow_diff / provider_success を記録
+pytest -q  # ERR / SHD シナリオのテスト一式
+```
+
+- `shadow_diff` ではプライマリと影のレイテンシ差分・トークン使用量・ハッシュを記録。
+- `provider_error` / `provider_chain_failed` でフォールバック過程をトレース可能。
+- 詳細な構成は `projects/04-llm-adapter-shadow/README.md` を参照。
 
 ---
 
@@ -90,19 +111,5 @@ This repository showcases small, complete automation pipelines and PoCs for inte
 - メトリクスや成果（工数削減、安定化率など）をREADME内に明記  
 - 英語READMEやデモ動画を追加予定  
 
-_Add more sample code for each project, include metrics/results (e.g., effort reduction, stability rate), and prepare an English-only README + demo video in the future._  
-
----
-
-
-### 4. LLM Adapter — Shadow Execution & Error Handling (Minimal)
-
-- プライマリ結果はそのまま採用しつつ、**影（shadow）実行**で別プロバイダを並走 → 差分をメトリクスに記録して可視化。
-- タイムアウト/レート制限/形式不正などの**異常系固定セット**でフォールバック動作を確認。
-- 📂 `projects/04-llm-adapter-shadow/`
-  - `src/llm_adapter/…`（最小コア）
-  - `tests/…`（ERR/SHDシナリオ）
-  - `demo_shadow.py`（デモ）
-
-> **EN:** Minimal adapter showcasing shadow execution (metrics-only background run) and error-case fallbacks.
+_Add more sample code for each project, include metrics/results (e.g., effort reduction, stability rate), and prepare an English-only README + demo video in the future._
 

--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -1,14 +1,24 @@
 # 04. LLM Adapter — Shadow Execution & Error Handling (Minimal)
 
-**JP:** プライマリ結果はそのまま採用しつつ、裏で別プロバイダに“影実行”してメトリクスだけを記録する PoC。タイムアウト/レート制限/形式不正などの**異常系固定セット**も最小実装で再現します。
+## Overview
 
-**EN:** Minimal adapter with **shadow execution** (primary result + background run on another provider, metrics-only) and a tiny **error-case suite** (timeout / rate limit / invalid JSON).
+**JP:** プライマリ結果はそのまま採用しつつ、裏で別プロバイダを“影実行”してメトリクスだけを記録する PoC。タイムアウト / レート制限 / 形式不正などの**異常系固定セット**も最小実装で再現します。
 
-## Why
-- 本番の意思決定は変えずに品質/レイテンシ差分を継続測定 → ベンダ選定や回帰検知に効く
-- 異常系を**明示的に再現**できるため、フォールバックや再試行の動作確認が容易
+**EN:** Minimal adapter that keeps the primary response, mirrors the request on a shadow provider for metrics only, and purposefully reproduces timeout / rate limit / malformed-response failures.
 
-## Layout
+## Motivation
+
+- 本番の意思決定を変えずに品質・レイテンシ差分を継続測定 → ベンダ選定や回帰検知に活用。
+- 異常系を**明示的に再現**できるため、フォールバックや再試行の動作確認が容易。
+
+## Key Features
+
+- **Shadow execution telemetry** — `run_with_shadow` でプライマリを待ちつつ、別スレッドで影プロバイダを実行。レスポンス差分やフィンガープリントを `artifacts/runs-metrics.jsonl` へ `shadow_diff` イベントとして記録。
+- **Fallback runner** — `Runner` が `TimeoutError` / `RateLimitError` / `RetriableError` を捕捉し、次候補へ切り替え。成功時は `provider_success`、失敗時は `provider_error` / `provider_chain_failed` を発火。
+- **Deterministic error simulation** — `MockProvider` はプロンプト中の `[TIMEOUT]` / `[RATELIMIT]` / `[INVALID_JSON]` を検知して対応する例外を投げ、異常系をテストから容易に再現。
+
+## Directory Layout
+
 ```
 projects/04-llm-adapter-shadow/
   ├─ src/llm_adapter/
@@ -27,24 +37,76 @@ projects/04-llm-adapter-shadow/
   └─ requirements.txt
 ```
 
-## Quick Start
+## Usage
+
+### Setup
+
 ```bash
 # repo root
 cd projects/04-llm-adapter-shadow
-python3 -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python3 -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-python demo_shadow.py
+```
 
-# run tests
+### Run the demo
+
+```bash
+python demo_shadow.py
+```
+
+標準出力でプライマリ結果を確認しつつ、影実行のメトリクスが `artifacts/runs-metrics.jsonl` に追記されます。
+
+### Run the tests
+
+```bash
 pytest -q
 ```
 
-## What it demonstrates
-- **Shadow execution:** `src/llm_adapter/shadow.py` — primaryを採用しつつ、影で別Providerを実行；差分は `artifacts/runs-metrics.jsonl` へ（成功時は `provider_success`、差分は `shadow_diff` として記録）。
-- **Fallback path:** `runner.py` — `TimeoutError / RateLimitError / RetriableError` を捕捉して**次のProviderに切替**。
-- **Mocked errors:** `providers/mock.py` — プロンプトに `[TIMEOUT]`, `[RATELIMIT]`, `[INVALID_JSON]` を含めると異常を発火。
+## Shadow Execution Metrics
+
+- `run_with_shadow(primary, shadow, request)` はプライマリ結果をそのまま返し、影実行はデーモンスレッドで並列に実行。
+- 影実行が完了すると、`shadow_diff` イベントが記録され、主なフィールドとして以下を含みます:
+  - `request_hash` / `request_fingerprint` — プロバイダ固有・ランナー共通のハッシュ値。
+  - `primary_provider`, `primary_latency_ms`, `primary_text_len`, `primary_token_usage_total`。
+  - `shadow_provider`, `shadow_ok`, `shadow_latency_ms`, `shadow_duration_ms`, `shadow_error`。
+  - 成功時のみ `latency_gap_ms`, `shadow_text_len`, `shadow_token_usage_total` を追加。
+  - 例外が発生した場合は `shadow_error_message` に詳細を格納。
+- `metrics_path=None` を渡すとメトリクス出力を無効化できます。
+
+### Example `shadow_diff`
+
+```json
+{
+  "ts": 1700000000000,
+  "event": "shadow_diff",
+  "request_hash": "7b84e1542fabe2c3",
+  "request_fingerprint": "a9d58e3f21d04ce1",
+  "primary_provider": "primary",
+  "primary_latency_ms": 57,
+  "primary_text_len": 24,
+  "primary_token_usage_total": 28,
+  "shadow_provider": "shadow",
+  "shadow_ok": true,
+  "shadow_latency_ms": 61,
+  "shadow_duration_ms": 63,
+  "latency_gap_ms": 4,
+  "shadow_text_len": 24,
+  "shadow_token_usage_total": 28
+}
+```
+
+## Error Handling & Mock Providers
+
+- `MockProvider` の `error_markers` 引数で有効化するマーカーを制御可能（未指定時は全マーカー有効）。
+- `[TIMEOUT]` → `TimeoutError`
+- `[RATELIMIT]` → `RateLimitError`
+- `[INVALID_JSON]` → `RetriableError`（再試行向けの汎用例外）
+- `Runner` は失敗を `provider_error` として記録し、最終的に全てのプロバイダが失敗した場合は `provider_chain_failed` を出力して例外を再送出します。
 
 ## Notes
+
 - 実プロバイダ統合は意図的に含めていません（**軽量のまま**にするため）。
-- メトリクスはJSONLで軽く残すだけ（ダッシュボードなし）。
-- 後続のLLM Adapter OSS本体とは**独立**して動きます（ポートフォリオ用サンプル）。
+- メトリクスは JSONL に追記するだけの最小構成です。
+- 後続の LLM Adapter OSS 本体とは**独立**して動作する、ポートフォリオ用サンプルです。
+

--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -40,7 +40,7 @@ pytest -q
 ```
 
 ## What it demonstrates
-- **Shadow execution:** `src/llm_adapter/shadow.py` — primaryを採用しつつ、影で別Providerを実行；差分は `artifacts/runs-metrics.jsonl` へ。
+- **Shadow execution:** `src/llm_adapter/shadow.py` — primaryを採用しつつ、影で別Providerを実行；差分は `artifacts/runs-metrics.jsonl` へ（成功時は `provider_success`、差分は `shadow_diff` として記録）。
 - **Fallback path:** `runner.py` — `TimeoutError / RateLimitError / RetriableError` を捕捉して**次のProviderに切替**。
 - **Mocked errors:** `providers/mock.py` — プロンプトに `[TIMEOUT]`, `[RATELIMIT]`, `[INVALID_JSON]` を含めると異常を発火。
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -1,5 +1,37 @@
-class TimeoutError(Exception): ...
-class RateLimitError(Exception): ...
-class AuthError(Exception): ...
-class RetriableError(Exception): ...
-class FatalError(Exception): ...
+"""Error hierarchy for the minimal LLM adapter."""
+
+from __future__ import annotations
+
+
+class AdapterError(Exception):
+    """Base class for errors originating from providers or the adapter."""
+
+
+class TimeoutError(AdapterError):
+    """Raised when a provider does not respond within the expected window."""
+
+
+class RateLimitError(AdapterError):
+    """Raised when a provider rejects the request due to rate limiting."""
+
+
+class AuthError(AdapterError):
+    """Raised when credentials are missing or invalid for the provider."""
+
+
+class RetriableError(AdapterError):
+    """Raised for transient issues where retrying with another provider may help."""
+
+
+class FatalError(AdapterError):
+    """Raised for unrecoverable issues that should halt the runner."""
+
+
+__all__ = [
+    "AdapterError",
+    "TimeoutError",
+    "RateLimitError",
+    "AuthError",
+    "RetriableError",
+    "FatalError",
+]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
@@ -1,11 +1,36 @@
-import time, random
+"""Mock provider that can deterministically trigger failure modes."""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Iterable, Optional, Set
+
 from ..provider_spi import ProviderSPI, ProviderRequest, ProviderResponse, TokenUsage
 from ..errors import TimeoutError, RateLimitError, RetriableError
 
+_MARKER_TO_ERROR = {
+    "[TIMEOUT]": (TimeoutError, "simulated timeout"),
+    "[RATELIMIT]": (RateLimitError, "simulated rate limit"),
+    "[INVALID_JSON]": (RetriableError, "simulated invalid JSON"),
+}
+
+
 class MockProvider(ProviderSPI):
-    def __init__(self, name: str, base_latency_ms: int = 50):
+    """Very small provider implementation for exercising the adapter."""
+
+    def __init__(
+        self,
+        name: str,
+        base_latency_ms: int = 50,
+        error_markers: Optional[Iterable[str]] = None,
+    ) -> None:
         self._name = name
         self.base_latency_ms = base_latency_ms
+        if error_markers is None:
+            self._error_markers: Set[str] = set(_MARKER_TO_ERROR)
+        else:
+            self._error_markers = {marker for marker in error_markers if marker in _MARKER_TO_ERROR}
 
     def name(self) -> str:
         return self._name
@@ -13,23 +38,27 @@ class MockProvider(ProviderSPI):
     def capabilities(self) -> set:
         return {"chat"}
 
+    def _maybe_raise_error(self, text: str) -> None:
+        for marker in self._error_markers:
+            if marker in text:
+                exc_cls, message = _MARKER_TO_ERROR[marker]
+                raise exc_cls(message)
+
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
         text = request.prompt
-        # Trigger errors by markers in prompt
-        if "[TIMEOUT]" in text:
-            time.sleep(self.base_latency_ms / 1000.0)
-            raise TimeoutError("simulated timeout")
-        if "[RATELIMIT]" in text:
-            raise RateLimitError("simulated rate limit")
-        if "[INVALID_JSON]" in text:
-            raise RetriableError("simulated invalid JSON")
+        self._maybe_raise_error(text)
 
-        latency = self.base_latency_ms + int(random.random()*20)
+        latency = self.base_latency_ms + int(random.random() * 20)
         time.sleep(latency / 1000.0)
-        prompt_tokens = max(1, len(text)//4)
-        completion = 16
+
+        prompt_tokens = max(1, len(text) // 4)
+        completion_tokens = 16
+
         return ProviderResponse(
             text=f"echo({self._name}): {text}",
-            token_usage=TokenUsage(prompt=prompt_tokens, completion=completion),
+            token_usage=TokenUsage(prompt=prompt_tokens, completion=completion_tokens),
             latency_ms=latency,
         )
+
+
+__all__ = ["MockProvider"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -1,22 +1,102 @@
+"""Provider runner with fallback handling."""
+
+from __future__ import annotations
+
 import time
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Sequence, Union
+
 from .provider_spi import ProviderSPI, ProviderRequest, ProviderResponse
 from .errors import TimeoutError, RateLimitError, RetriableError
-from .shadow import run_with_shadow
+from .shadow import run_with_shadow, DEFAULT_METRICS_PATH
+from .metrics import log_event
+from .utils import content_hash
+
+MetricsPath = Optional[Union[str, Path]]
+
 
 class Runner:
-    def __init__(self, providers: List[ProviderSPI]):
-        self.providers = providers
+    """Attempt providers sequentially until one succeeds."""
 
-    def run(self, request: ProviderRequest, shadow: Optional[ProviderSPI] = None) -> ProviderResponse:
-        last_err = None
-        for p in self.providers:
+    def __init__(self, providers: Sequence[ProviderSPI]):
+        if not providers:
+            raise ValueError("Runner requires at least one provider")
+        self.providers: List[ProviderSPI] = list(providers)
+
+    def run(
+        self,
+        request: ProviderRequest,
+        shadow: Optional[ProviderSPI] = None,
+        shadow_metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+    ) -> ProviderResponse:
+        """Execute ``request`` with fallback semantics.
+
+        Parameters
+        ----------
+        request:
+            The prompt/options payload shared across providers.
+        shadow:
+            Optional provider that will be executed in the background for
+            telemetry purposes.
+        shadow_metrics_path:
+            JSONL file path for recording metrics. ``None`` disables logging.
+        """
+
+        last_err: Optional[Exception] = None
+        metrics_path_str = None if shadow_metrics_path is None else str(Path(shadow_metrics_path))
+        request_fingerprint = content_hash("runner", request.prompt, request.options)
+
+        def _record_error(err: Exception, attempt: int, provider: ProviderSPI) -> None:
+            if not metrics_path_str:
+                return
+            log_event(
+                "provider_error",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                request_hash=content_hash(provider.name(), request.prompt, request.options),
+                provider=provider.name(),
+                attempt=attempt,
+                total_providers=len(self.providers),
+                error_type=type(err).__name__,
+                error_message=str(err),
+            )
+
+        for attempt_index, provider in enumerate(self.providers, start=1):
             try:
-                return run_with_shadow(p, shadow, request)
-            except RateLimitError as e:
-                last_err = e
-                time.sleep(0.05)  # small backoff then try next
-            except (TimeoutError, RetriableError) as e:
-                last_err = e
+                response = run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
+            except RateLimitError as err:
+                last_err = err
+                _record_error(err, attempt_index, provider)
+                time.sleep(0.05)
+            except (TimeoutError, RetriableError) as err:
+                last_err = err
+                _record_error(err, attempt_index, provider)
                 continue
-        raise last_err or RuntimeError("No providers succeeded")
+            else:
+                if metrics_path_str:
+                    log_event(
+                        "provider_success",
+                        metrics_path_str,
+                        request_fingerprint=request_fingerprint,
+                        request_hash=content_hash(provider.name(), request.prompt, request.options),
+                        provider=provider.name(),
+                        attempt=attempt_index,
+                        total_providers=len(self.providers),
+                        latency_ms=response.latency_ms,
+                        shadow_used=shadow is not None,
+                    )
+                return response
+        if metrics_path_str:
+            log_event(
+                "provider_chain_failed",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                provider_attempts=len(self.providers),
+                providers=[provider.name() for provider in self.providers],
+                last_error_type=type(last_err).__name__ if last_err else None,
+                last_error_message=str(last_err) if last_err else None,
+            )
+        raise last_err if last_err is not None else RuntimeError("No providers succeeded")
+
+
+__all__ = ["Runner"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -1,37 +1,121 @@
-import threading, time
-from typing import Optional
+"""Shadow execution helpers."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Optional, Union, Dict, Any
+
 from .provider_spi import ProviderSPI, ProviderRequest, ProviderResponse
 from .metrics import log_event
+from .utils import content_hash
 
-def run_with_shadow(primary: ProviderSPI, shadow: Optional[ProviderSPI], req: ProviderRequest, metrics_path: str = "artifacts/runs-metrics.jsonl") -> ProviderResponse:
-    shadow_rec = {}
-    if shadow:
-        def _shadow():
+MetricsPath = Optional[Union[str, Path]]
+DEFAULT_METRICS_PATH = "artifacts/runs-metrics.jsonl"
+
+
+def _to_path_str(path: MetricsPath) -> Optional[str]:
+    if path is None:
+        return None
+    return str(Path(path))
+
+
+def run_with_shadow(
+    primary: ProviderSPI,
+    shadow: Optional[ProviderSPI],
+    req: ProviderRequest,
+    metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+) -> ProviderResponse:
+    """Invoke ``primary`` while optionally mirroring the call on ``shadow``.
+
+    The shadow execution runs on a background thread and *never* affects the
+    primary result. Metrics about both executions are appended to a JSONL file
+    so they can be analysed offline.
+    """
+
+    shadow_thread: Optional[threading.Thread] = None
+    shadow_payload: Dict[str, Any] = {}
+    shadow_name: Optional[str] = None
+    metrics_path_str = _to_path_str(metrics_path)
+
+    if shadow is not None:
+        shadow_name = shadow.name()
+
+        def _shadow_worker() -> None:
             ts0 = time.time()
             try:
-                r = shadow.invoke(req)
-                shadow_rec.update({
-                    "ok": True,
-                    "latency_ms": r.latency_ms,
-                    "text_len": len(r.text),
-                    "provider": shadow.name(),
-                })
-            except Exception as e:
-                shadow_rec.update({"ok": False, "error": type(e).__name__, "provider": shadow.name()})
+                response = shadow.invoke(req)
+            except Exception as exc:  # pragma: no cover - error branch tested via metrics
+                shadow_payload.update(
+                    {
+                        "ok": False,
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                        "provider": shadow_name,
+                    }
+                )
+            else:
+                shadow_payload.update(
+                    {
+                        "ok": True,
+                        "provider": shadow_name,
+                        "latency_ms": response.latency_ms,
+                        "text_len": len(response.text),
+                        "token_usage_total": response.token_usage.total,
+                    }
+                )
             finally:
-                shadow_rec["duration_ms"] = int((time.time()-ts0)*1000)
-        th = threading.Thread(target=_shadow, daemon=True)
-        th.start()
-    # primary (blocking)
-    primary_res = primary.invoke(req)
+                shadow_payload["duration_ms"] = int((time.time() - ts0) * 1000)
 
-    if shadow:
-        th.join(timeout=10)
-        log_event("shadow_diff", metrics_path,
-                  primary_provider=primary.name(),
-                  shadow_provider=shadow.name(),
-                  primary_latency_ms=primary_res.latency_ms,
-                  shadow_ok=shadow_rec.get("ok"),
-                  shadow_latency_ms=shadow_rec.get("latency_ms"),
-                  shadow_error=shadow_rec.get("error"))
+        shadow_thread = threading.Thread(target=_shadow_worker, daemon=True)
+        shadow_thread.start()
+
+    try:
+        primary_res = primary.invoke(req)
+    except Exception:
+        if shadow_thread is not None:
+            shadow_thread.join(timeout=0)
+        raise
+
+    if shadow_thread is not None:
+        shadow_thread.join(timeout=10)
+        if shadow_thread.is_alive():
+            shadow_payload.setdefault("provider", shadow_name)
+            shadow_payload.update({"ok": False, "error": "ShadowTimeout"})
+
+        if metrics_path_str:
+            primary_text_len = len(primary_res.text)
+            request_fingerprint = content_hash("runner", req.prompt, req.options)
+            record: Dict[str, Any] = {
+                "request_hash": content_hash(primary.name(), req.prompt, req.options),
+                "request_fingerprint": request_fingerprint,
+                "primary_provider": primary.name(),
+                "primary_latency_ms": primary_res.latency_ms,
+                "primary_text_len": primary_text_len,
+                "primary_token_usage_total": primary_res.token_usage.total,
+                "shadow_provider": shadow_payload.get("provider", shadow_name),
+                "shadow_ok": shadow_payload.get("ok"),
+                "shadow_latency_ms": shadow_payload.get("latency_ms"),
+                "shadow_duration_ms": shadow_payload.get("duration_ms"),
+                "shadow_error": shadow_payload.get("error"),
+            }
+
+            if shadow_payload.get("latency_ms") is not None:
+                record["latency_gap_ms"] = shadow_payload["latency_ms"] - primary_res.latency_ms
+
+            if shadow_payload.get("text_len") is not None:
+                record["shadow_text_len"] = shadow_payload["text_len"]
+
+            if shadow_payload.get("token_usage_total") is not None:
+                record["shadow_token_usage_total"] = shadow_payload["token_usage_total"]
+
+            if shadow_payload.get("message"):
+                record["shadow_error_message"] = shadow_payload["message"]
+
+            log_event("shadow_diff", metrics_path_str, **record)
+
     return primary_res
+
+
+__all__ = ["run_with_shadow", "DEFAULT_METRICS_PATH"]

--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -1,24 +1,92 @@
-from projects.04-llm-adapter-shadow.src.llm_adapter.providers.mock import MockProvider
-from projects.04-llm-adapter-shadow.src.llm_adapter.runner import Runner
-from projects.04-llm-adapter-shadow.src.llm_adapter.provider_spi import ProviderRequest
+import json
+
+import pytest
+
+from src.llm_adapter.errors import TimeoutError
+from src.llm_adapter.providers.mock import MockProvider
+from src.llm_adapter.runner import Runner
+from src.llm_adapter.provider_spi import ProviderRequest
+
+
+def _providers_for(marker: str):
+    failing = MockProvider("p1", base_latency_ms=5, error_markers={marker})
+    fallback = MockProvider("p2", base_latency_ms=5, error_markers=set())
+    return failing, fallback
+
+
+def _read_metrics(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
 
 def test_timeout_fallback():
-    p1 = MockProvider("p1", base_latency_ms=10)
-    p2 = MockProvider("p2", base_latency_ms=10)
-    r = Runner([p1, p2])
-    out = r.run(ProviderRequest(prompt="[TIMEOUT] hello"))
-    assert out.text.startswith("echo(p2):")
+    p1, p2 = _providers_for("[TIMEOUT]")
+    runner = Runner([p1, p2])
+
+    response = runner.run(ProviderRequest(prompt="[TIMEOUT] hello"))
+    assert response.text.startswith("echo(p2):")
+
 
 def test_ratelimit_retry_fallback():
-    p1 = MockProvider("p1", base_latency_ms=5)
-    p2 = MockProvider("p2", base_latency_ms=5)
-    r = Runner([p1, p2])
-    out = r.run(ProviderRequest(prompt="[RATELIMIT] test"))
-    assert out.text.startswith("echo(p2):")
+    p1, p2 = _providers_for("[RATELIMIT]")
+    runner = Runner([p1, p2])
+
+    response = runner.run(ProviderRequest(prompt="[RATELIMIT] test"))
+    assert response.text.startswith("echo(p2):")
+
 
 def test_invalid_json_fallback():
-    p1 = MockProvider("p1", base_latency_ms=5)
-    p2 = MockProvider("p2", base_latency_ms=5)
-    r = Runner([p1, p2])
-    out = r.run(ProviderRequest(prompt="[INVALID_JSON] test"))
-    assert out.text.startswith("echo(p2):")
+    p1, p2 = _providers_for("[INVALID_JSON]")
+    runner = Runner([p1, p2])
+
+    response = runner.run(ProviderRequest(prompt="[INVALID_JSON] test"))
+    assert response.text.startswith("echo(p2):")
+
+
+def test_timeout_fallback_records_metrics(tmp_path):
+    p1, p2 = _providers_for("[TIMEOUT]")
+    runner = Runner([p1, p2])
+
+    metrics_path = tmp_path / "fallback.jsonl"
+    response = runner.run(
+        ProviderRequest(prompt="[TIMEOUT] metrics"),
+        shadow=None,
+        shadow_metrics_path=metrics_path,
+    )
+
+    assert response.text.startswith("echo(p2):")
+
+    payloads = _read_metrics(metrics_path)
+    error_event = next(item for item in payloads if item["event"] == "provider_error")
+    success_event = next(item for item in payloads if item["event"] == "provider_success")
+
+    assert error_event["provider"] == "p1"
+    assert error_event["attempt"] == 1
+    assert error_event["error_type"] == "TimeoutError"
+    assert error_event["request_fingerprint"]
+
+    assert success_event["provider"] == "p2"
+    assert success_event["attempt"] == 2
+    assert success_event["shadow_used"] is False
+
+
+def test_runner_emits_chain_failed_metric(tmp_path):
+    failing1 = MockProvider("p1", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    failing2 = MockProvider("p2", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    runner = Runner([failing1, failing2])
+
+    metrics_path = tmp_path / "failure.jsonl"
+
+    with pytest.raises(TimeoutError):
+        runner.run(
+            ProviderRequest(prompt="[TIMEOUT] hard"),
+            shadow=None,
+            shadow_metrics_path=metrics_path,
+        )
+
+    payloads = _read_metrics(metrics_path)
+    error_events = [item for item in payloads if item["event"] == "provider_error"]
+    assert {event["provider"] for event in error_events} == {"p1", "p2"}
+
+    chain_event = next(item for item in payloads if item["event"] == "provider_chain_failed")
+    assert chain_event["provider_attempts"] == 2
+    assert chain_event["last_error_type"] == "TimeoutError"

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -1,14 +1,62 @@
-import json, os
-from projects.04-llm-adapter-shadow.src.llm_adapter.providers.mock import MockProvider
-from projects.04-llm-adapter-shadow.src.llm_adapter.runner import Runner
-from projects.04-llm-adapter-shadow.src.llm_adapter.provider_spi import ProviderRequest
+import json
+
+from src.llm_adapter.providers.mock import MockProvider
+from src.llm_adapter.runner import Runner
+from src.llm_adapter.provider_spi import ProviderRequest
+
 
 def test_shadow_exec_records_metrics(tmp_path):
-    p1 = MockProvider("primary", base_latency_ms=5)
-    p2 = MockProvider("shadow", base_latency_ms=5)
-    r = Runner([p1])
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
+    runner = Runner([primary])
+
     metrics_path = tmp_path / "metrics.jsonl"
-    out = r.run(ProviderRequest(prompt="hello"), shadow=p2)
-    assert out.text.startswith("echo(primary):")
-    # Not asserting file write to avoid FS coupling in portfolio repo CI.
-    assert isinstance(out.latency_ms, int)
+    response = runner.run(
+        ProviderRequest(prompt="hello"),
+        shadow=shadow,
+        shadow_metrics_path=metrics_path,
+    )
+
+    assert response.text.startswith("echo(primary):")
+    assert metrics_path.exists()
+
+    payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
+    success_event = next(item for item in payloads if item["event"] == "provider_success")
+
+    assert diff_event["primary_provider"] == "primary"
+    assert diff_event["shadow_provider"] == "shadow"
+    assert diff_event["shadow_ok"] is True
+    assert diff_event["primary_text_len"] == len(response.text)
+    assert diff_event["primary_token_usage_total"] == response.token_usage.total
+    assert diff_event["request_fingerprint"]
+
+    assert success_event["provider"] == "primary"
+    assert success_event["attempt"] == 1
+    assert success_event["shadow_used"] is True
+    assert success_event["latency_ms"] == response.latency_ms
+
+    expected_tokens = max(1, len("hello") // 4) + 16
+    assert diff_event["shadow_token_usage_total"] == expected_tokens
+    assert diff_event["shadow_text_len"] == len("echo(shadow): hello")
+
+
+def test_shadow_error_records_metrics(tmp_path):
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    runner.run(
+        ProviderRequest(prompt="[TIMEOUT] hello"),
+        shadow=shadow,
+        shadow_metrics_path=metrics_path,
+    )
+
+    payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
+
+    assert diff_event["shadow_ok"] is False
+    assert diff_event["shadow_error"] == "TimeoutError"
+    assert diff_event["shadow_error_message"] == "simulated timeout"
+    assert diff_event["shadow_duration_ms"] >= 0


### PR DESCRIPTION
## Summary
- add a provider_success metrics event that captures the winning provider, latency and request hashes
- document the new event in the README and extend tests to assert both success and shadow-failure telemetry

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd22d5f9008321ad2625cedebd01a0