### PR TITLE
Handle timeout-like exceptions in Gemini provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -320,6 +320,21 @@ class GeminiProvider(ProviderSPI):
         if isinstance(exc, ConfigError):
             return exc
 
+        def _has_timeout_marker(value: Any) -> bool:
+            return isinstance(value, str) and "timeout" in value.lower()
+
+        exc_type = type(exc)
+        class_names = [
+            getattr(exc_type, "__qualname__", ""),
+            getattr(exc_type, "__name__", ""),
+        ]
+        module_names = [
+            getattr(exc_type, "__module__", ""),
+            getattr(exc, "__module__", ""),
+        ]
+        if any(_has_timeout_marker(name) for name in class_names + module_names):
+            return TimeoutError(str(exc))
+
         def _normalize_status(value: Any) -> str:
             if not value:
                 return ""

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -258,6 +258,24 @@ def test_gemini_provider_translates_timeout_status_object():
         provider.invoke(ProviderRequest(prompt="hello"))
 
 
+def test_gemini_provider_translates_named_timeout_exception():
+    class Timeout(Exception):
+        """Exception with a Timeout name similar to requests.exceptions.Timeout."""
+
+    class _FailingModels:
+        def generate_content(self, **kwargs):
+            raise Timeout("network timeout")
+
+    class _Client:
+        def __init__(self):
+            self.models = _FailingModels()
+
+    provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
+
+    with pytest.raises(TimeoutError):
+        provider.invoke(ProviderRequest(prompt="hello"))
+
+
 @pytest.mark.parametrize(
     "status_code, expected",
     [


### PR DESCRIPTION
## Summary
- map exceptions whose class or module names contain "Timeout" to `TimeoutError` within the Gemini provider
- add a regression test exercising the translation when the Gemini client raises a Timeout-named exception

## Testing
- pytest tests/test_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d649dec0e08321a2363269ddbfd3aa