### PR TITLE
Fix npm test script to use bundled Playwright stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "spec:validate:sample": "node projects/01-spec2cases/scripts/spec2cases.mjs projects/01-spec2cases/cases.sample.json",
     "spec:run": "node projects/01-spec2cases/scripts/run_cases.mjs",
     "e2e:gen": "node projects/02-llm-to-playwright/scripts/blueprint_to_code.mjs projects/02-llm-to-playwright/blueprint.sample.json",
-    "test": "playwright test -c projects/02-llm-to-playwright/playwright.config.ts",
+    "test": "node ./packages/playwright-test-stub/bin/playwright.js test -c projects/02-llm-to-playwright/playwright.config.ts",
     "ci:analyze": "node projects/03-ci-flaky/scripts/flaky.mjs analyze",
     "ci:issue": "node projects/03-ci-flaky/scripts/flaky.mjs issue"
   },


### PR DESCRIPTION
## Summary
- update the npm test script to execute the local Playwright stub directly so the suite runs without a separate install step

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1228170848321a3cf989604144b2e