### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -4,13 +4,20 @@ on:
     branches: [main]
   workflow_dispatch:
 permissions:
+  contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -31,5 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add the recommended Pages concurrency settings and permissions
- configure Pages before building docs and expose the deployment URL output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d10949f93c83218530aa7a80d62f5c