### PR TITLE
Add issue and PR templates with code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# このファイルは主要ディレクトリのコードオーナーを定義します
+# 行の形式: <パターン> <オーナー>
+
+* @Ryosuke4219
+/.github @Ryosuke4219
+/docs @Ryosuke4219
+/packages @Ryosuke4219
+/projects @Ryosuke4219
+/scripts @Ryosuke4219
+/tests @Ryosuke4219
+/tools @Ryosuke4219

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,38 @@
+---
+name: "バグ報告 / Bug report"
+about: "発生している不具合を報告する"
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## 概要 / Summary
+
+<!-- 発生している問題の簡潔な説明 -->
+
+## 再現手順 / Steps to Reproduce
+1. 
+2. 
+3. 
+
+## 期待される結果 / Expected Behavior
+
+<!-- 正しく動作した場合に期待される結果 -->
+
+## 実際の結果 / Actual Behavior
+
+<!-- 現状の結果やエラーメッセージなど -->
+
+## 影響範囲 / Impacted Areas
+
+<!-- 影響を受ける機能や利用者などがあれば記述してください -->
+
+## テスト影響 / Test Impact
+- [ ] 既存テストに影響なし / No impact to existing tests
+- [ ] 既存テストの更新が必要 / Existing tests need updates
+- [ ] 新しいテストが必要 / New tests required
+- [ ] その他（自由記入） / Other: 
+
+## 補足情報 / Additional Context
+
+<!-- 環境情報やログ、スクリーンショットなど -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,34 @@
+---
+name: "機能リクエスト / Feature request"
+about: "新しい機能や改善案を提案する"
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## 背景 / Background
+
+<!-- 解決したい課題やきっかけを記述してください -->
+
+## 再現手順 / Steps to Reproduce Current Behavior
+1. 
+2. 
+3. 
+
+## 期待される結果 / Expected Outcome
+
+<!-- 実現したい理想的な振る舞いやゴール -->
+
+## 提案内容 / Proposed Solution
+
+<!-- 実装アイデアやアプローチ案 -->
+
+## テスト影響 / Test Impact
+- [ ] 既存テストに影響なし / No impact to existing tests
+- [ ] 既存テストの更新が必要 / Existing tests need updates
+- [ ] 新しいテストが必要 / New tests required
+- [ ] その他（自由記入） / Other: 
+
+## 追加情報 / Additional Context
+
+<!-- 関連する資料やスクリーンショットなど -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## 変更概要 / Summary of Changes
+- 
+
+## テスト結果 / Test Results
+- [ ] テスト未実施 / Not run
+- [ ] テスト実施済み（結果を記載） / Tests run (describe results):
+
+## リスク評価 / Risk Assessment
+- 想定されるリスクや影響範囲:
+- 緩和策・ロールバック手順:


### PR DESCRIPTION
## Summary
- add bug and feature issue templates including reproduction steps, expected outcomes, and test impact prompts
- provide a pull request template covering summary, testing results, and risk assessment
- define code owners for major directories to ensure reviews by @Ryosuke4219

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1fabf66248321a450f02e1f6a3659