### PR TITLE
Enable manual CodeQL execution

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,15 +7,17 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '20 14 * * 1'
+  workflow_dispatch:
+    {}
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add workflow_dispatch so the CodeQL workflow can run on demand
- promote permissions to the workflow level to ensure code scanning results upload successfully

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2b67f37a88321b786f91a2a52eb9a