### PR TITLE
Add overview section to docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,12 @@ description: QA / SDET / LLM 成果物のハイライトと週次サマリを俯
   </ul>
 </nav>
 
+## このポートフォリオで分かること
+
+- QA 自動化パイプラインの組み立てと運用ノウハウ
+- LLM 活用によるテスト生成と評価の実践知
+- CI パイプラインの可観測性・改善サイクルの設計
+
 <div class="button-group">
   <a class="button button--github" href="https://github.com/Ryosuke4219/portfolio">GitHubリポジトリ</a>
   <a class="button button--evidence" href="{{ '/evidence/README.html' | relative_url }}">Evidence Catalog</a>


### PR DESCRIPTION
## Summary
- add a "このポートフォリオで分かること" overview section immediately after the docs navigation
- summarize three key learnings covering QA automation, LLM-driven testing, and CI observability

## Testing
- (cd docs && python3 -m http.server 4000)
- curl -s http://127.0.0.1:4000/index.md

------
https://chatgpt.com/codex/tasks/task_e_68d27cd5e0a08321bc5827fa992c3a50