### PR TITLE
Add hero CTA buttons to docs landing page

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -10,6 +10,11 @@
   margin: 1.5rem 0 2rem;
 }
 
+.page-header .button-group {
+  justify-content: center;
+  margin-top: 2rem;
+}
+
 .button-group .button {
   display: inline-flex;
   align-items: center;

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,12 @@ title: Portfolio Hub
 description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯瞰できるポータル
 ---
 
+<div class="button-group">
+  <a class="button button--github" href="https://github.com/Ryosuke4219/portfolio">GitHubリポジトリ</a>
+  <a class="button button--evidence" href="{{ '/evidence/README.html' | relative_url }}">Evidence Catalog</a>
+  <a class="button button--weekly" href="{{ '/weekly-summary.html' | relative_url }}">Weekly Summary</a>
+</div>
+
 > [English version]({{ '/en/' | relative_url }})
 
 


### PR DESCRIPTION
## Summary
- add a hero button group on `docs/index.md` linking to the GitHub repository, evidence catalog, and weekly summary
- center and space the hero button group within the Cayman theme header for better visibility

## Testing
- gem install jekyll jekyll-theme-cayman --no-document *(fails: rubygems access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d24f26082883218441c9dab0d39270