### PR TITLE
Ensure Ollama responses close on HTTP errors

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -242,20 +242,20 @@ class OllamaProvider(ProviderSPI):
         ts0 = time.time()
         response = self._request("/api/chat", payload)
         try:
-            response.raise_for_status()
-        except requests_exceptions.HTTPError as exc:
-            status = response.status_code
-            if status in {401, 403}:
-                raise AuthError(str(exc)) from exc
-            if status == 429:
-                raise RateLimitError(str(exc)) from exc
-            if status == 408:
-                raise TimeoutError(str(exc)) from exc
-            if status >= 500:
+            try:
+                response.raise_for_status()
+            except requests_exceptions.HTTPError as exc:
+                status = response.status_code
+                if status in {401, 403}:
+                    raise AuthError(str(exc)) from exc
+                if status == 429:
+                    raise RateLimitError(str(exc)) from exc
+                if status == 408:
+                    raise TimeoutError(str(exc)) from exc
+                if status >= 500:
+                    raise RetriableError(str(exc)) from exc
                 raise RetriableError(str(exc)) from exc
-            raise RetriableError(str(exc)) from exc
 
-        try:
             payload_json = response.json()
         except ValueError as exc:
             raise RetriableError("invalid JSON from Ollama") from exc


### PR DESCRIPTION
## Summary
- ensure `OllamaProvider.invoke` closes HTTP responses even when `raise_for_status` fails
- extend the Ollama auth error test to confirm the response handle is closed on HTTP errors

## Testing
- pytest tests/test_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d62615fb448321b512eabd8f5f44c2