### PR TITLE
Add shadow pipeline integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r projects/04-llm-adapter-shadow/requirements.txt
 
+      - name: Run shadow pipeline integration test
+        if: always()
+        run: node --test tests/e2e-shadow.test.mjs
+
       - name: Run pytest with coverage HTML
         if: always()
         run: |

--- a/justfile
+++ b/justfile
@@ -17,12 +17,13 @@ setup:
 	fi
 
 node-test:
-	set -euo pipefail
-	npm run spec:validate
-	npm run e2e:gen
-	bash scripts/run-node-suite.sh
-	npm run ci:analyze
-	npm run ci:issue
+        set -euo pipefail
+        npm run spec:validate
+        npm run e2e:gen
+        bash scripts/run-node-suite.sh
+        npm run ci:analyze
+        npm run ci:issue
+        node --test tests/e2e-shadow.test.mjs
 
 python-test:
 	set -euo pipefail

--- a/projects/04-llm-adapter-shadow/tools/consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tools/consume_cases.py
@@ -1,0 +1,160 @@
+"""Utility script to aggregate Node pipeline outputs for the shadow adapter demo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"cases file not found: {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+
+
+def _load_jsonl(path: Path) -> List[Mapping[str, Any]]:
+    if not path.exists():
+        raise SystemExit(f"attempts file not found: {path}")
+
+    attempts: List[Mapping[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            trimmed = raw.strip()
+            if not trimmed:
+                continue
+            try:
+                parsed = json.loads(trimmed)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+                raise SystemExit(f"invalid JSON on line {line_no} in {path}: {exc}") from exc
+            if isinstance(parsed, Mapping):
+                attempts.append(parsed)
+    return attempts
+
+
+def _extract_case_ids(cases: Iterable[Mapping[str, Any]]) -> List[str]:
+    ids: List[str] = []
+    for entry in cases:
+        if isinstance(entry, Mapping):
+            value = str(entry.get("id", "")).strip()
+            if value:
+                ids.append(value)
+    return ids
+
+
+def _attempt_case_id(attempt: Mapping[str, Any]) -> str | None:
+    name = attempt.get("name")
+    if not isinstance(name, str):
+        return None
+    prefix = name.split(maxsplit=1)[0]
+    return prefix.strip() or None
+
+
+def _build_metrics(cases: Mapping[str, Any], attempts: List[Mapping[str, Any]]) -> MutableMapping[str, Any]:
+    suite = str(cases.get("suite", "")).strip() if isinstance(cases, Mapping) else ""
+    case_entries = cases.get("cases") if isinstance(cases, Mapping) else None
+    if not isinstance(case_entries, Iterable):
+        case_entries = []
+
+    case_ids = _extract_case_ids(case_entries) if case_entries else []
+    statuses: Counter[str] = Counter()
+    seen: Dict[str, Mapping[str, Any]] = {}
+    failed_ids: List[str] = []
+
+    for attempt in attempts:
+        status = str(attempt.get("status", "unknown")).lower()
+        statuses[status] += 1
+        case_id = _attempt_case_id(attempt)
+        if case_id:
+            seen.setdefault(case_id, attempt)
+            if status not in {"pass", "skipped"}:
+                failed_ids.append(case_id)
+
+    missing_ids = sorted(set(case_ids) - set(seen))
+    failed_unique = sorted(set(failed_ids))
+
+    pass_count = statuses.get("pass", 0)
+    total_attempts = sum(statuses.values())
+    pass_rate = float(pass_count) / float(total_attempts) if total_attempts else 0.0
+
+    metrics: MutableMapping[str, Any] = {
+        "suite": suite or None,
+        "case_count": len(case_ids),
+        "attempt_count": total_attempts,
+        "status_breakdown": dict(statuses),
+        "covered_case_ids": sorted(seen),
+        "missing_case_ids": missing_ids,
+        "failed_case_ids": failed_unique,
+        "pass_rate": round(pass_rate, 4),
+        "all_green": total_attempts > 0 and not failed_unique,
+    }
+    return metrics
+
+
+def _format_text(metrics: Mapping[str, Any]) -> str:
+    lines = []
+    suite = metrics.get("suite") or "<unknown suite>"
+    lines.append(f"Suite: {suite}")
+    lines.append(f"Cases: {metrics.get('case_count', 0)}")
+    lines.append(
+        "Attempts: {attempts} (pass: {passed}, fail: {failed}, error: {error}, skipped: {skipped})".format(
+            attempts=metrics.get("attempt_count", 0),
+            passed=metrics.get("status_breakdown", {}).get("pass", 0),
+            failed=metrics.get("status_breakdown", {}).get("fail", 0),
+            error=metrics.get("status_breakdown", {}).get("error", 0),
+            skipped=metrics.get("status_breakdown", {}).get("skipped", 0),
+        )
+    )
+    if metrics.get("missing_case_ids"):
+        lines.append(f"Missing IDs: {', '.join(metrics['missing_case_ids'])}")
+    if metrics.get("failed_case_ids"):
+        lines.append(f"Failed IDs: {', '.join(metrics['failed_case_ids'])}")
+    lines.append(f"Pass rate: {metrics.get('pass_rate', 0.0):.2%}")
+    lines.append(f"All green: {'yes' if metrics.get('all_green') else 'no'}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", required=True, help="Path to spec2cases JSON output")
+    parser.add_argument("--attempts", required=True, help="Path to analyze-junit JSONL output")
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Output format (default: json)",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output",
+    )
+
+    args = parser.parse_args(argv)
+
+    cases_path = Path(args.cases).expanduser().resolve()
+    attempts_path = Path(args.attempts).expanduser().resolve()
+
+    cases_data = _load_json(cases_path)
+    attempts = _load_jsonl(attempts_path)
+    metrics = _build_metrics(cases_data, attempts)
+
+    if args.format == "json":
+        indent = 2 if args.pretty else None
+        separators = (",", ": ") if args.pretty else (",", ":")
+        text = json.dumps(metrics, ensure_ascii=False, indent=indent, separators=separators, sort_keys=True)
+    else:
+        text = _format_text(metrics)
+
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tests/e2e-shadow.test.mjs
+++ b/tests/e2e-shadow.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { parseSpecFile } from '../projects/01-spec2cases/scripts/spec2cases.mjs';
+import { generateTestsFromBlueprint } from '../projects/02-llm-to-playwright/scripts/blueprint_to_code.mjs';
+import { analyzeJUnitReport } from '../projects/03-ci-flaky/scripts/analyze-junit.mjs';
+import {
+  LLM2PW_SAMPLE_BLUEPRINT_PATH,
+  SPEC2CASES_SAMPLE_SPEC_TXT_PATH,
+} from '../scripts/paths.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+async function waitForFile(targetPath, { timeoutMs = 1000, intervalMs = 25 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(targetPath)) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  assert.fail(`expected file to exist within ${timeoutMs}ms: ${targetPath}`);
+}
+
+test('spec → playwright → junit → python metrics pipeline', async () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-pipeline-'));
+  const generatedDir = path.join(tmpRoot, 'projects', '02-llm-to-playwright', 'tests', 'generated');
+  fs.mkdirSync(generatedDir, { recursive: true });
+
+  const cases = parseSpecFile(SPEC2CASES_SAMPLE_SPEC_TXT_PATH);
+  const casesPath = path.join(tmpRoot, 'cases.json');
+  fs.writeFileSync(casesPath, JSON.stringify(cases, null, 2), 'utf8');
+
+  const blueprint = readJson(LLM2PW_SAMPLE_BLUEPRINT_PATH);
+  const generatedFiles = generateTestsFromBlueprint(blueprint, generatedDir);
+  assert.equal(
+    generatedFiles.length,
+    blueprint.scenarios.length,
+    'expected one generated spec file per scenario',
+  );
+
+  const playwrightCli = path.join(repoRoot, 'node_modules', '.bin', 'playwright');
+  assert.ok(fs.existsSync(playwrightCli), 'playwright CLI stub should exist');
+
+  const runResult = spawnSync(process.execPath, [playwrightCli, 'test'], {
+    cwd: tmpRoot,
+    encoding: 'utf8',
+    env: { ...process.env },
+  });
+  if (runResult.status !== 0) {
+    const stderr = runResult.stderr || '<no stderr>';
+    const stdout = runResult.stdout || '<no stdout>';
+    assert.fail(`playwright stub failed (status=${runResult.status})\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`);
+  }
+
+  const junitPath = path.join(tmpRoot, 'junit-results.xml');
+  assert.ok(fs.existsSync(junitPath), 'junit-results.xml should be produced by the stub');
+
+  const dbPath = path.join(tmpRoot, 'artifacts', 'junit-attempts.jsonl');
+  const analysis = await analyzeJUnitReport(junitPath, dbPath);
+  assert.equal(analysis.attemptsCount, blueprint.scenarios.length);
+  await waitForFile(analysis.outputPath);
+
+  const pythonExe = process.env.PYTHON || 'python3';
+  const adapterScript = path.join(
+    repoRoot,
+    'projects',
+    '04-llm-adapter-shadow',
+    'tools',
+    'consume_cases.py',
+  );
+  assert.ok(fs.existsSync(adapterScript), 'adapter metrics script should exist');
+
+  const pythonResult = spawnSync(
+    pythonExe,
+    [
+      adapterScript,
+      '--cases',
+      casesPath,
+      '--attempts',
+      analysis.outputPath,
+      '--format',
+      'json',
+    ],
+    {
+      encoding: 'utf8',
+    },
+  );
+
+  if (pythonResult.status !== 0) {
+    assert.fail(`consume_cases.py failed: ${pythonResult.stderr || pythonResult.stdout}`);
+  }
+
+  const trimmed = pythonResult.stdout.trim();
+  assert.ok(trimmed, 'adapter script should emit metrics');
+  const metrics = JSON.parse(trimmed);
+  assert.equal(metrics.suite, cases.suite);
+  assert.equal(metrics.case_count, cases.cases.length);
+  assert.equal(metrics.attempt_count, blueprint.scenarios.length);
+  assert.deepEqual(metrics.missing_case_ids, []);
+  assert.deepEqual(metrics.failed_case_ids, []);
+  assert.equal(metrics.status_breakdown.pass, blueprint.scenarios.length);
+  assert.equal(metrics.all_green, true);
+});


### PR DESCRIPTION
## Summary
- add a Python helper to aggregate spec cases and JUnit attempts into metrics for the shadow adapter project
- create an end-to-end Node test that runs the Spec→Playwright→JUnit→Python pipeline and validates the metrics output
- wire the new integration test into `just test` and the CI workflow so it runs automatically

## Testing
- node --test tests/e2e-shadow.test.mjs
- pytest -q projects/04-llm-adapter-shadow/tests


------
https://chatgpt.com/codex/tasks/task_e_68d232c48e8c8321b201e1eb85103d63