### PR TITLE
Add thread-safe logging to metrics module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from threading import Lock
 from typing import Any, Union
 
 PathLike = Union[str, "Path"]
+
+
+_LOG_LOCK = Lock()
 
 
 def _ensure_dir(path: Path) -> None:
@@ -31,5 +35,6 @@ def log_event(event_type: str, path: PathLike, **fields: Any) -> None:
     record = {"ts": int(time.time() * 1000), "event": event_type}
     record.update(fields)
 
-    with target.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    with _LOG_LOCK:
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -1,0 +1,39 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from src.llm_adapter.metrics import log_event
+
+
+@pytest.mark.parametrize("thread_count,event_per_thread", [(8, 200)])
+def test_log_event_threadsafe(tmp_path: Path, thread_count: int, event_per_thread: int) -> None:
+    target = tmp_path / "events.jsonl"
+    start_barrier = threading.Barrier(thread_count)
+
+    def worker(thread_id: int) -> None:
+        start_barrier.wait()
+        for i in range(event_per_thread):
+            log_event(
+                "test",
+                target,
+                thread=thread_id,
+                index=i,
+            )
+
+    threads = [threading.Thread(target=worker, args=(idx,)) for idx in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected_records = thread_count * event_per_thread
+    lines = target.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == expected_records
+
+    for line in lines:
+        record = json.loads(line)
+        assert record["event"] == "test"
+        assert "thread" in record
+        assert "index" in record


### PR DESCRIPTION
## Summary
- guard metrics file writes with a module-level lock to avoid interleaving records
- add a concurrency test that stresses log_event from multiple threads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d601e2b5d48321a74ee4d20e1dbd4c