### PR TITLE
Handle existing adapter errors in Gemini provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -33,6 +33,7 @@ if gt is None:  # pragma: no cover - stub for unit tests without the SDK
     gt = cast(Any, _TypesModule())
 
 from ..errors import (
+    AdapterError,
     AuthError,
     ConfigError,
     ProviderSkip,
@@ -318,6 +319,9 @@ class GeminiProvider(ProviderSPI):
 
     def _translate_error(self, exc: Exception) -> Exception:
         if isinstance(exc, ConfigError):
+            return exc
+
+        if isinstance(exc, AdapterError) and not isinstance(exc, ProviderSkip):
             return exc
 
         def _has_timeout_marker(value: Any) -> bool:

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -234,6 +234,25 @@ def test_gemini_provider_translates_rate_limit_status_object():
         provider.invoke(ProviderRequest(prompt="hello"))
 
 
+def test_gemini_provider_preserves_rate_limit_error_instances():
+    raised_error = RateLimitError("rate limited")
+
+    class _FailingModels:
+        def generate_content(self, **kwargs):
+            raise raised_error
+
+    class _Client:
+        def __init__(self):
+            self.models = _FailingModels()
+
+    provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
+
+    with pytest.raises(RateLimitError) as excinfo:
+        provider.invoke(ProviderRequest(prompt="hello"))
+
+    assert excinfo.value is raised_error
+
+
 def test_gemini_provider_translates_timeout_status_object():
     class _StatusCode:
         def __init__(self, name: str):
@@ -256,6 +275,25 @@ def test_gemini_provider_translates_timeout_status_object():
 
     with pytest.raises(TimeoutError):
         provider.invoke(ProviderRequest(prompt="hello"))
+
+
+def test_gemini_provider_preserves_timeout_error_instances():
+    raised_error = TimeoutError("took too long")
+
+    class _FailingModels:
+        def generate_content(self, **kwargs):
+            raise raised_error
+
+    class _Client:
+        def __init__(self):
+            self.models = _FailingModels()
+
+    provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
+
+    with pytest.raises(TimeoutError) as excinfo:
+        provider.invoke(ProviderRequest(prompt="hello"))
+
+    assert excinfo.value is raised_error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- ensure Gemini error translation returns existing adapter errors without wrapping, while still allowing ProviderSkip to bubble for control flow
- add unit tests confirming direct RateLimitError and TimeoutError from the client remain unchanged

## Testing
- pytest tests/test_providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d66afecbfc8321944e64d7084f8aa1