### PR TITLE
Add repository description and homepage

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,4 +1,6 @@
 repository:
+  description: "> QA × SDET × LLM の実践ポートフォリオ。小さく完結した自動化パイプラインを公開。 / Practical QA × SDET × LLM portfolio featuring compact automation pipelines."
+  homepage: https://ryosuke4219.github.io/portfolio/
   topics:
     - qa
     - sdet


### PR DESCRIPTION
## Summary
- add the README introduction copy to the repository description in `.github/settings.yml`
- register the GitHub Pages URL as the repository homepage while keeping the existing topics list intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1fae5adac8321b4dcdf9416628122