### PR TITLE
Add sticky navigation to docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,89 @@ title: Portfolio Hub
 description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯瞰できるポータル
 ---
 
+<nav class="page-toc" aria-label="ページ内ナビゲーション">
+  <p class="page-toc__title">Jump to</p>
+  <ul class="page-toc__list">
+    <li><a href="#demos">Demos</a>
+      <ul>
+        <li><a href="#demo-01">01. Spec to Cases</a></li>
+        <li><a href="#demo-02">02. LLM to Playwright</a></li>
+        <li><a href="#demo-03">03. CI Flaky Analyzer</a></li>
+        <li><a href="#demo-04">04. LLM Adapter — Shadow Execution</a></li>
+      </ul>
+    </li>
+    <li><a href="#weekly-summary">Weekly Summary</a></li>
+    <li><a href="#evidence-library">Evidence Library</a></li>
+    <li><a href="#operations-notes">運用メモ</a></li>
+  </ul>
+</nav>
+
+<style>
+.page-toc {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  background-color: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(27, 31, 35, 0.15);
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 12px rgba(31, 41, 55, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.page-toc__title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #4a5568;
+}
+
+.page-toc__list,
+.page-toc__list ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+.page-toc__list > li {
+  margin-bottom: 0.25rem;
+}
+
+.page-toc__list ul {
+  margin-top: 0.25rem;
+  padding-left: 1rem;
+  font-size: 0.95rem;
+}
+
+.page-toc a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page-toc a:hover,
+.page-toc a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .page-toc {
+    top: -1px;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    border-radius: 0;
+  }
+}
+</style>
+
 > 🔎 最新CIレポート: [JUnit要約]({{ '/reports/junit/index.html' | relative_url }}) / [Flakyランキング]({{ '/reports/flaky/index.html' | relative_url }}) / [Coverage HTML]({{ '/reports/coverage/index.html' | relative_url }})
 
 # Demos
 
 <div class="demo-grid">
-  <article class="demo-card">
+  <article class="demo-card" id="demo-01">
     <header>
       <p class="demo-card__id">01</p>
       <h2><a href="{{ '/evidence/spec2cases.html' | relative_url }}">Spec to Cases</a></h2>
@@ -22,7 +99,7 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
     <p><a class="demo-card__link" href="{{ '/evidence/spec2cases.html' | relative_url }}">Evidence &rarr;</a></p>
   </article>
 
-  <article class="demo-card">
+  <article class="demo-card" id="demo-02">
     <header>
       <p class="demo-card__id">02</p>
       <h2><a href="{{ '/evidence/llm2pw.html' | relative_url }}">LLM to Playwright</a></h2>
@@ -35,7 +112,7 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
     <p><a class="demo-card__link" href="{{ '/evidence/llm2pw.html' | relative_url }}">Evidence &rarr;</a></p>
   </article>
 
-  <article class="demo-card">
+  <article class="demo-card" id="demo-03">
     <header>
       <p class="demo-card__id">03</p>
       <h2><a href="{{ '/evidence/flaky.html' | relative_url }}">CI Flaky Analyzer</a></h2>
@@ -48,7 +125,7 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
     <p><a class="demo-card__link" href="{{ '/evidence/flaky.html' | relative_url }}">Evidence &rarr;</a></p>
   </article>
 
-  <article class="demo-card">
+  <article class="demo-card" id="demo-04">
     <header>
       <p class="demo-card__id">04</p>
       <h2><a href="{{ '/evidence/llm-adapter.html' | relative_url }}">LLM Adapter — Shadow Execution</a></h2>
@@ -95,7 +172,7 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
 - [テスト計画書](./test-plan.md)
 - [欠陥レポートサンプル](./defect-report-sample.md)
 
-## 運用メモ
+## 運用メモ {#operations-notes}
 
 - `weekly-qa-summary.yml` ワークフローが `docs/weekly-summary.md` を自動更新。
 - `tools/generate_gallery_snippets.py` が週次サマリからハイライトカードを生成。


### PR DESCRIPTION
## Summary
- add an in-page navigation block to jump between the demos and summary sections
- make the new navigation sticky and style it for readability
- expose anchor targets for each demo card and the operations memo section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d232c7376c8321b3f1fa5e026eb5a0