### PR TITLE
Add repository description and homepage settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 repository:
-  description: "> QA × SDET × LLM の実践ポートフォリオ。小さく完結した自動化パイプラインを公開。 / Practical QA × SDET × LLM portfolio featuring compact automation pipelines."
+  description: "QA × SDET × LLM の実践ポートフォリオ。小さく完結した自動化パイプラインを公開。 / Practical QA × SDET × LLM portfolio featuring compact automation pipelines."
   homepage: https://ryosuke4219.github.io/portfolio/
   topics:
     - qa


### PR DESCRIPTION
## Summary
- populate the repository description with the README lead-in text
- set the repository homepage to the published portfolio URL while keeping existing topics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1fd09bbb4832183046b3b2ee0adb9