### PR TITLE
Add Gemini and Ollama providers with defaults

### DIFF
--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -57,6 +57,15 @@ python demo_shadow.py
 
 標準出力でプライマリ結果を確認しつつ、影実行のメトリクスが `artifacts/runs-metrics.jsonl` に追記されます。
 
+### Provider configuration
+
+- `PRIMARY_PROVIDER` — 形式は `"<prefix>:<model-id>"`。デフォルトは `gemini:gemini-2.5-flash`。
+- `SHADOW_PROVIDER` — 影実行用。デフォルトは `ollama:gemma3n:e2b`。`none` や空文字で無効化できます。
+- `OLLAMA_HOST` — Ollama API のベースURL（未指定時は `http://127.0.0.1:11434`）。
+- `GEMINI_API_KEY` — Gemini SDK が自動検出するAPIキー。環境にセットしておくと `GeminiProvider` が利用します。
+
+プロバイダ文字列は最初のコロンのみを区切り文字として扱うため、`ollama:gemma3n:e2b` のようにモデルIDにコロンを含めても問題ありません。`mock:foo` を指定するとモックプロバイダで簡易動作確認が可能です。
+
 ### Run the tests
 
 ```bash

--- a/projects/04-llm-adapter-shadow/demo_shadow.py
+++ b/projects/04-llm-adapter-shadow/demo_shadow.py
@@ -1,11 +1,36 @@
-from src.llm_adapter.providers.mock import MockProvider
+from __future__ import annotations
+
+import sys
+
 from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.providers.factory import provider_from_environment
 from src.llm_adapter.runner import Runner
 
 if __name__ == "__main__":
-    primary = MockProvider("openai-like", base_latency_ms=20)
-    shadow = MockProvider("anthropic-like", base_latency_ms=15)
+    try:
+        primary = provider_from_environment(
+            "PRIMARY_PROVIDER", default="gemini:gemini-2.5-flash"
+        )
+        shadow = provider_from_environment(
+            "SHADOW_PROVIDER",
+            default="ollama:gemma3n:e2b",
+            optional=True,
+        )
+    except ValueError as exc:  # pragma: no cover - defensive CLI guard
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
     runner = Runner([primary])
-    res = runner.run(ProviderRequest(prompt="こんにちは、世界"), shadow=shadow)
-    print(res.text, res.latency_ms, "ms")
-    print("Shadow metrics would be written to artifacts/runs-metrics.jsonl")
+    request = ProviderRequest(prompt="こんにちは、世界")
+
+    try:
+        response = runner.run(request, shadow=shadow)
+    except Exception as exc:  # pragma: no cover - demo script resilience
+        print(f"Provider execution failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(f"Primary provider: {primary.name()} -> {response.text}")
+    print(f"Latency: {response.latency_ms} ms, tokens: {response.token_usage.total}")
+    if shadow is not None:
+        print(f"Shadow provider: {shadow.name()} (metrics only)")
+    print("Shadow metrics are written to artifacts/runs-metrics.jsonl")

--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -1,2 +1,4 @@
 pytest>=8.2.0
 pytest-cov>=5.0.0
+google-genai>=0.3
+requests>=2.31.0

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
@@ -1,0 +1,93 @@
+"""Helpers for instantiating providers from configuration strings."""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Mapping
+
+from ..provider_spi import ProviderSPI
+from .gemini import GeminiProvider
+from .mock import MockProvider
+from .ollama import OllamaProvider
+
+__all__ = [
+    "parse_provider_spec",
+    "create_provider_from_spec",
+    "provider_from_environment",
+]
+
+
+ProviderFactory = Callable[[str], ProviderSPI]
+
+
+def parse_provider_spec(spec: str) -> tuple[str, str]:
+    """Split ``spec`` into ``(prefix, remainder)``.
+
+    Only the first ``":"`` acts as the separator so that model identifiers such
+    as ``"gemma3n:e2b"`` remain intact.
+    """
+
+    if not isinstance(spec, str):
+        raise ValueError("provider spec must be a string")
+
+    prefix, sep, remainder = spec.partition(":")
+    if not sep:
+        raise ValueError(f"invalid provider spec: {spec!r}")
+
+    prefix = prefix.strip().lower()
+    remainder = remainder.strip()
+    if not prefix or not remainder:
+        raise ValueError(f"invalid provider spec: {spec!r}")
+
+    return prefix, remainder
+
+
+def create_provider_from_spec(
+    spec: str,
+    *,
+    factories: Mapping[str, ProviderFactory] | None = None,
+) -> ProviderSPI:
+    prefix, remainder = parse_provider_spec(spec)
+
+    default_factories: dict[str, ProviderFactory] = {
+        "gemini": lambda model: GeminiProvider(model=model),
+        "ollama": lambda model: OllamaProvider(model=model),
+        "mock": lambda model: MockProvider(model),
+    }
+
+    if factories:
+        default_factories.update(factories)
+
+    try:
+        factory = default_factories[prefix]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"unsupported provider prefix: {prefix}") from exc
+
+    return factory(remainder)
+
+
+_DISABLED_VALUES = {"", "none", "null", "off"}
+
+
+def provider_from_environment(
+    variable: str,
+    *,
+    default: str | None = None,
+    optional: bool = False,
+    factories: Mapping[str, ProviderFactory] | None = None,
+) -> ProviderSPI | None:
+    value = os.environ.get(variable, default)
+    if value is None:
+        if optional:
+            return None
+        raise ValueError(f"environment variable {variable} is required")
+
+    normalized = value.strip()
+    if normalized.lower() in _DISABLED_VALUES:
+        if optional:
+            return None
+        raise ValueError(
+            f"environment variable {variable} disabled without optional flag"
+        )
+
+    return create_provider_from_spec(normalized, factories=factories)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Callable, Mapping
+from collections.abc import Callable, Mapping
 
 from ..provider_spi import ProviderSPI
 from .gemini import GeminiProvider

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from typing import Any
 
 try:  # pragma: no cover - import guard for offline test environments
     from google import genai  # type: ignore[import]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -1,0 +1,212 @@
+"""Gemini provider integration for the minimal adapter."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+try:  # pragma: no cover - import guard for offline test environments
+    from google import genai  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - fallback when SDK is unavailable
+    genai = None  # type: ignore[assignment]
+
+from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
+
+__all__ = ["GeminiProvider", "parse_gemini_messages"]
+
+
+def _coerce_usage(value: Any) -> TokenUsage:
+    """Extract token usage metadata from ``value``.
+
+    The Google SDK exposes ``usage_metadata`` both as attributes on the
+    ``GenerateContentResponse`` object and within ``to_dict()`` payloads. The
+    helper is defensive so that tests can supply light-weight fakes.
+    """
+
+    prompt_tokens = 0
+    completion_tokens = 0
+
+    if value is None:
+        return TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
+
+    usage_obj = getattr(value, "usage_metadata", None)
+    if usage_obj is not None:
+        prompt_tokens = int(getattr(usage_obj, "input_tokens", 0) or 0)
+        completion_tokens = int(getattr(usage_obj, "output_tokens", 0) or 0)
+    else:
+        if hasattr(value, "to_dict"):
+            payload = value.to_dict()
+        elif isinstance(value, Mapping):
+            payload = value
+        else:
+            payload = {}
+        usage_dict = payload.get("usage_metadata")
+        if isinstance(usage_dict, Mapping):
+            prompt_tokens = int(usage_dict.get("input_tokens", 0) or 0)
+            completion_tokens = int(usage_dict.get("output_tokens", 0) or 0)
+
+    return TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
+
+
+def _coerce_output_text(response: Any) -> str:
+    text = getattr(response, "output_text", None)
+    if isinstance(text, str):
+        return text
+
+    if hasattr(response, "to_dict"):
+        payload = response.to_dict()
+        if isinstance(payload, Mapping):
+            text = payload.get("output_text")
+            if isinstance(text, str):
+                return text
+
+    return ""
+
+
+def parse_gemini_messages(messages: Sequence[Mapping[str, Any]] | None) -> list[Mapping[str, Any]]:
+    """Convert chat-style messages into Gemini "Content" entries.
+
+    The adapter keeps the schema intentionally small: each message is expected
+    to provide ``role`` and ``content``. ``content`` may be either a string or a
+    list of strings. Invalid entries are skipped gracefully so that the caller
+    does not have to perform extensive validation ahead of time.
+    """
+
+    if not messages:
+        return []
+
+    converted: list[Mapping[str, Any]] = []
+    for entry in messages:
+        if not isinstance(entry, Mapping):
+            continue
+        role = str(entry.get("role", "user")).strip() or "user"
+        raw_parts: Any = entry.get("content")
+        parts_list: list[Mapping[str, str]] = []
+
+        if isinstance(raw_parts, str):
+            text_value = raw_parts.strip()
+            if text_value:
+                parts_list.append({"text": text_value})
+        elif isinstance(raw_parts, Iterable):
+            for part in raw_parts:
+                if isinstance(part, str) and part.strip():
+                    parts_list.append({"text": part.strip()})
+
+        if parts_list:
+            converted.append({"role": role, "parts": parts_list})
+
+    return converted
+
+
+def _merge_generation_config(
+    base_config: Mapping[str, Any] | None,
+    request: ProviderRequest,
+) -> MutableMapping[str, Any] | None:
+    config: MutableMapping[str, Any] = {}
+    if base_config:
+        config.update(base_config)
+
+    option_config = None
+    if request.options and isinstance(request.options, Mapping):
+        option_config = request.options.get("generation_config")
+    if isinstance(option_config, Mapping):
+        config.update(option_config)
+
+    if request.max_tokens and "max_output_tokens" not in config:
+        config["max_output_tokens"] = int(request.max_tokens)
+
+    return config or None
+
+
+def _select_safety_settings(
+    base_settings: Sequence[Mapping[str, Any]] | None,
+    request: ProviderRequest,
+) -> Sequence[Mapping[str, Any]] | None:
+    if request.options and isinstance(request.options, Mapping):
+        overrides = request.options.get("safety_settings")
+        if isinstance(overrides, Sequence):
+            return list(overrides)
+    if base_settings:
+        return list(base_settings)
+    return None
+
+
+class GeminiProvider(ProviderSPI):
+    """Provider implementation backed by the Gemini Responses API."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        name: str | None = None,
+        client: Any | None = None,
+        generation_config: Mapping[str, Any] | None = None,
+        safety_settings: Sequence[Mapping[str, Any]] | None = None,
+    ) -> None:
+        self._model = model
+        self._name = name or f"gemini:{model}"
+        if client is None:
+            if genai is None:  # pragma: no cover - defensive branch
+                raise ImportError(
+                    "google-genai is not installed; provide a pre-configured client"
+                )
+            client = genai.Client()
+        self._client = client
+        self._generation_config = dict(generation_config or {})
+        self._safety_settings = list(safety_settings or [])
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def _translate_error(self, exc: Exception) -> Exception:
+        status = getattr(exc, "status", "") or getattr(exc, "code", "")
+        status_text = str(status).upper()
+
+        if status_text in {"UNAUTHENTICATED", "PERMISSION_DENIED"}:
+            return AuthError(str(exc))
+        if status_text in {"RESOURCE_EXHAUSTED", "QUOTA_EXCEEDED"}:
+            return RateLimitError(str(exc))
+        if status_text in {"DEADLINE_EXCEEDED", "GATEWAY_TIMEOUT"}:
+            return TimeoutError(str(exc))
+
+        return RetriableError(str(exc))
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        messages = []
+        if request.options and isinstance(request.options, Mapping):
+            messages = parse_gemini_messages(request.options.get("messages"))
+            system_message = request.options.get("system")
+            if isinstance(system_message, str) and system_message.strip():
+                system_content = system_message.strip()
+                if messages:
+                    messages.insert(0, {"role": "system", "parts": [{"text": system_content}]})
+                else:
+                    messages = [{"role": "system", "parts": [{"text": system_content}]}]
+
+        if not messages:
+            messages = [{"role": "user", "parts": [{"text": request.prompt}]}]
+
+        config = _merge_generation_config(self._generation_config, request)
+        safety_settings = _select_safety_settings(self._safety_settings, request)
+
+        ts0 = time.time()
+        try:
+            response = self._client.responses.generate(  # type: ignore[no-untyped-call]
+                model=self._model,
+                input=messages,
+                config=config,
+                safety_settings=safety_settings,
+            )
+        except Exception as exc:  # pragma: no cover - translated in unit tests
+            translated = self._translate_error(exc)
+            raise translated from exc
+
+        latency_ms = int((time.time() - ts0) * 1000)
+        usage = _coerce_usage(response)
+        text = _coerce_output_text(response)
+
+        return ProviderResponse(text=text, token_usage=usage, latency_ms=latency_ms)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from types import ModuleType
 from typing import Any, Protocol, cast
 
 try:  # pragma: no cover - import guard for offline test environments
-    from google import genai
+    from google import genai as _genai_module
 except ModuleNotFoundError:  # pragma: no cover - fallback when SDK is unavailable
-    genai = None
+    genai: ModuleType | None = None
+else:
+    genai = cast(ModuleType, _genai_module)
 
 from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
@@ -168,7 +171,8 @@ class GeminiProvider(ProviderSPI):
                 raise ImportError(
                     "google-genai is not installed; provide a pre-configured client"
                 )
-            client = genai.Client()
+            module = cast(Any, genai)
+            client = cast(_GeminiClient, module.Client())
         self._client: _GeminiClient = cast(_GeminiClient, client)
         self._generation_config = dict(generation_config or {})
         self._safety_settings = list(safety_settings or [])

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 try:  # pragma: no cover - allow running without the optional dependency
     import requests  # type: ignore[import]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -8,6 +8,9 @@ from collections.abc import Iterable, Mapping
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
+
 
 class _ResponseProtocol(Protocol):
     status_code: int
@@ -15,7 +18,7 @@ class _ResponseProtocol(Protocol):
     def close(self) -> None:
         ...
 
-    def __enter__(self) -> "_ResponseProtocol":
+    def __enter__(self) -> _ResponseProtocol:
         ...
 
     def __exit__(
@@ -78,7 +81,7 @@ else:  # pragma: no cover - allow running without the optional dependency
             def close(self) -> None:  # pragma: no cover - trivial stub
                 return None
 
-            def __enter__(self) -> "Response":  # pragma: no cover - stub
+            def __enter__(self) -> Response:  # pragma: no cover - stub
                 return self
 
             def __exit__(
@@ -100,11 +103,8 @@ else:  # pragma: no cover - allow running without the optional dependency
                 return []
     else:
         requests = cast(Any, _requests_module)
-        Response = cast(type[_ResponseProtocol], getattr(_requests_module, "Response"))
-        requests_exceptions = cast(Any, getattr(_requests_module, "exceptions"))
-
-from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
-from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
+        Response = cast(type[_ResponseProtocol], _requests_module.Response)
+        requests_exceptions = cast(Any, _requests_module.exceptions)
 
 DEFAULT_HOST = "http://127.0.0.1:11434"
 __all__ = ["OllamaProvider", "DEFAULT_HOST"]

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.llm_adapter.errors import AuthError, RateLimitError
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderSPI
+from src.llm_adapter.providers.factory import (
+    create_provider_from_spec,
+    parse_provider_spec,
+    provider_from_environment,
+)
+from src.llm_adapter.providers.gemini import GeminiProvider
+from src.llm_adapter.providers.ollama import OllamaProvider
+from src.llm_adapter.providers import ollama as ollama_module
+
+
+def test_parse_provider_spec_allows_colons_in_model():
+    prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
+    assert prefix == "ollama"
+    assert model == "gemma3n:e2b"
+
+
+def test_parse_provider_spec_requires_separator():
+    with pytest.raises(ValueError):
+        parse_provider_spec("gemini")
+
+
+class DummyProvider(ProviderSPI):
+    def __init__(self, model: str):
+        self._model = model
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return f"dummy:{self._model}"
+
+    def capabilities(self) -> set[str]:  # pragma: no cover - trivial
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def test_create_provider_from_spec_supports_overrides():
+    provider = create_provider_from_spec(
+        "gemini:test-model",
+        factories={"gemini": lambda model: DummyProvider(model)},
+    )
+    assert isinstance(provider, DummyProvider)
+    assert provider.name() == "dummy:test-model"
+
+
+def test_provider_from_environment_optional_none(monkeypatch):
+    monkeypatch.setenv("SHADOW_PROVIDER", "none")
+    result = provider_from_environment(
+        "SHADOW_PROVIDER",
+        optional=True,
+        factories={"gemini": lambda model: DummyProvider(model)},
+    )
+    assert result is None
+
+
+def test_provider_from_environment_disabled_requires_optional(monkeypatch):
+    monkeypatch.setenv("PRIMARY_PROVIDER", "none")
+    with pytest.raises(ValueError):
+        provider_from_environment(
+            "PRIMARY_PROVIDER",
+            optional=False,
+            factories={"gemini": lambda model: DummyProvider(model)},
+        )
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, payload: dict | None = None, lines: list[bytes] | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self._lines = lines or [b"{}"]
+        self.closed = False
+
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise ollama_module.requests_exceptions.HTTPError(response=self)
+
+    def json(self):
+        return self._payload
+
+    def iter_lines(self):
+        yield from self._lines
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):  # pragma: no cover - context protocol
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - context protocol
+        self.close()
+        return False
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls: list[tuple[str, dict | None, bool]] = []
+        self._show_calls = 0
+
+    def post(self, url, json=None, stream=False, timeout=None):  # pragma: no cover - patched in tests
+        raise NotImplementedError
+
+
+class _RecordClient:
+    def __init__(self):
+        self.calls = []
+
+        class _Responses:
+            def __init__(self, outer):
+                self._outer = outer
+
+            def generate(self, **kwargs):
+                self._outer.calls.append(kwargs)
+                return SimpleNamespace(
+                    output_text="こんにちは",
+                    usage_metadata=SimpleNamespace(input_tokens=12, output_tokens=7),
+                )
+
+        self.responses = _Responses(self)
+
+
+def test_gemini_provider_invokes_client_with_config():
+    client = _RecordClient()
+    provider = GeminiProvider(
+        "gemini-2.5-flash",
+        client=client,  # type: ignore[arg-type]
+        generation_config={"temperature": 0.2},
+    )
+
+    request = ProviderRequest(
+        prompt="テスト", max_tokens=128, options={"system": "you are helpful"}
+    )
+    response = provider.invoke(request)
+
+    assert response.text == "こんにちは"
+    assert response.token_usage.prompt == 12
+    assert response.token_usage.completion == 7
+    assert response.latency_ms >= 0
+
+    recorded = client.calls.pop()
+    assert recorded["model"] == "gemini-2.5-flash"
+    assert recorded["config"]["temperature"] == 0.2
+    assert recorded["config"]["max_output_tokens"] == 128
+    assert isinstance(recorded["input"], list)
+
+
+def test_gemini_provider_translates_rate_limit():
+    class _FailingResponses:
+        def generate(self, **kwargs):
+            err = Exception("rate limited")
+            setattr(err, "status", "RESOURCE_EXHAUSTED")
+            raise err
+
+    class _Client:
+        def __init__(self):
+            self.responses = _FailingResponses()
+
+    provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
+
+    with pytest.raises(RateLimitError):
+        provider.invoke(ProviderRequest(prompt="hello"))
+
+
+def test_ollama_provider_auto_pull_and_chat():
+    class Session(_FakeSession):
+        def __init__(self):
+            super().__init__()
+            self._chat_called = False
+
+        def post(self, url, json=None, stream=False, timeout=None):
+            self.calls.append((url, json, stream))
+            if url.endswith("/api/show"):
+                self._show_calls += 1
+                if self._show_calls == 1:
+                    return _FakeResponse(status_code=404, payload={})
+                return _FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/pull"):
+                return _FakeResponse(status_code=200, payload={}, lines=[b"{}"])
+            if url.endswith("/api/chat"):
+                self._chat_called = True
+                return _FakeResponse(
+                    status_code=200,
+                    payload={
+                        "message": {"content": "hello"},
+                        "prompt_eval_count": 3,
+                        "eval_count": 5,
+                    },
+                )
+            raise AssertionError(f"unexpected url: {url}")
+
+    session = Session()
+    provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
+
+    response = provider.invoke(ProviderRequest(prompt="hello"))
+
+    assert response.text == "hello"
+    assert response.token_usage.prompt == 3
+    assert response.token_usage.completion == 5
+    assert response.latency_ms >= 0
+    assert session._chat_called
+
+    show_calls = [url for url, *_ in session.calls if url.endswith("/api/show")]
+    assert len(show_calls) == 2  # first miss + verification after pull
+
+
+def test_ollama_provider_maps_auth_error():
+    class Session(_FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):
+            if url.endswith("/api/show"):
+                return _FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                return _FakeResponse(status_code=401, payload={})
+            raise AssertionError(f"unexpected url: {url}")
+
+    provider = OllamaProvider("gemma3n:e2b", session=Session(), host="http://localhost")
+
+    with pytest.raises(AuthError):
+        provider.invoke(ProviderRequest(prompt="hello"))


### PR DESCRIPTION
## Summary
- add Gemini and Ollama provider implementations with parsing, error handling, and fallback support
- add provider factory plus demo/readme updates to default to Gemini 2.5 Flash and Gemma 3n E2B
- add dependencies and tests covering provider loading and request flows

## Testing
- pytest projects/04-llm-adapter-shadow -q

------
https://chatgpt.com/codex/tasks/task_e_68d3f20484ec8321bad28730b186c43f