### PR TITLE
Add GitHub Pages status gate for docs publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,102 @@
+name: Publish Docs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish documentation to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check GitHub Pages status
+        id: pages_status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+
+            const { data: repoData } = await github.rest.repos.get({ owner, repo });
+            let buildType = repoData?.pages?.build_type ?? null;
+            let pendingInitialDeploy = false;
+
+            try {
+              const { data: pagesData } = await github.rest.repos.getPages({ owner, repo });
+              if (pagesData?.build_type) {
+                buildType = pagesData.build_type;
+              }
+            } catch (error) {
+              if (error.status === 404) {
+                pendingInitialDeploy = true;
+                if (!buildType) {
+                  buildType = 'workflow';
+                }
+                core.info('GitHub Pages is configured for GitHub Actions but has not been deployed yet.');
+              } else {
+                throw error;
+              }
+            }
+
+            const actionsReady = buildType === 'workflow';
+            const pagesDisabled = !repoData.has_pages && !pendingInitialDeploy && buildType !== 'workflow';
+
+            const status = {
+              buildType: buildType ?? 'unknown',
+              actionsReady,
+              pendingInitialDeploy,
+              pagesDisabled,
+              repoHasPages: repoData.has_pages,
+            };
+
+            core.info(`GitHub Pages build type: ${status.buildType}`);
+            if (status.pendingInitialDeploy) {
+              core.info('GitHub Pages workflow has been selected but no deployment is available yet.');
+            }
+            if (status.pagesDisabled) {
+              core.info('GitHub Pages is currently disabled for this repository.');
+            }
+
+            core.setOutput('build_type', buildType ?? '');
+            core.setOutput('actions_ready', actionsReady ? 'true' : 'false');
+            core.setOutput('pending_initial_deploy', pendingInitialDeploy ? 'true' : 'false');
+            core.setOutput('pages_disabled', pagesDisabled ? 'true' : 'false');
+            core.setOutput('has_pages', repoData.has_pages ? 'true' : 'false');
+            core.setOutput('status_json', JSON.stringify(status));
+
+            return status;
+
+      - name: GitHub Pages is disabled
+        if: steps.pages_status.outputs.pages_disabled == 'true'
+        run: |
+          echo "::warning::GitHub Pages が完全に無効化されているため、ドキュメントの公開をスキップします。"
+          echo "::notice::Settings > Pages で Build and deployment を \"GitHub Actions\" に設定し、有効化してください。"
+
+      - name: Checkout repository
+        if: steps.pages_status.outputs.pages_disabled != 'true' && steps.pages_status.outputs.actions_ready == 'true'
+        uses: actions/checkout@v4
+
+      - name: Upload documentation artifact
+        if: steps.pages_status.outputs.pages_disabled != 'true' && steps.pages_status.outputs.actions_ready == 'true'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs
+
+      - name: Configure GitHub Pages
+        if: steps.pages_status.outputs.pages_disabled != 'true' && steps.pages_status.outputs.actions_ready == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Deploy GitHub Pages
+        if: steps.pages_status.outputs.pages_disabled != 'true' && steps.pages_status.outputs.actions_ready == 'true'
+        uses: actions/deploy-pages@v4
+
+      - name: Switch Pages build to GitHub Actions
+        if: steps.pages_status.outputs.pages_disabled != 'true' && steps.pages_status.outputs.actions_ready != 'true'
+        run: |
+          echo "::notice::現在の GitHub Pages は GitHub Actions ワークフロー以外の方法で公開されています。"
+          echo "::notice::GitHub Pages の Build and deployment を \"GitHub Actions\" に変更してください。"
+          echo "::notice::設定後にこのワークフローを再実行すると、Docs を GitHub Pages へ公開できます。"


### PR DESCRIPTION
## Summary
- add a Publish Docs workflow with a github-script step that always queries the Pages API, handles 404s as pending GitHub Actions deployments, and marks workflow builds as ready
- gate deployment steps on the new status outputs so only fully disabled Pages configurations are skipped, and adjust the setup messaging accordingly

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d14f2916308321ae8759adbe1983b0