### PR TITLE
Add CI snapshot reports and automate README metrics

### DIFF
--- a/.github/workflows/weekly-qa-summary.yml
+++ b/.github/workflows/weekly-qa-summary.yml
@@ -20,16 +20,32 @@ jobs:
         run: |
           python tools/weekly_summary.py \
             --runs projects/03-ci-flaky/data/runs.jsonl \
-            --flaky projects/03-ci-flaky/out/flaky_rank.csv \
+            --flaky projects/03-ci-flaky/data/flaky_rank.csv \
             --out docs/weekly-summary.md \
             --days 7
       - name: Refresh gallery snippet
         run: |
           python tools/generate_gallery_snippets.py
+      - name: Generate CI reliability snapshot
+        run: |
+          python tools/generate_ci_report.py \
+            --runs projects/03-ci-flaky/data/runs.jsonl \
+            --flaky projects/03-ci-flaky/data/flaky_rank.csv \
+            --out-markdown docs/reports/latest.md \
+            --out-json docs/reports/latest.json \
+            --index docs/reports/index.md \
+            --days 7
+      - name: Update README metrics table
+        run: |
+          python tools/update_readme_metrics.py \
+            --readme README.md \
+            --source docs/reports/latest.json \
+            --report-url https://ryosuke4219.github.io/portfolio/reports/latest/
       - name: Commit summary
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/weekly-summary.md docs/_includes/weekly-summary-card.md
+          git add README.md docs/weekly-summary.md docs/_includes/weekly-summary-card.md \
+            docs/reports/index.md docs/reports/latest.md docs/reports/latest.json
           git commit -m "chore(docs): update weekly QA summary" || echo "no changes"
           git push

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/ci.yml?branch=main&label=tests)](https://github.com/Ryosuke4219/portfolio/actions/workflows/ci.yml)
 [![Lint](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/lint.yml?branch=main&label=lint)](https://github.com/Ryosuke4219/portfolio/actions/workflows/lint.yml)
 [![Coverage](https://img.shields.io/github/actions/workflow/status/Ryosuke4219/portfolio/coverage.yml?branch=main&label=coverage)](https://github.com/Ryosuke4219/portfolio/actions/workflows/coverage.yml)
+[![QA Snapshot](https://img.shields.io/badge/QA%20Snapshot-Auto%20weekly-6f42c1?logo=github)](https://ryosuke4219.github.io/portfolio/reports/latest)
+
+<!-- qa-metrics:start -->
+| 指標 | 値 |
+|------|----|
+| Pass Rate | 40.00% (2/5) |
+| Top Flaky | 1. ui-e2e.LoginFlow.spec.should show error for invalid user (score 0.71)<br/>2. ui-e2e.LoginFlow.spec.should login with valid user (score 0.58)<br/>3. api-report.ReportJob.test.generates flaky summary (score 0.46) |
+| 最終更新 | 2025-09-21T03:44:09Z |
+| レポート | [最新レポートを見る](https://ryosuke4219.github.io/portfolio/reports/latest/) |
+
+<!-- qa-metrics:end -->
+<sub>※週次ワークフロー (`weekly-qa-summary.yml`) が `tools/update_readme_metrics.py` で自動更新します。</sub>
+
 
 > QA × SDET × LLM の実践ポートフォリオ。小さく完結した自動化パイプラインを公開。 / Practical QA × SDET × LLM portfolio featuring compact automation pipelines.
 

--- a/docs/reports/index.md
+++ b/docs/reports/index.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: QA Reliability Reports
+description: Snapshot reports generated from CI telemetry
+---
+
+# QA Reliability Reports
+
+最新のCI信頼性レポートとソースJSONへのリンクです。週次ワークフローで自動更新されます。
+
+- [Latest Snapshot (2025-09-23)](./latest)
+  - [Source JSON](./latest.json)
+  - 更新元: tools/generate_ci_report.py
+
+過去分の保管が必要になった場合は、このフォルダに日付別のMarkdown/JSONを追加してください。
+

--- a/docs/reports/latest.json
+++ b/docs/reports/latest.json
@@ -1,0 +1,52 @@
+{
+  "generated_at": "2025-09-23T01:52:24.413926Z",
+  "window_days": 7,
+  "totals": {
+    "passes": 2,
+    "fails": 2,
+    "errors": 1,
+    "executions": 5
+  },
+  "pass_rate": 0.4,
+  "failure_kinds": [
+    {
+      "kind": "timeout",
+      "count": 1
+    },
+    {
+      "kind": "guard_violation",
+      "count": 1
+    },
+    {
+      "kind": "infra",
+      "count": 1
+    }
+  ],
+  "top_flaky": [
+    {
+      "rank": 1,
+      "canonical_id": "ui-e2e.LoginFlow.spec.should show error for invalid user",
+      "attempts": 8,
+      "p_fail": 0.38,
+      "score": 0.71,
+      "as_of": "2025-09-22T00:00:00Z"
+    },
+    {
+      "rank": 2,
+      "canonical_id": "ui-e2e.LoginFlow.spec.should login with valid user",
+      "attempts": 8,
+      "p_fail": 0.25,
+      "score": 0.58,
+      "as_of": "2025-09-22T00:00:00Z"
+    },
+    {
+      "rank": 3,
+      "canonical_id": "api-report.ReportJob.test.generates flaky summary",
+      "attempts": 5,
+      "p_fail": 0.2,
+      "score": 0.46,
+      "as_of": "2025-09-22T00:00:00Z"
+    }
+  ],
+  "last_updated": "2025-09-21T03:44:09Z"
+}

--- a/docs/reports/latest.md
+++ b/docs/reports/latest.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: QA Reliability Snapshot — 2025-09-23
+description: CI pass rate and flaky ranking (auto-generated)
+---
+
+# QA Reliability Snapshot — 2025-09-23
+
+- Window: Last 7 days
+- Data Last Updated: 2025-09-21T03:44:09Z
+
+## KPI
+| 指標 | 値 |
+|------|----|
+| Pass Rate | 40.00% (2/5) |
+| Failures | 2 |
+| Errors | 1 |
+| Top Failure Kinds | timeout 1 / guard_violation 1 / infra 1 |
+| ソースJSON | [latest.json](./latest.json) |
+
+## Top Flaky Tests
+| Rank | Canonical ID | Attempts | p_fail | Score |
+|-----:|--------------|---------:|------:|------:|
+| 1 | ui-e2e.LoginFlow.spec.should show error for invalid user | 8 | 0.38 | 0.71 |
+| 2 | ui-e2e.LoginFlow.spec.should login with valid user | 8 | 0.25 | 0.58 |
+| 3 | api-report.ReportJob.test.generates flaky summary | 5 | 0.20 | 0.46 |
+
+<details><summary>Generation</summary>
+Source: runs=projects/03-ci-flaky/data/runs.jsonl / flaky=projects/03-ci-flaky/data/flaky_rank.csv
+Window: 7 days / Executions: 5
+Automation: tools/generate_ci_report.py (GitHub Actions)
+</details>
+

--- a/docs/weekly-summary.md
+++ b/docs/weekly-summary.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Weekly QA Summary — 2025-09-22
+title: Weekly QA Summary — 2025-09-23
 description: 直近7日間のQA状況サマリ
 ---
 
-# Weekly QA Summary — 2025-09-22
+# Weekly QA Summary — 2025-09-23
 
 ## Overview (last 7 days)
 - TotalTests: 5
@@ -18,19 +18,19 @@ description: 直近7日間のQA状況サマリ
 | 1 | ui-e2e.LoginFlow.spec.should show error for invalid user | 8 | 0.38 | 0.71 |
 | 2 | ui-e2e.LoginFlow.spec.should login with valid user | 8 | 0.25 | 0.58 |
 | 3 | api-report.ReportJob.test.generates flaky summary | 5 | 0.20 | 0.46 |
+| 4 | ui-e2e.Dashboard.spec.should render analytics widgets | 4 | 0.10 | 0.30 |
 
 ## Week-over-Week
 - PassRate Δ: -26.67pp
-- Entered: ui-e2e.LoginFlow.spec.should login with valid user
-- Exited: ui-e2e.Dashboard.spec.should render analytics widgets
+- Entered: ui-e2e.LoginFlow.spec.should show error for invalid user, ui-e2e.LoginFlow.spec.should login with valid user, api-report.ReportJob.test.generates flaky summary, ui-e2e.Dashboard.spec.should render analytics widgets
+- Exited: なし
 
 ## Notes
 - PassRate WoW: -26.67pp (prev 66.67%).
-- Top Flaky 新規: ui-e2e.LoginFlow.spec.should login with valid user
-- Top Flaky 離脱: ui-e2e.Dashboard.spec.should render analytics widgets
+- Top Flaky 新規: ui-e2e.LoginFlow.spec.should show error for invalid user, ui-e2e.LoginFlow.spec.should login with valid user, api-report.ReportJob.test.generates flaky summary, ui-e2e.Dashboard.spec.should render analytics widgets
 
 <details><summary>Method</summary>
-データソース: projects/03-ci-flaky/data/runs.jsonl / projects/03-ci-flaky/out/flaky_rank.csv / 欠陥: docs/defect-report-sample.md
+データソース: projects/03-ci-flaky/data/runs.jsonl / projects/03-ci-flaky/data/flaky_rank.csv / 欠陥: docs/defect-report-sample.md
 期間: 直近7日 / 比較対象: その前の7日
 再計算: 毎週月曜 09:00 JST (GitHub Actions)
 </details>

--- a/projects/03-ci-flaky/data/flaky_rank.csv
+++ b/projects/03-ci-flaky/data/flaky_rank.csv
@@ -1,0 +1,5 @@
+canonical_id,attempts,p_fail,score,as_of
+ui-e2e.LoginFlow.spec.should show error for invalid user,8,0.38,0.71,2025-09-22T00:00:00Z
+ui-e2e.LoginFlow.spec.should login with valid user,8,0.25,0.58,2025-09-22T00:00:00Z
+api-report.ReportJob.test.generates flaky summary,5,0.20,0.46,2025-09-22T00:00:00Z
+ui-e2e.Dashboard.spec.should render analytics widgets,4,0.10,0.30,2025-09-16T00:00:00Z

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Generate CI reliability snapshot in Markdown and JSON."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from weekly_summary import (  # type: ignore
+    aggregate_status,
+    filter_by_window,
+    format_percentage,
+    load_flaky,
+    load_runs,
+    parse_iso8601,
+    select_flaky_rows,
+    to_float,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate CI reliability snapshot")
+    parser.add_argument("--runs", type=Path, required=True, help="Path to runs.jsonl")
+    parser.add_argument("--flaky", type=Path, required=True, help="Path to flaky_rank.csv")
+    parser.add_argument(
+        "--out-markdown",
+        type=Path,
+        required=True,
+        help="Output path for rendered markdown",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        required=True,
+        help="Output path for metrics json",
+    )
+    parser.add_argument(
+        "--index",
+        type=Path,
+        default=None,
+        help="Optional path to update index markdown",
+    )
+    parser.add_argument("--days", type=int, default=7, help="Window size in days")
+    return parser.parse_args()
+
+
+def compute_last_updated(runs: List[dict]) -> Optional[str]:
+    timestamps: List[dt.datetime] = []
+    for run in runs:
+        ts = parse_iso8601(run.get("ts"))
+        if ts is not None:
+            timestamps.append(ts)
+    if not timestamps:
+        return None
+    latest = max(timestamps)
+    return latest.isoformat().replace("+00:00", "Z")
+
+
+def summarize_failure_kinds(runs: List[dict], limit: int = 3) -> List[dict]:
+    counter: Counter[str] = Counter()
+    for run in runs:
+        status = (run.get("status") or "").lower()
+        if status not in {"fail", "failed", "error"}:
+            continue
+        kind = run.get("failure_kind") or "unknown"
+        counter[str(kind)] += 1
+    most_common = counter.most_common(limit)
+    return [
+        {"kind": kind, "count": count}
+        for kind, count in most_common
+    ]
+
+
+def normalize_flaky_rows(rows: List[dict], limit: int = 3) -> List[dict]:
+    if not rows:
+        return []
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: to_float(row.get("score")) or 0.0,
+        reverse=True,
+    )
+    normalized: List[dict] = []
+    for idx, row in enumerate(sorted_rows[:limit], start=1):
+        attempts = row.get("attempts") or row.get("Attempts")
+        normalized.append(
+            {
+                "rank": idx,
+                "canonical_id": row.get("canonical_id") or row.get("Canonical ID") or "-",
+                "attempts": int(float(attempts)) if attempts not in {None, ""} else 0,
+                "p_fail": to_float(row.get("p_fail")),
+                "score": to_float(row.get("score")),
+                "as_of": row.get("as_of") or row.get("generated_at"),
+            }
+        )
+    return normalized
+
+
+def build_json_payload(
+    *,
+    generated_at: dt.datetime,
+    window_days: int,
+    passes: int,
+    fails: int,
+    errors: int,
+    failure_kinds: List[dict],
+    flaky_rows: List[dict],
+    last_updated: Optional[str],
+) -> Dict[str, Any]:
+    total = passes + fails + errors
+    pass_rate = (passes / total) if total else None
+    return {
+        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+        "window_days": window_days,
+        "totals": {
+            "passes": passes,
+            "fails": fails,
+            "errors": errors,
+            "executions": total,
+        },
+        "pass_rate": pass_rate,
+        "failure_kinds": failure_kinds,
+        "top_flaky": flaky_rows,
+        "last_updated": last_updated,
+    }
+
+
+def format_flaky_markdown(rows: List[dict]) -> List[str]:
+    header = "| Rank | Canonical ID | Attempts | p_fail | Score |"
+    divider = "|-----:|--------------|---------:|------:|------:|"
+    lines = [header, divider]
+    if not rows:
+        lines.append("| - | データなし | 0 | 0.00 | 0.00 |")
+        return lines
+    for row in rows:
+        p_fail = row.get("p_fail")
+        score = row.get("score")
+        lines.append(
+            "| {rank} | {cid} | {attempts} | {p_fail:.2f} | {score:.2f} |".format(
+                rank=row.get("rank", "-"),
+                cid=row.get("canonical_id", "-"),
+                attempts=row.get("attempts", 0),
+                p_fail=p_fail or 0.0,
+                score=score or 0.0,
+            )
+        )
+    return lines
+
+
+def render_markdown(
+    *,
+    today: dt.date,
+    window_days: int,
+    totals: Dict[str, int],
+    pass_rate: Optional[float],
+    failure_kinds: List[dict],
+    flaky_rows: List[dict],
+    last_updated: Optional[str],
+    runs_path: Path,
+    flaky_path: Path,
+) -> List[str]:
+    kinds_summary = (
+        " / ".join(f"{item['kind']} {item['count']}" for item in failure_kinds)
+        if failure_kinds
+        else "-"
+    )
+    lines: List[str] = [
+        "---",
+        "layout: default",
+        f"title: QA Reliability Snapshot — {today.isoformat()}",
+        "description: CI pass rate and flaky ranking (auto-generated)",
+        "---",
+        "",
+        f"# QA Reliability Snapshot — {today.isoformat()}",
+        "",
+        f"- Window: Last {window_days} days",
+        f"- Data Last Updated: {last_updated or 'N/A'}",
+        "",
+        "## KPI",
+        "| 指標 | 値 |",
+        "|------|----|",
+        f"| Pass Rate | {format_percentage(pass_rate)} ({totals['passes']}/{totals['executions']}) |",
+        f"| Failures | {totals['fails']} |",
+        f"| Errors | {totals['errors']} |",
+        f"| Top Failure Kinds | {kinds_summary} |",
+        "| ソースJSON | [latest.json](./latest.json) |",
+        "",
+        "## Top Flaky Tests",
+        *format_flaky_markdown(flaky_rows),
+        "",
+        "<details><summary>Generation</summary>",
+        f"Source: runs={runs_path} / flaky={flaky_path}",
+        f"Window: {window_days} days / Executions: {totals['executions']}",
+        "Automation: tools/generate_ci_report.py (GitHub Actions)",
+        "</details>",
+        "",
+    ]
+    return lines
+
+
+def update_index(index_path: Path, *, today: dt.date) -> None:
+    index_lines = [
+        "---",
+        "layout: default",
+        "title: QA Reliability Reports",
+        "description: Snapshot reports generated from CI telemetry",
+        "---",
+        "",
+        "# QA Reliability Reports",
+        "",
+        "最新のCI信頼性レポートとソースJSONへのリンクです。週次ワークフローで自動更新されます。",
+        "",
+        f"- [Latest Snapshot ({today.isoformat()})](./latest)",
+        "  - [Source JSON](./latest.json)",
+        "  - 更新元: tools/generate_ci_report.py",
+        "",
+        "過去分の保管が必要になった場合は、このフォルダに日付別のMarkdown/JSONを追加してください。",
+        "",
+    ]
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text("\n".join(index_lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    now = dt.datetime.now(dt.timezone.utc)
+    window = dt.timedelta(days=max(args.days, 1))
+    start = now - window
+
+    runs = load_runs(args.runs) if args.runs.exists() else []
+    flaky_rows = load_flaky(args.flaky) if args.flaky.exists() else []
+
+    filtered_runs = filter_by_window(runs, start, now)
+    passes, fails, errors = aggregate_status(filtered_runs)
+    failure_kinds = summarize_failure_kinds(filtered_runs)
+
+    selected_flaky = select_flaky_rows(flaky_rows, start, now)
+    normalized_flaky = normalize_flaky_rows(selected_flaky)
+
+    last_updated = compute_last_updated(filtered_runs)
+
+    payload = build_json_payload(
+        generated_at=now,
+        window_days=args.days,
+        passes=passes,
+        fails=fails,
+        errors=errors,
+        failure_kinds=failure_kinds,
+        flaky_rows=normalized_flaky,
+        last_updated=last_updated,
+    )
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    totals = payload["totals"]
+    markdown_lines = render_markdown(
+        today=now.date(),
+        window_days=args.days,
+        totals={
+            "passes": totals["passes"],
+            "fails": totals["fails"],
+            "errors": totals["errors"],
+            "executions": totals["executions"],
+        },
+        pass_rate=payload["pass_rate"],
+        failure_kinds=failure_kinds,
+        flaky_rows=normalized_flaky,
+        last_updated=last_updated,
+        runs_path=args.runs,
+        flaky_path=args.flaky,
+    )
+
+    args.out_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.out_markdown.write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")
+
+    if args.index is not None:
+        update_index(args.index, today=now.date())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/update_readme_metrics.py
+++ b/tools/update_readme_metrics.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Update README metrics table from generated CI report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update README QA metrics table")
+    parser.add_argument("--readme", type=Path, default=Path("README.md"), help="Path to README")
+    parser.add_argument("--source", type=Path, required=True, help="Path to metrics JSON")
+    parser.add_argument("--report-url", type=str, required=True, help="Public URL to the latest report")
+    return parser.parse_args()
+
+
+def load_payload(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def format_pass_rate(value: Optional[float]) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value * 100:.2f}%"
+
+
+def format_top_flaky(rows: List[Dict[str, Any]]) -> str:
+    if not rows:
+        return "データなし"
+    formatted: List[str] = []
+    for row in rows[:3]:
+        cid = row.get("canonical_id") or "-"
+        score = row.get("score")
+        if isinstance(score, (int, float)):
+            formatted.append(f"{len(formatted) + 1}. {cid} (score {score:.2f})")
+        else:
+            formatted.append(f"{len(formatted) + 1}. {cid}")
+    return "<br/>".join(formatted)
+
+
+def build_table(payload: Optional[Dict[str, Any]], report_url: str) -> List[str]:
+    if payload is None:
+        rows = [
+            "| 指標 | 値 |",
+            "|------|----|",
+            "| Pass Rate | N/A |",
+            "| Top Flaky | データなし |",
+            "| 最終更新 | N/A |",
+            f"| レポート | [最新レポートを見る]({report_url}) |",
+        ]
+        return rows
+
+    totals = payload.get("totals", {})
+    executions = totals.get("executions") or 0
+    passes = totals.get("passes") or 0
+    pass_rate = payload.get("pass_rate")
+    top_flaky = payload.get("top_flaky") or []
+    last_updated = payload.get("last_updated") or "N/A"
+    if isinstance(last_updated, str):
+        # Normalize to ISO8601 without microseconds when possible
+        try:
+            parsed = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+            last_updated = parsed.isoformat().replace("+00:00", "Z")
+        except ValueError:
+            pass
+
+    rows = [
+        "| 指標 | 値 |",
+        "|------|----|",
+        f"| Pass Rate | {format_pass_rate(pass_rate)} ({passes}/{executions}) |",
+        f"| Top Flaky | {format_top_flaky(top_flaky)} |",
+        f"| 最終更新 | {last_updated} |",
+        f"| レポート | [最新レポートを見る]({report_url}) |",
+    ]
+    return rows
+
+
+def replace_section(text: str, new_lines: List[str]) -> str:
+    start_marker = "<!-- qa-metrics:start -->"
+    end_marker = "<!-- qa-metrics:end -->"
+    if start_marker not in text or end_marker not in text:
+        raise ValueError("README markers <!-- qa-metrics:start --> / <!-- qa-metrics:end --> not found")
+    start_index = text.index(start_marker) + len(start_marker)
+    end_index = text.index(end_marker)
+    before = text[:start_index]
+    after = text[end_index:]
+    body = "\n" + "\n".join(new_lines) + "\n"
+    if not after.startswith("\n"):
+        after = "\n" + after
+    return before + body + after
+
+
+def main() -> None:
+    args = parse_args()
+    payload = load_payload(args.source)
+    table_lines = build_table(payload, args.report_url)
+    original = args.readme.read_text(encoding="utf-8")
+    updated = replace_section(original, table_lines)
+    args.readme.write_text(updated, encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add tooling to build QA reliability reports (Markdown + JSON) under docs/reports and expose index
- update weekly automation workflow to publish reports and refresh README metrics table via new scripts
- surface latest CI pass rate in README with badge/table linked to the generated report and include sample flaky ranking data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1fbd9f0c483218f1fe4ad729fafce