### PR TITLE
Add English quick glance copy for README and site hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
 - **Docs Deploy:** `.github/workflows/pages.yml` が `docs/` をビルド&公開（追加の Pages ワークフローは不要）
 - **Topics:** `qa`, `sdet`, `playwright`, `llm`, `pytest`, `github-actions`, `devcontainers`, `codeql`
 
+### Quick glance (EN)
+
+This hub curates hands-on QA, SDET, and LLM automation assets—pipelines, PoCs, and reports—that you can remix for your own delivery workflows.
+
+```bash
+just test
+```
+
+[Browse the live Portfolio Gallery →](https://ryosuke4219.github.io/portfolio/)
+
 ---
 
 ## 概要 (Overview)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
 ---
 
 > 🔎 最新CIレポート: [JUnit要約]({{ '/reports/junit/index.html' | relative_url }}) / [Flakyランキング]({{ '/reports/flaky/index.html' | relative_url }}) / [Coverage HTML]({{ '/reports/coverage/index.html' | relative_url }})
+>
+> 🚀 Fresh CI signals in English: [JUnit digest]({{ '/reports/junit/index.html' | relative_url }}) / [Flaky leaderboard]({{ '/reports/flaky/index.html' | relative_url }}) / [Coverage dashboard]({{ '/reports/coverage/index.html' | relative_url }})
 
 # Demos
 


### PR DESCRIPTION
## Summary
- introduce a "Quick glance (EN)" subsection in the README with an English overview, representative `just` command, and gallery link
- add an English subcopy line to the GitHub Pages hero so both languages surface the CI report links

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d232b9c108832188fc788bc172122d