### PR TITLE
Add CI badges and supporting workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r projects/04-llm-adapter-shadow/requirements.txt
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=projects/04-llm-adapter-shadow --cov-report=xml --cov-report=term-missing projects/04-llm-adapter-shadow/tests
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage
+          path: coverage.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Check JavaScript modules
+        run: |
+          set -euo pipefail
+          files=$(find . -type f \( -name '*.mjs' -o -name '*.js' \))
+          if [ -z "$files" ]; then
+            echo "No JavaScript modules found"
+          else
+            for file in $files; do
+              echo "Checking $file"
+              node --check "$file"
+            done
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check Python modules
+        run: |
+          python -m compileall projects/04-llm-adapter-shadow

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Portfolio Hub ?
 
-[![CI](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml)
-[![CI](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/ci.yml?branch=main&label=tests)](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml)
+[![Lint](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/lint.yml?branch=main&label=lint)](https://github.com/Ryosuke4219/portfolio/actions/workflows/lint.yml)
+[![Coverage](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/coverage.yml?branch=main&label=coverage)](https://github.com/Ryosuke4219/portfolio/actions/workflows/coverage.yml)
 
 ---
 

--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=8.2.0
+pytest-cov>=5.0.0


### PR DESCRIPTION
## Summary
- replace the duplicate CI badge in the README with dedicated badges for tests, lint, and coverage
- add a lint workflow that checks JavaScript module syntax and compiles the Python sources
- add a coverage workflow that runs the Python test suite with coverage reporting

## Testing
- npm test
- pytest -q projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68d0a114c3ec83219aed39907b8c9691