### PR TITLE
Handle Gemini 504 HTTP status as timeout

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -386,7 +386,7 @@ class GeminiProvider(ProviderSPI):
             return AuthError(message)
         if status_text in {"RESOURCE_EXHAUSTED", "QUOTA_EXCEEDED"} or http_status == 429:
             return RateLimitError(message)
-        if status_text in {"DEADLINE_EXCEEDED", "GATEWAY_TIMEOUT"} or http_status == 408:
+        if status_text in {"DEADLINE_EXCEEDED", "GATEWAY_TIMEOUT"} or http_status in {408, 504}:
             return TimeoutError(message)
 
         return RetriableError(message)

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -328,6 +328,7 @@ def test_gemini_provider_translates_named_timeout_exception():
         (401, AuthError),
         (403, AuthError),
         (408, TimeoutError),
+        (504, TimeoutError),
     ],
 )
 def test_gemini_provider_translates_http_errors(status_code: int, expected: type[Exception]):


### PR DESCRIPTION
## Summary
- treat HTTP 504 responses from the Gemini provider as timeout errors
- add regression coverage for translating 504 status codes to TimeoutError

## Testing
- pytest tests/test_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d65c80ddb483218bae8a75759661a5