### PR TITLE
Add OpenAI provider support

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -179,21 +179,39 @@ def _invoke_gemini(
 ) -> Any:
     models_api = getattr(client, "models", None)
     if models_api and hasattr(models_api, "generate_content"):
-        return models_api.generate_content(
-            model=model,
-            contents=contents,
-            config=config,
-            safety_settings=safety_settings,
-        )
+        try:
+            return models_api.generate_content(
+                model=model,
+                contents=contents,
+                config=config,
+                safety_settings=safety_settings,
+            )
+        except TypeError as exc:  # pragma: no cover - legacy SDK fallback
+            if safety_settings and "safety_settings" in str(exc):
+                return models_api.generate_content(
+                    model=model,
+                    contents=contents,
+                    config=config,
+                )
+            raise
 
     responses_api = getattr(client, "responses", None)
     if responses_api and hasattr(responses_api, "generate"):
-        return responses_api.generate(
-            model=model,
-            input=contents,
-            config=config,
-            safety_settings=safety_settings,
-        )
+        try:
+            return responses_api.generate(
+                model=model,
+                input=contents,
+                config=config,
+                safety_settings=safety_settings,
+            )
+        except TypeError as exc:  # pragma: no cover - legacy SDK fallback
+            if safety_settings and "safety_settings" in str(exc):
+                return responses_api.generate(
+                    model=model,
+                    input=contents,
+                    config=config,
+                )
+            raise
 
     raise AttributeError("Gemini client does not provide a supported generate method")
 

--- a/projects/04-llm-adapter/README.md
+++ b/projects/04-llm-adapter/README.md
@@ -13,6 +13,33 @@ pip install -r requirements.txt
 
 Python 3.10+ を想定。仮想環境下で CLI (`adapter/run_compare.py`) やレポート生成ツールを利用します。
 
+### Google Gemini を利用する
+
+
+実プロバイダとして Google Gemini を呼び出す場合は、API キーを `GOOGLE_API_KEY` に設定し、Gemini 用の設定ファイルを指定します。
+
+```bash
+export GOOGLE_API_KEY="<取得したAPIキー>"
+python adapter/run_compare.py \
+  --providers adapter/config/providers/gemini.yaml \
+  --prompts datasets/golden/tasks.jsonl
+```
+
+`adapter/config/providers/gemini.yaml` では `model: gemini-1.5-flash` を既定とし、料金（入力 0.00035 USD/1k tokens、出力 0.00105 USD/1k tokens）やレートリミット（60 rpm / 60k tpm）を設定済みです。追加の `generation_config` や `safety_settings` を調整したい場合は YAML を編集してください。SDK が `safety_settings` 引数を受け付けない旧バージョンでも、自動的に同引数を除外して再試行します。
+
+### OpenAI を利用する
+
+OpenAI API を利用する場合は、`OPENAI_API_KEY` を設定し OpenAI 用の設定ファイルを指定します。
+
+```bash
+export OPENAI_API_KEY="<取得したAPIキー>"
+python adapter/run_compare.py \
+  --providers adapter/config/providers/openai.yaml \
+  --prompts datasets/golden/tasks.jsonl
+```
+
+`adapter/config/providers/openai.yaml` では `model: gpt-4o-mini` を既定とし、Responses API を優先的に呼び出します。旧 Chat Completion API しか利用できない SDK バージョンでも自動的にフォールバックします。料金（入力 0.00015 USD/1k tokens、出力 0.00060 USD/1k tokens）やレートリミット（5k rpm / 500k tpm）は目安値です。Azure OpenAI 等でエンドポイントが異なる場合は `endpoint` や `request_kwargs` を適宜上書きしてください。
+
 ## コマンド一覧
 
 | コマンド | 説明 |

