### PR TITLE
Refine coverage workflow artifact packaging

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -14,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -23,12 +26,23 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          mkdir -p reports/coverage
           pytest -q \
             --cov=projects/04-llm-adapter-shadow/src \
-            --cov-report=xml:reports/coverage/coverage.xml \
-            --cov-report=html:reports/coverage/html \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov \
             projects/04-llm-adapter-shadow/tests
+
+      - name: Prepare coverage bundle
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p reports/coverage
+          if [ -d htmlcov ]; then
+            cp -a htmlcov/. reports/coverage/
+          fi
+          if [ -f coverage.xml ]; then
+            cp coverage.xml reports/coverage/coverage.xml
+          fi
 
       - name: Upload coverage XML
         if: always()


### PR DESCRIPTION
## Summary
- copy pytest's HTML coverage output into reports/coverage to align with GitHub Pages structure
- keep coverage XML alongside the HTML bundle and always upload it for downstream workflows
- downgrade workflow Python runtime to 3.11 for compatibility and guard bundle preparation so it never fails when artifacts are missing

## Testing
- no tests were run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2a61e92808321b76fbbfcfd02dd66