### PR TITLE
Restore blueprint generator and add duplicate detection

### DIFF
--- a/projects/02-llm-to-playwright/scripts/blueprint_to_code.mjs
+++ b/projects/02-llm-to-playwright/scripts/blueprint_to_code.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ---- CLI / Paths ----
 function usage() {
-  console.error('Usage: node blueprint_to_code.mjs <blueprint.json>');
+  console.error('Usage: node blueprint_to_code.mjs <blueprint.json> [outputDir]');
 }
 
 const defaultOutputDir = path.join(process.cwd(), 'projects/02-llm-to-playwright/tests/generated');
@@ -68,6 +69,12 @@ function toQuoted(value) {
   return JSON.stringify((value ?? '').toString());
 }
 
+function toSingleQuoted(value) {
+  const raw = (value ?? '').toString();
+  const escaped = raw.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return `'${escaped}'`;
+}
+
 function toUrlRegex(assertion) {
   const raw = assertion.split(':', 2)[1] ?? '';
   const trimmed = raw.replace(/^\/+/, '');
@@ -91,7 +98,94 @@ function buildAssert(assertion) {
 
 // ---- Rendering ----
 function renderScenario(scenario) {
+  validateScenario(scenario);
   const selectors = scenario.selectors || {};
   const data = scenario.data || {};
-  const assertLines = Array.isArray(scenario.asserts)
-    ? scen
+  const assertLines = Array.isArray(scenario.asserts) ? scenario.asserts.map((assertion) => buildAssert(assertion)) : [];
+  const startUrl = typeof scenario.url === 'string' && scenario.url.trim().length > 0 ? scenario.url : '/';
+
+  const lines = [
+    "import { test, expect } from '@playwright/test';",
+    '',
+    `test(${toSingleQuoted(`${scenario.id} ${scenario.title}`)}, async ({ page }) => {`,
+    `  await page.goto(${toQuoted(startUrl)});`,
+    `  await page.fill(${toQuoted(selectors.user)}, ${toQuoted(data.user)});`,
+    `  await page.fill(${toQuoted(selectors.pass)}, ${toQuoted(data.pass)});`,
+    `  await page.click(${toQuoted(selectors.submit)});`,
+  ];
+
+  if (assertLines.length > 0) {
+    lines.push('');
+    lines.push(...assertLines);
+  }
+
+  lines.push('});', '');
+
+  return lines.join('\n');
+}
+
+// ---- Generation ----
+function generateTestsFromBlueprint(blueprint, outputDir = defaultOutputDir) {
+  validateBlueprint(blueprint);
+  const targetDir = outputDir ? path.resolve(outputDir) : defaultOutputDir;
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const seenFileNames = new Set();
+  const fileNameSources = new Map();
+  const written = [];
+
+  for (const scenario of blueprint.scenarios) {
+    validateScenario(scenario);
+    const fileNameBase = sanitiseFileName(scenario.id);
+
+    if (seenFileNames.has(fileNameBase)) {
+      const previousId = fileNameSources.get(fileNameBase);
+      throw new Error(
+        `Duplicate scenario file name "${fileNameBase}" generated from scenario IDs "${previousId}" and "${scenario.id}".`,
+      );
+    }
+
+    seenFileNames.add(fileNameBase);
+    fileNameSources.set(fileNameBase, scenario.id);
+
+    const fileName = `${fileNameBase}.spec.ts`;
+    const filePath = path.join(targetDir, fileName);
+    const fileContents = renderScenario(scenario);
+    fs.writeFileSync(filePath, fileContents, 'utf8');
+    written.push(fileName);
+  }
+
+  return written;
+}
+
+// ---- CLI Entrypoint ----
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+  : false;
+
+if (isMainModule) {
+  const [, , blueprintPath, outputDirArg] = process.argv;
+
+  if (!blueprintPath) {
+    usage();
+    process.exit(1);
+  }
+
+  const resolvedBlueprintPath = path.resolve(process.cwd(), blueprintPath);
+  const resolvedOutputDir = outputDirArg ? path.resolve(process.cwd(), outputDirArg) : defaultOutputDir;
+
+  try {
+    const blueprint = readJson(resolvedBlueprintPath);
+    fs.mkdirSync(resolvedOutputDir, { recursive: true });
+    const generated = generateTestsFromBlueprint(blueprint, resolvedOutputDir);
+    const count = generated.length;
+    const suffix = count === 1 ? '' : 's';
+    console.log(`Generated ${count} Playwright test file${suffix} in ${resolvedOutputDir}`);
+  } catch (error) {
+    const message = error && typeof error.message === 'string' ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}
+
+export { generateTestsFromBlueprint, renderScenario, sanitiseFileName };


### PR DESCRIPTION
## Summary
- restore the Playwright blueprint generator, including scenario rendering and CLI invocation
- normalise scenario ids into unique filenames and throw on duplicates

## Testing
- node --test tests/pipeline.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cff5f53f70832182f0e965c176bdd4