### PR TITLE
Add repository metadata and developer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "QA SDET LLM Portfolio",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye",
+  "postCreateCommand": "npm run setup",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-playwright.playwright",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,8 @@
+repository:
+  topics:
+    - qa
+    - sdet
+    - playwright
+    - testing
+    - llm
+    - ci

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 QA SDET LLM Portfolio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,18 @@ pytest -q   # ERR（障害注入）/ SHD（影実行）シナリオ一式
 * Node: v24.6.0 (fnm)
 * Python: 3.11+ (uv)
 * CI: GitHub Actions
-* Node.js 標準ライブラリのみで動く CLI を採用。`npm install` は Playwright 実行時のみ必要。
+* Node.js 標準ライブラリのみで動く CLI を採用。`npm run setup`（内部で `npm install` を実行）は Playwright 実行時のみ必要。
+
+## セットアップ & テスト (Setup & Test)
+
+開発環境は VS Code Dev Containers に対応しています。`.devcontainer/devcontainer.json` を利用することで、Node.js と Playwright 拡張が揃った環境が自動構築されます。
+
+ローカル／Dev Container のいずれでも、以下の 2 コマンドで依存関係の導入からテスト実行まで完結します。
+
+```bash
+npm run setup
+npm test
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "setup": "npm install",
     "spec:generate": "node projects/01-spec2cases/scripts/text_to_cases.mjs projects/01-spec2cases/spec.sample.md projects/01-spec2cases/cases.generated.json",
     "spec:from-text": "node projects/01-spec2cases/scripts/spec2cases.mjs projects/01-spec2cases/spec.sample.txt projects/01-spec2cases/cases.sample.json",
     "spec:validate": "node projects/01-spec2cases/scripts/spec2cases.mjs",


### PR DESCRIPTION
## Summary
- add an MIT LICENSE file and configure repository topics for discoverability
- introduce an npm `setup` script and document the single-command workflow
- provide a VS Code devcontainer that automatically runs the setup step

## Testing
- npm run setup
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cffb907a448321b7490642ea978786