### PR TITLE
chore: update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "dependencies": {
         "fast-xml-parser": "file:packages/fast-xml-parser"
       },
+      "bin": {
+        "flaky": "projects/03-ci-flaky/scripts/flaky.mjs"
+      },
       "devDependencies": {
         "@playwright/test": "file:packages/playwright-test-stub"
       }


### PR DESCRIPTION
## Summary
- regenerate package-lock.json to include the flaky bin entry that mirrors package.json

## Testing
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68d202c64d088321872fa1f29cc7929b