--- a/projects/04-llm-adapter/adapter/config/providers/gemini.yaml
+++ b/projects/04-llm-adapter/adapter/config/providers/gemini.yaml
@@ -1,0 +1,29 @@
+provider: gemini
+endpoint: null
+model: gemini-1.5-flash
+auth_env: GOOGLE_API_KEY
+seed: 0
+temperature: 0.2
+top_p: 1.0
+max_tokens: 1024
+timeout_s: 30
+retries:
+  max: 2
+  backoff_s: 1.0
+persist_output: true
+pricing:
+  prompt_usd: 0.00035
+  completion_usd: 0.00105
+rate_limit:
+  rpm: 60
+  tpm: 60000
+quality_gates:
+  determinism_diff_rate_max: 0.15
+  determinism_len_stdev_max: 40
+generation_config:
+  candidate_count: 1
+safety_settings:
+  - category: HARM_CATEGORY_HARASSMENT
+    threshold: BLOCK_MEDIUM_AND_ABOVE
+  - category: HARM_CATEGORY_SEXUAL
+    threshold: BLOCK_MEDIUM_AND_ABOVE

--- a/projects/04-llm-adapter/adapter/config/providers/openai.yaml
+++ b/projects/04-llm-adapter/adapter/config/providers/openai.yaml
@@ -1,22 +1,26 @@
 provider: openai
-endpoint: https://api.openai.com/v1/chat/completions
-model: gpt-4.1-mini
+endpoint: null
+model: gpt-4o-mini
 auth_env: OPENAI_API_KEY
-seed: 42
+seed: 0
 temperature: 0.2
 top_p: 1.0
-max_tokens: 512
-timeout_s: 60
+max_tokens: 1024
+timeout_s: 30
 retries:
   max: 2
-  backoff_s: 2
-persist_output: false
+  backoff_s: 1.0
+persist_output: true
 pricing:
-  prompt_usd: 0.005
-  completion_usd: 0.015
+  prompt_usd: 0.00015
+  completion_usd: 0.00060
 rate_limit:
-  rpm: 300
-  tpm: 400000
+  rpm: 5000
+  tpm: 500000
 quality_gates:
   determinism_diff_rate_max: 0.15
-  determinism_len_stdev_max: 8
+  determinism_len_stdev_max: 40
+api: responses
+system_prompt: "You are a helpful assistant."
+response_format:
+  type: text

--- a/projects/04-llm-adapter/adapter/core/providers/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/providers/__init__.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from typing import Dict, Optional, Type
 
-from .config import ProviderConfig
+from ..config import ProviderConfig
 
 LOGGER = logging.getLogger(__name__)
 
@@ -64,9 +64,7 @@ class SimulatedProvider(BaseProvider):
 class ProviderFactory:
     """プロバイダ生成のためのファクトリ。"""
 
-    _registry: Dict[str, Type[BaseProvider]] = {
-        "simulated": SimulatedProvider,
-    }
+    _registry: Dict[str, Type[BaseProvider]] = {"simulated": SimulatedProvider}
 
     @classmethod
     def register(cls, provider_name: str, provider_cls: Type[BaseProvider]) -> None:
@@ -81,3 +79,18 @@ class ProviderFactory:
             )
             provider_cls = SimulatedProvider
         return provider_cls(config)
+
+
+try:  # pragma: no cover - optional依存の存在に応じて処理
+    from .gemini import GeminiProvider
+except Exception:  # pragma: no cover - 依存不足時は gemini を登録しない
+    GeminiProvider = None  # type: ignore[assignment]
+else:  # pragma: no cover - 実行時に gemini プロバイダを登録
+    ProviderFactory.register("gemini", GeminiProvider)
+
+try:  # pragma: no cover - optional依存の存在に応じて処理
+    from .openai import OpenAIProvider
+except Exception:  # pragma: no cover - 依存不足時は openai を登録しない
+    OpenAIProvider = None  # type: ignore[assignment]
+else:  # pragma: no cover - 実行時に openai プロバイダを登録
+    ProviderFactory.register("openai", OpenAIProvider)

