### PR TITLE
Build docs with Jekyll in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,10 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: docs
+          path: _site
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- configure the Pages workflow to set up Pages and build the docs directory with the Jekyll build action
- upload the generated `_site` directory so the built HTML is deployed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d163b4a5948321bf697bfe90f843a8