### PR TITLE
Add v1.0 release notes and refresh release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,19 +178,20 @@ pytest -q   # ERR（障害注入）/ SHD（影実行）シナリオ一式
 
 ## リリース (Releases)
 
-- 最新: [v0.3 – flaky検出＋週次サマリ](https://github.com/Ryosuke4219/portfolio/releases/tag/v0.3)
+- 最新: [v1.0 – ポートフォリオ統合リリース](https://github.com/Ryosuke4219/portfolio/releases/tag/v1.0)
 
 ### マイルストーン一覧
 
-1. **[v0.3 – flaky検出＋週次サマリ](docs/releases/v0.3.md)** — 週次 QA サマリ（README 自動更新）と CI レポート公開を整備し、Pages／Releases から参照できるようにしました。
-2. **[v0.2 – LLMアダプタ（shadow/fallback）最小版](docs/releases/v0.2.md)** — Python 製 LLM アダプタを追加し、shadow 実行とフォールバック検証を pytest / GitHub Actions で自動化しました。
-3. **[v0.1 – 初期プロジェクト群](docs/releases/v0.1.md)** — テキスト仕様 → テストケース生成、LLM→Playwright 自動化、CI ログ解析の 3 パイプラインを公開しました。
+1. **[v1.0 – ポートフォリオ統合リリース](docs/releases/v1.0.md)** — 4 本の自動化パイプラインと CI / Pages / Releases の公開フローを整備し、ポートフォリオ全体を横断的に参照できるようにしました。
+2. **[v0.3 – flaky検出＋週次サマリ](docs/releases/v0.3.md)** — 週次 QA サマリ（README 自動更新）と CI レポート公開を整備し、Pages／Releases から参照できるようにしました。
+3. **[v0.2 – LLMアダプタ（shadow/fallback）最小版](docs/releases/v0.2.md)** — Python 製 LLM アダプタを追加し、shadow 実行とフォールバック検証を pytest / GitHub Actions で自動化しました。
+4. **[v0.1 – 初期プロジェクト群](docs/releases/v0.1.md)** — テキスト仕様 → テストケース生成、LLM→Playwright 自動化、CI ログ解析の 3 パイプラインを公開しました。
 
 ### リリース運用手順
 
 1. 直近のマイルストーンを `docs/releases/` に追記し、変更点・テスト・関連ドキュメントを整理。
-2. 対象コミットに注釈付きタグを作成: `git tag -a v0.x <commit> -m "v0.x – サマリ"`
-3. `gh release create v0.x --verify-tag --notes-file docs/releases/v0.x.md` で GitHub Releases を公開し、README の最新リンクを更新。
+2. 対象コミットに注釈付きタグを作成: `git tag -a vX.Y <commit> -m "vX.Y – サマリ"`
+3. `gh release create vX.Y --verify-tag --notes-file docs/releases/vX.Y.md` で GitHub Releases を公開し、README の最新リンクを更新。
 4. タグと README 更新を `git push --follow-tags` で共有。
 
 

--- a/docs/releases/v1.0.md
+++ b/docs/releases/v1.0.md
@@ -1,0 +1,21 @@
+# v1.0 – ポートフォリオ統合リリース
+
+## 主要変更点
+- 4 本の自動化パイプライン（仕様→テストケース生成、LLM AC 拡張→Playwright、CI flaky 解析、LLM Adapter）が README / docs に集約され、GitHub Pages の Portfolio Gallery から横断的に参照可能に。
+- QA メトリクスと CI レポートの週次更新を `tools/update_readme_metrics.py`・`scripts/build-ci-reports.mjs`・Pages ワークフローで自動化し、最新状態を README / Reports に反映。
+- リリース手順・週次サマリ・プロジェクト運用ドキュメントを整備し、`docs/` 配下に統一的な公開ルールを記述。`docs/releases/` で各バージョンの変更履歴をトレース可能にした。
+
+## 既知の制約
+- QA 指標はサンプルプロジェクト由来のテストを含むため、Pass Rate や flaky ランキングはデモデータとして扱う必要がある。
+- LLM Adapter はモック/スタブを前提とした最小構成であり、実運用の API キー管理やレート制御は別途実装が必要。
+- Playwright 互換スタブに依存しているため、本物のブラウザでの E2E 検証は別リポジトリや追加設定が必要。
+
+## 推奨環境
+- Node.js 24.x（`fnm` 管理）＋ npm `npm ci`
+- Python 3.11 (`uv` / `venv`) ＋ `just test` による一括検証
+- GitHub Actions（`ci.yml` / `lint.yml` / `coverage.yml` / `pages.yml` / `weekly-qa-summary.yml`）による CI/CD 実行
+
+## テスト観点
+- `just test` で Node.js パイプラインと Python pytest を一括実行。
+- `npm run ci:analyze` / `npm run ci:issue` により flaky レポートと Issue テンプレートを生成。
+- `node scripts/build-ci-reports.mjs` で GitHub Pages 用の CI レポートを再現。


### PR DESCRIPTION
## Summary
- add the v1.0 release notes documenting major changes, known limitations, and recommended environment
- refresh the README release section to highlight v1.0 and generalize the tagging/release instructions

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d232c38a8c8321ac3db0c62874a03e