--- a/projects/04-llm-adapter/adapter/core/providers/gemini.py
+++ b/projects/04-llm-adapter/adapter/core/providers/gemini.py
@@ -1,0 +1,212 @@
+"""Google Gemini プロバイダ実装。"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from ..config import ProviderConfig
+from . import BaseProvider, ProviderResponse
+
+__all__ = ["GeminiProvider"]
+
+try:  # pragma: no cover - 実行環境により SDK が存在しない場合がある
+    from google import genai as _genai  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - SDK 未導入時
+    _genai = None  # type: ignore[assignment]
+
+
+def _resolve_api_key(env_name: str | None) -> str:
+    if not env_name:
+        raise RuntimeError("Gemini プロバイダを利用するには auth_env に API キーの環境変数を指定してください")
+    value = os.getenv(env_name)
+    if not value:
+        raise RuntimeError(f"Gemini API キーが環境変数 '{env_name}' に見つかりません")
+    return value
+
+
+def _prepare_generation_config(config_obj: ProviderConfig) -> MutableMapping[str, Any]:
+    config: MutableMapping[str, Any] = {}
+    raw = config_obj.raw.get("generation_config")
+    if isinstance(raw, Mapping):
+        config.update(raw)
+    if config_obj.temperature:
+        config.setdefault("temperature", float(config_obj.temperature))
+    if config_obj.top_p and config_obj.top_p < 1.0:
+        config.setdefault("top_p", float(config_obj.top_p))
+    if config_obj.max_tokens:
+        config.setdefault("max_output_tokens", int(config_obj.max_tokens))
+    return config
+
+
+def _prepare_safety_settings(config_obj: ProviderConfig) -> Sequence[Mapping[str, Any]] | None:
+    raw = config_obj.raw.get("safety_settings")
+    if isinstance(raw, Sequence):
+        candidates: list[Mapping[str, Any]] = []
+        for item in raw:
+            if isinstance(item, Mapping):
+                candidates.append(dict(item))
+        if candidates:
+            return candidates
+    return None
+
+
+def _call_with_optional_safety(
+    func: Any,
+    *,
+    model: str,
+    config: Mapping[str, Any] | None,
+    safety_settings: Sequence[Mapping[str, Any]] | None,
+    payload_key: str,
+    payload: Any,
+) -> Any:
+    kwargs: dict[str, Any] = {"model": model, payload_key: payload}
+    if config:
+        kwargs["config"] = config
+    if safety_settings:
+        kwargs["safety_settings"] = safety_settings
+    try:
+        return func(**kwargs)
+    except TypeError as exc:  # pragma: no cover - 旧 SDK 互換
+        if safety_settings and "safety_settings" in str(exc):
+            kwargs.pop("safety_settings", None)
+            return func(**kwargs)
+        raise
+
+
+def _invoke_gemini(client: Any, model: str, contents: Sequence[Mapping[str, Any]] | None, config: Mapping[str, Any] | None, safety_settings: Sequence[Mapping[str, Any]] | None) -> Any:
+    models_api = getattr(client, "models", None)
+    if models_api and hasattr(models_api, "generate_content"):
+        func = getattr(models_api, "generate_content")
+        return _call_with_optional_safety(
+            func,
+            model=model,
+            config=config,
+            safety_settings=safety_settings,
+            payload_key="contents",
+            payload=contents,
+        )
+    responses_api = getattr(client, "responses", None)
+    if responses_api and hasattr(responses_api, "generate"):
+        func = getattr(responses_api, "generate")
+        return _call_with_optional_safety(
+            func,
+            model=model,
+            config=config,
+            safety_settings=safety_settings,
+            payload_key="input",
+            payload=contents,
+        )
+    raise AttributeError("Gemini クライアントが対応する generate メソッドを提供していません")
+
+
+def _extract_usage(response: Any, prompt: str, output_text: str) -> tuple[int, int]:
+    prompt_tokens = 0
+    output_tokens = 0
+    usage = getattr(response, "usage_metadata", None)
+    if usage is not None:
+        prompt_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    else:
+        payload = None
+        if hasattr(response, "to_dict"):
+            try:
+                payload = response.to_dict()
+            except Exception:  # pragma: no cover - defensive
+                payload = None
+        if isinstance(payload, Mapping):
+            usage_dict = payload.get("usage_metadata")
+            if isinstance(usage_dict, Mapping):
+                prompt_tokens = int(usage_dict.get("input_tokens", 0) or 0)
+                output_tokens = int(usage_dict.get("output_tokens", 0) or 0)
+    if prompt_tokens <= 0:
+        prompt_tokens = max(1, len(prompt.split()))
+    if output_tokens <= 0:
+        tokens = len(output_text.split())
+        output_tokens = max(1, tokens) if tokens else 0
+    return prompt_tokens, output_tokens
+
+
+def _extract_output_text(response: Any) -> str:
+    text = getattr(response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    text = getattr(response, "output_text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    candidates = getattr(response, "candidates", None)
+    if isinstance(candidates, Sequence):
+        for candidate in candidates:
+            if isinstance(candidate, Mapping):
+                candidate_text = candidate.get("text")
+                if isinstance(candidate_text, str) and candidate_text.strip():
+                    return candidate_text
+            text_attr = getattr(candidate, "text", None)
+            if isinstance(text_attr, str) and text_attr.strip():
+                return text_attr
+    if hasattr(response, "to_dict"):
+        try:
+            payload = response.to_dict()
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        if isinstance(payload, Mapping):
+            for key in ("text", "output_text"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value
+    return ""
+
+
+def _coerce_raw_output(response: Any) -> Mapping[str, Any] | None:
+    if hasattr(response, "to_dict"):
+        try:
+            payload = response.to_dict()
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        else:
+            if isinstance(payload, Mapping):
+                return dict(payload)
+    if isinstance(response, Mapping):
+        return dict(response)
+    return {"repr": repr(response)}
+
+
+class GeminiProvider(BaseProvider):
+    """Google Gemini (Generative AI) 向けプロバイダ。"""
+
+    def __init__(self, config):
+        super().__init__(config)
+        if _genai is None:  # pragma: no cover - SDK 未導入時
+            raise ImportError("google-genai がインストールされていません")
+        api_key = _resolve_api_key(config.auth_env)
+        self._client = _genai.Client(api_key=api_key)  # type: ignore[call-arg]
+        self._model = config.model
+        base_config = _prepare_generation_config(config)
+        self._generation_config: Mapping[str, Any] | None = dict(base_config) if base_config else None
+        safety_settings = _prepare_safety_settings(config)
+        self._safety_settings: Sequence[Mapping[str, Any]] | None = (
+            list(safety_settings) if safety_settings else None
+        )
+
+    def generate(self, prompt: str) -> ProviderResponse:
+        contents = [{"role": "user", "parts": [{"text": prompt}]}]
+        ts0 = time.time()
+        response = _invoke_gemini(
+            self._client,
+            self._model,
+            contents,
+            self._generation_config,
+            self._safety_settings,
+        )
+        latency_ms = int((time.time() - ts0) * 1000)
+        output_text = _extract_output_text(response)
+        prompt_tokens, output_tokens = _extract_usage(response, prompt, output_text)
+        raw_output = _coerce_raw_output(response)
+        return ProviderResponse(
+            output_text=output_text,
+            input_tokens=prompt_tokens,
+            output_tokens=output_tokens,
+            latency_ms=latency_ms,
+            raw_output=dict(raw_output) if isinstance(raw_output, Mapping) else None,
+        )

--- a/projects/04-llm-adapter/adapter/core/providers/openai.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai.py
@@ -1,0 +1,366 @@
+"""OpenAI プロバイダ実装。"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from ..config import ProviderConfig
+from . import BaseProvider, ProviderResponse
+
+__all__ = ["OpenAIProvider"]
+
+try:  # pragma: no cover - OpenAI SDK が存在しない環境では読み込まれない
+    import openai as _openai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - 依存が無い環境ではプロバイダを登録しない
+    _openai = None  # type: ignore[assignment]
+
+
+def _resolve_api_key(env_name: str | None) -> str:
+    if not env_name:
+        raise RuntimeError(
+            "OpenAI プロバイダを利用するには auth_env に API キーの環境変数を指定してください"
+        )
+    value = os.getenv(env_name)
+    if not value:
+        raise RuntimeError(f"OpenAI API キーが環境変数 '{env_name}' に見つかりません")
+    return value
+
+
+def _coerce_mapping(value: Any) -> MutableMapping[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _prepare_common_kwargs(config: ProviderConfig) -> MutableMapping[str, Any]:
+    kwargs: MutableMapping[str, Any] = {}
+    if config.temperature:
+        kwargs["temperature"] = float(config.temperature)
+    if config.top_p and config.top_p < 1.0:
+        kwargs["top_p"] = float(config.top_p)
+    extra = config.raw.get("request_kwargs")
+    kwargs.update(_coerce_mapping(extra))
+    return kwargs
+
+
+def _build_system_user_contents(system_prompt: str | None, user_prompt: str) -> list[Mapping[str, Any]]:
+    contents: list[Mapping[str, Any]] = []
+    if system_prompt:
+        contents.append(
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": system_prompt}],
+            }
+        )
+    contents.append({"role": "user", "content": [{"type": "text", "text": user_prompt}]})
+    return contents
+
+
+def _build_chat_messages(system_prompt: str | None, user_prompt: str) -> list[Mapping[str, Any]]:
+    messages: list[Mapping[str, Any]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_prompt})
+    return messages
+
+
+def _extract_text_from_response(response: Any) -> str:
+    text = getattr(response, "output_text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    text = getattr(response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    choices = getattr(response, "choices", None)
+    if isinstance(choices, Sequence) and choices:
+        first = choices[0]
+        if isinstance(first, Mapping):
+            message = first.get("message")
+            if isinstance(message, Mapping):
+                content = message.get("content")
+                if isinstance(content, str) and content.strip():
+                    return content
+                if isinstance(content, Sequence):
+                    parts: list[str] = []
+                    for item in content:
+                        if isinstance(item, Mapping):
+                            text_part = item.get("text")
+                            if isinstance(text_part, str):
+                                parts.append(text_part)
+                    if parts:
+                        return "".join(parts)
+            text_value = first.get("text")
+            if isinstance(text_value, str) and text_value.strip():
+                return text_value
+        message_attr = getattr(first, "message", None)
+        if isinstance(message_attr, Mapping):
+            content_attr = message_attr.get("content")
+            if isinstance(content_attr, str) and content_attr.strip():
+                return content_attr
+        text_attr = getattr(first, "text", None)
+        if isinstance(text_attr, str) and text_attr.strip():
+            return text_attr
+    output = getattr(response, "output", None)
+    if isinstance(output, Sequence):
+        parts: list[str] = []
+        for item in output:
+            if isinstance(item, Mapping):
+                content = item.get("content")
+                if isinstance(content, Sequence):
+                    for fragment in content:
+                        if isinstance(fragment, Mapping):
+                            text_part = fragment.get("text")
+                            if isinstance(text_part, str):
+                                parts.append(text_part)
+                elif isinstance(content, str):
+                    parts.append(content)
+        if parts:
+            return "".join(parts)
+    if hasattr(response, "model_dump"):
+        try:
+            dumped = response.model_dump()
+        except Exception:  # pragma: no cover - defensive
+            dumped = None
+        if isinstance(dumped, Mapping):
+            for key in ("output_text", "text"):
+                value = dumped.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value
+            choices = dumped.get("choices")
+            if isinstance(choices, Sequence) and choices:
+                first = choices[0]
+                if isinstance(first, Mapping):
+                    for path in (("message", "content"), ("text",)):
+                        cursor: Any = first
+                        for segment in path:
+                            if isinstance(cursor, Mapping):
+                                cursor = cursor.get(segment)
+                            else:
+                                cursor = None
+                                break
+                        if isinstance(cursor, str) and cursor.strip():
+                            return cursor
+    return ""
+
+
+def _extract_usage_tokens(response: Any, prompt: str, output_text: str) -> tuple[int, int]:
+    prompt_tokens = 0
+    completion_tokens = 0
+    usage = getattr(response, "usage", None)
+    if usage is not None:
+        prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+        if prompt_tokens <= 0:
+            prompt_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+        completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+        if completion_tokens <= 0:
+            completion_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    if prompt_tokens <= 0 or completion_tokens <= 0:
+        if isinstance(usage, Mapping):
+            prompt_tokens = int(usage.get("prompt_tokens", usage.get("input_tokens", 0)) or prompt_tokens)
+            completion_tokens = int(
+                usage.get("completion_tokens", usage.get("output_tokens", 0)) or completion_tokens
+            )
+    if prompt_tokens <= 0 or completion_tokens <= 0:
+        if hasattr(response, "model_dump"):
+            try:
+                payload = response.model_dump()
+            except Exception:  # pragma: no cover - defensive
+                payload = None
+            if isinstance(payload, Mapping):
+                usage_dict = payload.get("usage")
+                if isinstance(usage_dict, Mapping):
+                    prompt_tokens = int(
+                        usage_dict.get("prompt_tokens", usage_dict.get("input_tokens", prompt_tokens)) or prompt_tokens
+                    )
+                    completion_tokens = int(
+                        usage_dict.get("completion_tokens", usage_dict.get("output_tokens", completion_tokens))
+                        or completion_tokens
+                    )
+    if prompt_tokens <= 0:
+        prompt_tokens = max(1, len(prompt.split()))
+    if completion_tokens <= 0:
+        tokens = len(output_text.split())
+        completion_tokens = max(1, tokens) if tokens else 0
+    return prompt_tokens, completion_tokens
+
+
+def _coerce_raw_output(response: Any) -> Mapping[str, Any] | None:
+    if hasattr(response, "model_dump"):
+        try:
+            payload = response.model_dump()
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        else:
+            if isinstance(payload, Mapping):
+                return dict(payload)
+    if hasattr(response, "to_dict"):
+        try:
+            payload = response.to_dict()
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        else:
+            if isinstance(payload, Mapping):
+                return dict(payload)
+    if isinstance(response, Mapping):
+        return dict(response)
+    return {"repr": repr(response)}
+
+
+class OpenAIProvider(BaseProvider):
+    """OpenAI API を利用したプロバイダ実装。"""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        super().__init__(config)
+        if _openai is None:  # pragma: no cover - 依存未導入
+            raise ImportError("openai パッケージがインストールされていません")
+        api_key = _resolve_api_key(config.auth_env)
+        self._model = config.model
+        self._system_prompt = config.raw.get("system_prompt") if isinstance(config.raw.get("system_prompt"), str) else None
+        self._preferred_modes: tuple[str, ...] = self._determine_modes(config)
+        base_kwargs = _prepare_common_kwargs(config)
+        self._request_kwargs = dict(base_kwargs)
+        response_format = config.raw.get("response_format")
+        self._response_format = dict(response_format) if isinstance(response_format, Mapping) else None
+        self._client = self._create_client(api_key, config)
+
+    def _determine_modes(self, config: ProviderConfig) -> tuple[str, ...]:
+        preferred = config.raw.get("api")
+        modes: list[str] = []
+        if isinstance(preferred, str) and preferred.strip():
+            modes.append(preferred.strip().lower())
+        modes.extend(["responses", "chat_completions", "completions"])
+        # 順序は維持しつつ重複を排除
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for mode in modes:
+            if mode not in {"responses", "chat_completions", "completions"}:
+                continue
+            if mode in seen:
+                continue
+            seen.add(mode)
+            ordered.append(mode)
+        return tuple(ordered)
+
+    def _create_client(self, api_key: str, config: ProviderConfig) -> Any:
+        endpoint = config.endpoint
+        organization = config.raw.get("organization") if isinstance(config.raw.get("organization"), str) else None
+        default_headers = _coerce_mapping(config.raw.get("default_headers"))
+        if hasattr(_openai, "OpenAI"):
+            kwargs: dict[str, Any] = {"api_key": api_key}
+            if endpoint:
+                kwargs["base_url"] = endpoint
+            if organization:
+                kwargs["organization"] = organization
+            if default_headers:
+                kwargs["default_headers"] = dict(default_headers)
+            return _openai.OpenAI(**kwargs)
+        # v0 系 SDK 互換
+        _openai.api_key = api_key  # type: ignore[attr-defined]
+        if endpoint:
+            setattr(_openai, "base_url", endpoint)
+        if organization:
+            setattr(_openai, "organization", organization)
+        for key, value in default_headers.items():
+            # API v0 では default_headers が無いため、ベースとなるヘッダ辞書を用意
+            headers = getattr(_openai, "_default_headers", {})
+            headers[key] = value
+            setattr(_openai, "_default_headers", headers)
+        return _openai
+
+    def generate(self, prompt: str) -> ProviderResponse:
+        last_error: Exception | None = None
+        for mode in self._preferred_modes:
+            try:
+                response = self._invoke_mode(mode, prompt)
+                if response is None:
+                    continue
+                break
+            except Exception as exc:  # pragma: no cover - 実行時エラーを保持して次のモードへ
+                last_error = exc
+        else:
+            if last_error:
+                raise last_error
+            raise RuntimeError("OpenAI API 呼び出しに使用可能なモードが見つかりませんでした")
+        # response 取得後に計測しても間に合わないので invoke 内で測定する
+        # 上記ループでは response は (結果, latency_ms) のタプルを想定
+        result_obj, latency_ms = response
+        output_text = _extract_text_from_response(result_obj)
+        prompt_tokens, completion_tokens = _extract_usage_tokens(result_obj, prompt, output_text)
+        raw_output = _coerce_raw_output(result_obj)
+        return ProviderResponse(
+            output_text=output_text,
+            input_tokens=prompt_tokens,
+            output_tokens=completion_tokens,
+            latency_ms=latency_ms,
+            raw_output=dict(raw_output) if isinstance(raw_output, Mapping) else None,
+        )
+
+    def _invoke_mode(self, mode: str, prompt: str) -> tuple[Any, int] | None:
+        if mode == "responses":
+            return self._call_responses(prompt)
+        if mode == "chat_completions":
+            return self._call_chat_completions(prompt)
+        if mode == "completions":
+            return self._call_completions(prompt)
+        return None
+
+    def _call_responses(self, prompt: str) -> tuple[Any, int] | None:
+        responses_api = getattr(self._client, "responses", None)
+        create = getattr(responses_api, "create", None)
+        if not callable(create):
+            return None
+        kwargs = dict(self._request_kwargs)
+        if self.config.max_tokens:
+            kwargs.setdefault("max_output_tokens", int(self.config.max_tokens))
+        if self._response_format:
+            kwargs.setdefault("response_format", dict(self._response_format))
+        contents = _build_system_user_contents(self._system_prompt, prompt)
+        ts0 = time.time()
+        result = create(model=self._model, input=contents, **kwargs)
+        latency_ms = int((time.time() - ts0) * 1000)
+        return result, latency_ms
+
+    def _call_chat_completions(self, prompt: str) -> tuple[Any, int] | None:
+        chat_api = getattr(getattr(self._client, "chat", None), "completions", None)
+        create = getattr(chat_api, "create", None)
+        if not callable(create):
+            # v0 互換
+            create = getattr(self._client, "ChatCompletion", None)
+            if create and hasattr(create, "create"):
+                create = getattr(create, "create")
+        if not callable(create):
+            return None
+        kwargs = dict(self._request_kwargs)
+        if self.config.max_tokens:
+            kwargs.setdefault("max_tokens", int(self.config.max_tokens))
+        if self._response_format and "response_format" not in kwargs:
+            kwargs["response_format"] = dict(self._response_format)
+        messages = _build_chat_messages(self._system_prompt, prompt)
+        ts0 = time.time()
+        result = create(model=self._model, messages=messages, **kwargs)
+        latency_ms = int((time.time() - ts0) * 1000)
+        return result, latency_ms
+
+    def _call_completions(self, prompt: str) -> tuple[Any, int] | None:
+        # v0 系の text-davinci シリーズ向けエンドポイント
+        create = getattr(self._client, "Completion", None)
+        if create and hasattr(create, "create"):
+            create = getattr(create, "create")
+        if not callable(create):
+            completions_api = getattr(self._client, "completions", None)
+            create = getattr(completions_api, "create", None)
+        if not callable(create):
+            return None
+        kwargs = dict(self._request_kwargs)
+        if self.config.max_tokens:
+            kwargs.setdefault("max_tokens", int(self.config.max_tokens))
+        prompt_text = prompt
+        if self._system_prompt:
+            prompt_text = f"{self._system_prompt}\n\n{prompt}" if prompt else self._system_prompt
+        ts0 = time.time()
+        result = create(model=self._model, prompt=prompt_text, **kwargs)
+        latency_ms = int((time.time() - ts0) * 1000)
+        return result, latency_ms
+

--- a/projects/04-llm-adapter/requirements.txt
+++ b/projects/04-llm-adapter/requirements.txt
@@ -1,1 +1,3 @@
 PyYAML>=6.0
+google-genai>=0.3.0
+openai>=1.14.0


### PR DESCRIPTION
## Summary
- implement an OpenAI provider with multi-endpoint fallbacks, shared request assembly, and robust response/usage parsing
- register the provider, ship a sample openai.yaml configuration, and document OpenAI usage alongside dependency updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4debce2d4832180e97e956200a433