### PR TITLE
Align repository topics with README

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,6 +5,8 @@ repository:
     - qa
     - sdet
     - playwright
-    - testing
     - llm
-    - ci
+    - pytest
+    - github-actions
+    - devcontainers
+    - codeql


### PR DESCRIPTION
## Summary
- align the repository topics in `.github/settings.yml` with the eight topics listed in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1fe9346848321ad6b72937ac08f96