### PR TITLE
Fix Pages rsync permissions error

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
           for dir in coverage flaky junit; do
             if [ -d "docs/reports/${dir}" ]; then
               mkdir -p "_site/reports/${dir}"
-              rsync -av --delete "docs/reports/${dir}/" "_site/reports/${dir}/"
+              rsync -av --no-group --no-owner --delete "docs/reports/${dir}/" "_site/reports/${dir}/"
             fi
           done
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- add rsync flags to skip preserving ownership when copying bundled CI reports to the site output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d34f9e179883218bafb7acb04e2872