### PR TITLE
chore: add import group spacing

### DIFF
--- a/projects/01-spec2cases/scripts/run_cases.mjs
+++ b/projects/01-spec2cases/scripts/run_cases.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { SPEC2CASES_SAMPLE_CASES_PATH } from '../../../scripts/paths.mjs';
 
 const args = process.argv.slice(2);

--- a/projects/01-spec2cases/scripts/spec2cases.mjs
+++ b/projects/01-spec2cases/scripts/spec2cases.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { SPEC2CASES_SAMPLE_CASES_PATH } from '../../../scripts/paths.mjs';
 
 function usage() {

--- a/projects/01-spec2cases/scripts/text_to_cases.mjs
+++ b/projects/01-spec2cases/scripts/text_to_cases.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/projects/03-ci-flaky/src/junit-parser.js
+++ b/projects/03-ci-flaky/src/junit-parser.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { classifyFailureByMessage, createFailureSignature, applyTimeoutClassification } from './classification.js';
 
 const ATTRIBUTE_REGEX = /([:\w.-]+)(?:\s*=\s*("([^"]*)"|'([^']*)'|([^\s'"=<>`]+)))?/g;

--- a/projects/03-ci-flaky/src/report.js
+++ b/projects/03-ci-flaky/src/report.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { ensureDir } from './fs-utils.js';
 
 function escapeHtml(value) {

--- a/projects/03-ci-flaky/src/store.js
+++ b/projects/03-ci-flaky/src/store.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { appendJsonl, ensureDir, getFileSize } from './fs-utils.js';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB

--- a/tests/fast-xml-parser.test.mjs
+++ b/tests/fast-xml-parser.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+
 import { XMLParser } from 'fast-xml-parser';
 
 test('XMLParser parses basic junit suite with attributes and text content', () => {

--- a/tests/spec2cases.test.mjs
+++ b/tests/spec2cases.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
+
 import { parseSpecFile, validateCasesSchema } from '../projects/01-spec2cases/scripts/spec2cases.mjs';
 import { SPEC2CASES_SAMPLE_SPEC_MD_PATH } from '../scripts/paths.mjs';
 


### PR DESCRIPTION
## Summary
- ensure built-in, external, and relative imports are separated by blank lines in spec2cases scripts and associated tests
- align the ci flaky store modules with the import grouping convention from eslint.config.js

## Testing
- npm run lint:js *(fails: Missing script "lint:js")*

------
https://chatgpt.com/codex/tasks/task_e_68d202c4dcd0832180480bfc8bac8977