### PR TITLE
docs: add project readmes and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ New automation pipelines and LLM-driven PoCs are published regularly, with a per
   * `--tag` や `--id` で絞り込めるため、スモークテスト／個別ケースを即座に確認可能。
   * 期待値や手順が欠落している場合は失敗としてサマリに計上し、仕様漏れを検知。
 
+→ 詳細: [Spec2Cases CLI README](projects/01-spec2cases/README.md)
+
 ### 2. LLM設計 → Playwright E2E テスト自動生成
 
 * `docs/examples/llm2pw/blueprint.sample.json` をもとにテストコードを自動生成。
@@ -103,6 +105,8 @@ New automation pipelines and LLM-driven PoCs are published regularly, with a per
   * CI ではこれらの成果物を `npm run ci:analyze` / `npm run ci:issue` へ渡して履歴管理を行う。
   * `projects/02-llm-to-playwright/tests/README.md` にテスト生成時の**セレクタ・ガード方針**や**ビジュアル／a11y スモーク**の運用メモを記載。`login-cases.json` / `a11y-pages.csv` を編集するだけでデータドリブンにシナリオを増やせる構成とした。
 
+→ 詳細: [LLM → Playwright Pipeline README](projects/02-llm-to-playwright/README.md)
+
 ### 3. CI ログ解析と flaky テスト検出
 
 * JUnit XML を解析して履歴 DB (`database.json`) を更新。
@@ -122,6 +126,8 @@ New automation pipelines and LLM-driven PoCs are published regularly, with a per
 
   * 失敗率や平均時間、直近 10 実行のタイムラインを含むレポートを生成。
   * 解析結果は `projects/03-ci-flaky/out/`（HTML/CSV/JSON）に出力され、CI 実行時はアーティファクトとして取得できる。
+
+→ 詳細: [Flaky Analyzer CLI README](projects/03-ci-flaky/README.md)
 
 ### 4. LLM Adapter — Shadow Execution & Error Handling (Minimal)
 
@@ -157,6 +163,8 @@ pytest -q   # ERR（障害注入）/ SHD（影実行）シナリオ一式
 * `[TIMEOUT]` / `[RATELIMIT]` / `[INVALID_JSON]` を含むプロンプトで異常系を明示的に再現し、フォールバック挙動を検証。
 
 **記録フォーマット（例）**
