### PR TITLE
fix: update gemini sdk integration and ci

### DIFF
--- a/.github/workflows/adapter-tests.yml
+++ b/.github/workflows/adapter-tests.yml
@@ -1,0 +1,36 @@
+name: Adapter Shadow Tests
+
+on:
+  push:
+    paths:
+      - 'projects/04-llm-adapter-shadow/**'
+      - '.github/workflows/adapter-tests.yml'
+  pull_request:
+    paths:
+      - 'projects/04-llm-adapter-shadow/**'
+      - '.github/workflows/adapter-tests.yml'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        working-directory: projects/04-llm-adapter-shadow
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        working-directory: projects/04-llm-adapter-shadow
+        env:
+          PYTHONPATH: src
+        run: pytest -q

--- a/projects/04-llm-adapter-shadow/.env.example
+++ b/projects/04-llm-adapter-shadow/.env.example
@@ -1,0 +1,9 @@
+# Gemini (Google AI Studio) API key
+GEMINI_API_KEY=your-gemini-key
+
+# Provider wiring
+PRIMARY_PROVIDER=gemini:gemini-2.5-flash
+SHADOW_PROVIDER=ollama:gemma3n:e2b
+
+# Ollama endpoint (defaults to http://127.0.0.1:11434 if unset)
+OLLAMA_HOST=http://127.0.0.1:11434

--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -6,6 +6,8 @@
 
 **EN:** Minimal adapter that keeps the primary response, mirrors the request on a shadow provider for metrics only, and purposefully reproduces timeout / rate limit / malformed-response failures.
 
+> ℹ️ **本ポートフォリオで外部LLM APIを利用するのはこの04プロジェクトのみです。** 01〜03は決定的なスタブ／ルールベース処理で完結し、ネットワークやAPIキーを必要としません。
+
 ## Motivation
 
 - 本番の意思決定を変えずに品質・レイテンシ差分を継続測定 → ベンダ選定や回帰検知に活用。
@@ -66,6 +68,23 @@ python demo_shadow.py
 
 プロバイダ文字列は最初のコロンのみを区切り文字として扱うため、`ollama:gemma3n:e2b` のようにモデルIDにコロンを含めても問題ありません。`mock:foo` を指定するとモックプロバイダで簡易動作確認が可能です。
 
+#### よく使う環境変数例
+
+```bash
+export PRIMARY_PROVIDER="gemini:gemini-2.5-flash"
+export SHADOW_PROVIDER="ollama:gemma3n:e2b"
+export GEMINI_API_KEY="<YOUR_GEMINI_KEY>"
+export OLLAMA_HOST="http://127.0.0.1:11434"
+```
+
+ルート直下の `.env.example` をコピーして `.env` を作成すると、上記の雛形をそのまま利用できます。
+
+Gemini の構造化出力を利用したい場合は、`generation_config` に
+`{"response_mime_type": "application/json"}` や
+`{"response_schema": {...}}` を指定すると JSON 固定のレスポンスを要求できます。
+`demo_shadow.py` の `request_options` を編集するか、環境変数で
+`PRIMARY_OPTIONS` を与えて `ProviderRequest.options` に受け渡してください。
+
 ### Run the tests
 
 ```bash
@@ -115,7 +134,8 @@ pytest -q
 
 ## Notes
 
-- 実プロバイダ統合は意図的に含めていません（**軽量のまま**にするため）。
+- ポートフォリオ全体を通じて、実LLMプロバイダ統合はこの04だけに閉じています。他のチャプターは決定的（deterministic）な処理で構成されています。
+- 実プロバイダ統合は Gemini（Google AI Studio）とローカル Ollama の最小構成に限定し、Mock プロバイダでネットワーク無しのテストも維持しています。
 - メトリクスは JSONL に追記するだけの最小構成です。
 - 後続の LLM Adapter OSS 本体とは**独立**して動作する、ポートフォリオ用サンプルです。
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -208,7 +208,7 @@ class OllamaProvider(ProviderSPI):
                 pass
 
         # Verify again with a short retry window.
-        for _ in range(3):
+        for _ in range(10):
             show_after = self._request("/api/show", {"model": self._model})
             if show_after.status_code == 200:
                 self._model_ready = True

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -111,18 +111,18 @@ class _RecordClient:
     def __init__(self):
         self.calls = []
 
-        class _Responses:
+        class _Models:
             def __init__(self, outer):
                 self._outer = outer
 
-            def generate(self, **kwargs):
+            def generate_content(self, **kwargs):
                 self._outer.calls.append(kwargs)
                 return SimpleNamespace(
-                    output_text="こんにちは",
+                    text="こんにちは",
                     usage_metadata=SimpleNamespace(input_tokens=12, output_tokens=7),
                 )
 
-        self.responses = _Responses(self)
+        self.models = _Models(self)
 
 
 def test_gemini_provider_invokes_client_with_config():
@@ -147,19 +147,19 @@ def test_gemini_provider_invokes_client_with_config():
     assert recorded["model"] == "gemini-2.5-flash"
     assert recorded["config"]["temperature"] == 0.2
     assert recorded["config"]["max_output_tokens"] == 128
-    assert isinstance(recorded["input"], list)
+    assert isinstance(recorded["contents"], list)
 
 
 def test_gemini_provider_translates_rate_limit():
-    class _FailingResponses:
-        def generate(self, **kwargs):
+    class _FailingModels:
+        def generate_content(self, **kwargs):
             err = Exception("rate limited")
             setattr(err, "status", "RESOURCE_EXHAUSTED")
             raise err
 
     class _Client:
         def __init__(self):
-            self.responses = _FailingResponses()
+            self.models = _FailingModels()
 
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Summary
- migrate the Gemini provider to the current google-genai models API while keeping a fallback for older clients and richer text coercion
- document required environment variables for the shadow adapter, provide a .env example, clarify that project 04 is the only LLM-backed sample, and make the Ollama auto-pull retry loop more forgiving
- add a GitHub Actions workflow that runs the adapter test suite on relevant pushes and pull requests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d48814cd908321abe148c0fa4354ac