+
+→ 詳細: [LLM Adapter (Core) README](projects/04-llm-adapter/README.md) / [Shadow Adapter README](projects/04-llm-adapter-shadow/README.md)
 
 ```json
 {

--- a/projects/01-spec2cases/README.md
+++ b/projects/01-spec2cases/README.md
@@ -1,0 +1,52 @@
+# Spec2Cases CLI
+
+Markdown/テキスト仕様書から構造化テストケース(JSON)を生成し、軽量なCLIで検証・擬似実行まで行う最小パイプラインです。`docs/examples/spec2cases/` のサンプルをもとにフロー全体を再現できます。
+
+## セットアップ
+
+```bash
+npm install
+```
+
+Node.js 18+ を想定しています。リポジトリ直下で `npm install` を実行すると、全スクリプトが `node` または `npm run ...` で利用可能になります。
+
+## コマンド一覧
+
+| コマンド | 説明 |
+| --- | --- |
+| `npm run spec:generate` | Markdown仕様 (`spec.sample.md`) から JSON テストケースを生成します。 |
+| `npm run spec:from-text` | プレーンテキスト仕様 (`spec.sample.txt`) を JSON に変換し、サンプル出力を更新します。 |
+| `npm run spec:validate -- <path>` | JSON 定義をスキーマチェックします。引数なしの場合はサンプルを使用。 |
+| `npm run spec:run -- <cases.json> [--tag <tag>] [--id <id>]` | テストケースを読み込み、タグ/IDでフィルタしながら擬似実行レポートを表示します。 |
+
+> CLI を直接利用する場合は `projects/01-spec2cases/scripts/*.mjs` を `node` で呼び出せます。
+
+## 代表的な使い方
+
+```bash
+# 1. Markdown仕様からケースを生成（sample を上書き）
+npm run spec:generate
+# => projects/01-spec2cases/cases.generated.json
+
+# 2. 生成物のスキーマを検証（期待・手順欠落を検出）
+npm run spec:validate -- projects/01-spec2cases/cases.generated.json
+
+# 3. タグでフィルタして擬似実行
+npm run spec:run -- projects/01-spec2cases/cases.generated.json --tag smoke
+```
+
+* `spec2cases.mjs` は Markdown/テキスト/JSON を自動判別し、必要に応じて JSON を標準出力へ書き出します。
+* `run_cases.mjs` は手順・期待値の欠落を失敗としてカウントし、仕様の穴を早期検出できます。
+
+## 生成物
+
+- `projects/01-spec2cases/cases.generated.json` : Markdown仕様から生成された最新テストケース。
+- `docs/examples/spec2cases/cases.sample.json` : テキスト仕様から生成されるサンプル出力。
+- CLI 実行ログ : `spec:run` 実行時のサマリ (標準出力)。
+
+## 拡張ポイント
+
+- **フォーマット追加**：CSV/Gherkin など別形式の仕様から同一スキーマに変換するアダプタを追加可能。
+- **実行エンジン差し替え**：`run_cases.mjs` を他言語ランナーに置き換え、実際のテスト自動化に接続。
+- **CI 連携**：生成→検証→擬似実行を GitHub Actions の Job として連結し、仕様変更の差分を定常的に検証。
+- **メタデータ拡張**：`schema.json` を拡張して優先度やオーナー情報を付与し、テスト計画と連動。

--- a/projects/02-llm-to-playwright/README.md
+++ b/projects/02-llm-to-playwright/README.md
@@ -1,0 +1,43 @@
+# LLM → Playwright Pipeline
+
+LLM から受け取ったブループリント(JSON)を検証し、Playwright 互換のテストコードを生成・実行・可視化する PoC です。静的デモ (`docs/examples/llm2pw/demo/`) とスタブランナーを同梱し、LLM 補完から CI 連携までの一連の流れを再現できます。
+
+## セットアップ
+
+```bash
+npm install
+```
+
+Node.js 18+ を想定。依存解決後は `npm run e2e:gen` / `npm test` などの npm script を利用できます。
+
+## コマンド一覧
+
+| コマンド | 説明 |
+| --- | --- |
+| `npm run e2e:gen` | ブループリント (`blueprint.sample.json`) を検証し、Playwright テストコードを `tests/generated/` に生成します。 |
+| `npm test` | Playwright スタブランナーで生成済みテストを実行し、`junit-results.xml` / `test-results/` を出力します。 |
+| `node projects/02-llm-to-playwright/server.mjs` | デモ HTML をローカル配信し、UI/セレクタの挙動をブラウザで確認できます。 |
+
+> `scripts/blueprint_to_code.mjs` を直接実行すると、任意のブループリントファイルを指定してコード生成できます。
+
+## ワークフロー
+
+1. **LLM 補完** — 受け入れ基準やシナリオをプロンプトとして投げ、`scenarios[]` を含むブループリント JSON を取得。
+2. **テスト生成** — `blueprint_to_code.mjs` がセレクタ/データ/アサーションを検証しつつ `.spec.ts` を生成。重複 ID や欠損時はエラーで停止。
+3. **テスト実行** — `npm test` がスタブ化された Playwright ランナーを呼び出し、DOM のテキスト検証・フォーム操作・ビジュアル/アクセシビリティスモークを実施。
+4. **成果物活用** — JUnit XML / `test-results/` / スナップショット差分を `projects/03-ci-flaky` の解析コマンドへ渡し、履歴や Issue 起票に利用。
+
+## 生成物
+
+- `projects/02-llm-to-playwright/tests/generated/*.spec.ts` : ブループリントから生成された Playwright テスト。
+- `projects/02-llm-to-playwright/tests/generated/__snapshots__/` : ビジュアルスモークのゴールデンファイル。
+- `junit-results.xml`, `test-results/` : スタブランナーによる実行ログ (CI でアーティファクト化)。
+
+詳細なセレクタガイドや a11y/ビジュアル運用メモは [`tests/README.md`](tests/README.md) を参照してください。
+
+## 拡張ポイント
+
+- **HITL レビュー支援**：ブループリントを PR コメントに埋め込み、差分レビューツールとして活用。
+- **UI カバレッジ拡張**：`login-cases.json` や `a11y-pages.csv` を増やし、データドリブンでシナリオを追加。
+- **実ブラウザ統合**：スタブを本物の Playwright ランナーに差し替え、`server.mjs` で配信するデモや外部環境に接続。
+- **生成ガード強化**：セレクタ命名規則やアクセシビリティ要件を追加検証し、LLM 生成物の品質を自動診断。

--- a/projects/04-llm-adapter/README.md
+++ b/projects/04-llm-adapter/README.md
@@ -1,0 +1,59 @@
+# LLM Adapter (Core)
+
+複数プロバイダの LLM 応答を比較・記録・可視化する実験用アダプタです。Shadow 実行なしで本番想定のリクエストを発行し、コスト/レイテンシ/差分率・失敗分類などを JSONL に追記します。`datasets/golden/` のゴールデンタスクと `config/providers/*.yaml` を組み合わせ、基準データに対する回帰テストを高速に行えます。
+
+## セットアップ
+
+```bash
+cd projects/04-llm-adapter
+python3 -m venv .venv
+source .venv/bin/activate        # Windows: .\.venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+Python 3.10+ を想定。仮想環境下で CLI (`adapter/run_compare.py`) やレポート生成ツールを利用します。
+
+## コマンド一覧
+
+| コマンド | 説明 |
+| --- | --- |
+| `python adapter/run_compare.py --providers adapter/config/providers/simulated.yaml --prompts datasets/golden/tasks.jsonl` | 指定プロバイダ構成とゴールデンタスクを比較実行し、`data/runs-metrics.jsonl` に追記します。 |
+| `python adapter/run_compare.py --providers <a,b> --mode parallel --repeat 3 --metrics tmp/metrics.jsonl` | 複数プロバイダを並列実行し、出力先をカスタマイズします。 |
+| `python tools/report/metrics_to_html.py --metrics data/runs-metrics.jsonl --out reports/index.html` | JSONL メトリクスを HTML ダッシュボードに変換します。 |
+
+> `--budgets` で `adapter/config/budgets.yaml` を差し替えると、実行ごとのコスト上限や停止条件を変更できます。
+
+## 代表的な使い方
+
+```bash
+# 1. 仮想環境を有効化し、サンプル設定で比較実行
+python adapter/run_compare.py \
+  --providers adapter/config/providers/simulated.yaml \
+  --prompts datasets/golden/tasks.jsonl \
+  --repeat 2 \
+  --mode serial
+# => data/runs-metrics.jsonl に追記（プロジェクト直下に data/ が自動生成されます）
+
+# 2. 収集したメトリクスを HTML に変換
+python tools/report/metrics_to_html.py \
+  --metrics data/runs-metrics.jsonl \
+  --golden datasets/golden/baseline \
+  --out reports/index.html
+```
+
+- 実行ごとのレイテンシ/コスト/トークン数を計測し、`eval.diff_rate` などのメトリクスで決定性を評価します。
+- `datasets/golden/baseline/` の期待値と比較し、差分が閾値を超えた場合は `failure_kind` や `budget.hit_stop` を明示します。
+
+## 生成物
+
+- `data/runs-metrics.jsonl` : 1リクエスト=1行のメトリクスログ（既定の追記先）。
+- `reports/index.html` : メトリクスを可視化したダッシュボード（Git管理外）。
+- `datasets/golden/tasks.jsonl` : ゴールデンタスク定義。`baseline/expectations.jsonl` でプロバイダごとの許容差分を保持。
+- `adapter/config/providers/*.yaml` / `adapter/config/budgets.yaml` : プロバイダ別のシード・料金・レート制限と実行予算設定。
+
+## 拡張ポイント
+
+- **Shadow 実行統合**：`projects/04-llm-adapter-shadow` の仕組みを取り込み、プライマリ応答と比較実行を同一 JSONL で記録。
+- **評価モジュール追加**：`adapter/core/metrics.py` を拡張し、BLEU/ROUGE や構造比較など用途別メトリクスを追加。
+- **外部連携**：`tools/report/metrics_to_html.py` を CI から呼び出し、GitHub Pages や Dashboards SaaS へ自動配信。
+- **予算ポリシー強化**：`adapter/core/budgets.py` に日次/週次の複合制限や優先度キューを実装し、コスト最適化を自動化。


### PR DESCRIPTION
## Summary
- add dedicated READMEs for the spec2cases, llm-to-playwright, and llm-adapter projects
- align section structure with the flaky analyzer docs and clarify core vs shadow adapter deliverables
- link the top-level project overviews to their detailed READMEs for easier navigation

## Testing
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68d232b657808321a46df6ffff4ef9f2