### PR TITLE
Update Ollama provider environment variable handling

### DIFF
--- a/projects/04-llm-adapter-shadow/.env.example
+++ b/projects/04-llm-adapter-shadow/.env.example
@@ -6,4 +6,4 @@ PRIMARY_PROVIDER=gemini:gemini-2.5-flash
 SHADOW_PROVIDER=ollama:gemma3n:e2b
 
 # Ollama endpoint (defaults to http://127.0.0.1:11434 if unset)
-OLLAMA_HOST=http://127.0.0.1:11434
+OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -105,7 +105,7 @@ projects/04-llm-adapter-shadow/
 
 - `PRIMARY_PROVIDER` — 形式は `"<prefix>:<model-id>"`。デフォルトは `gemini:gemini-2.5-flash`。
 - `SHADOW_PROVIDER` — 影実行用。デフォルトは `ollama:gemma3n:e2b`。`none` や空文字で無効化できます。
-- `OLLAMA_HOST` — Ollama API のベースURL（未指定時は `http://127.0.0.1:11434`）。
+- `OLLAMA_BASE_URL` — Ollama API のベースURL（未指定時は `http://127.0.0.1:11434`。旧名の `OLLAMA_HOST` もフォールバックとして解釈されます）。
 - `GOOGLE_API_KEY` — Gemini SDK が参照するAPIキー。未設定の場合、Gemini プロバイダは安全にスキップされます。
 
 プロバイダ文字列は最初のコロンのみを区切り文字として扱うため、`ollama:gemma3n:e2b` のようにモデルIDにコロンを含めても問題ありません。`mock:foo` を指定するとモックプロバイダで簡易動作確認が可能です。
@@ -116,7 +116,7 @@ projects/04-llm-adapter-shadow/
 export PRIMARY_PROVIDER="gemini:gemini-2.5-flash"
 export SHADOW_PROVIDER="ollama:gemma3n:e2b"
 export GOOGLE_API_KEY="<YOUR_GEMINI_KEY>"
-export OLLAMA_HOST="http://127.0.0.1:11434"
+export OLLAMA_BASE_URL="http://127.0.0.1:11434"
 ```
 
 ルート直下の `.env.example` をコピーして `.env` を作成すると、上記の雛形をそのまま利用できます。
@@ -125,7 +125,7 @@ Gemini の構造化出力を利用したい場合は、`generation_config` に
 `{"response_mime_type": "application/json"}` や
 `{"response_schema": {...}}` を指定すると JSON 固定のレスポンスを要求できます。
 `demo_shadow.py` の `request_options` を編集するか、環境変数で
-`PRIMARY_OPTIONS` を与えて `ProviderRequest.options` に受け渡してください。
+`PRIMARY_OPTIONS` を与えて `ProviderRequest.options` に受け渡してください。Ollama 向けには `REQUEST_TIMEOUT_S`（または小文字の `request_timeout_s`）を指定するとリクエスト単位のタイムアウトを秒数で上書きできます。
 
 ### Run the tests
 

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -109,6 +109,32 @@ class _FakeSession:
         raise NotImplementedError
 
 
+def test_ollama_provider_prefers_base_url_over_legacy(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://env-base")
+    monkeypatch.setenv("OLLAMA_HOST", "http://legacy-host")
+
+    provider = OllamaProvider(
+        "test-model",
+        session=_FakeSession(),
+        auto_pull=False,
+    )
+
+    assert provider._host == "http://env-base"
+
+
+def test_ollama_provider_legacy_host_fallback(monkeypatch):
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.setenv("OLLAMA_HOST", "http://legacy-host")
+
+    provider = OllamaProvider(
+        "test-model",
+        session=_FakeSession(),
+        auto_pull=False,
+    )
+
+    assert provider._host == "http://legacy-host"
+
+
 class _RecordClient:
     def __init__(self):
         self.calls = []
@@ -394,9 +420,14 @@ def test_ollama_provider_auto_pull_and_chat():
         def __init__(self):
             super().__init__()
             self._chat_called = False
+            self.last_timeout = None
+            self.last_payload: dict | None = None
 
         def post(self, url, json=None, stream=False, timeout=None):
             self.calls.append((url, json, stream))
+            if url.endswith("/api/chat"):
+                self.last_timeout = timeout
+                self.last_payload = json
             if url.endswith("/api/show"):
                 self._show_calls += 1
                 if self._show_calls == 1:
@@ -426,6 +457,10 @@ def test_ollama_provider_auto_pull_and_chat():
     assert response.token_usage.completion == 5
     assert response.latency_ms >= 0
     assert session._chat_called
+    assert session.last_timeout == provider._timeout
+    assert session.last_payload is not None
+    assert "REQUEST_TIMEOUT_S" not in session.last_payload
+    assert "request_timeout_s" not in session.last_payload
 
     show_calls = [url for url, *_ in session.calls if url.endswith("/api/show")]
     assert len(show_calls) == 2  # first miss + verification after pull
@@ -469,6 +504,43 @@ def test_ollama_provider_auto_pull_error_mapping(status_code: int, expected: typ
 
     assert session.pull_response is not None
     assert session.pull_response.closed
+
+
+def test_ollama_provider_request_timeout_override():
+    class Session(_FakeSession):
+        def __init__(self):
+            super().__init__()
+            self.last_timeout = None
+            self.last_payload: dict | None = None
+
+        def post(self, url, json=None, stream=False, timeout=None):
+            if url.endswith("/api/show"):
+                return _FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                self.last_timeout = timeout
+                self.last_payload = json
+                return _FakeResponse(
+                    status_code=200,
+                    payload={"message": {"content": "ok"}},
+                )
+            raise AssertionError(f"unexpected url: {url}")
+
+    session = Session()
+    provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
+
+    response = provider.invoke(
+        ProviderRequest(
+            prompt="hello",
+            options={"REQUEST_TIMEOUT_S": "2.5", "extra": True},
+        )
+    )
+
+    assert response.text == "ok"
+    assert session.last_timeout == pytest.approx(2.5)
+    assert session.last_payload is not None
+    assert "REQUEST_TIMEOUT_S" not in session.last_payload
+    assert "request_timeout_s" not in session.last_payload
+    assert session.last_payload.get("extra") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- read the Ollama base URL from the new OLLAMA_BASE_URL environment variable while keeping OLLAMA_HOST as a fallback
- document the new environment variable and example values in the README and .env template
- allow request-level timeout overrides via the REQUEST_TIMEOUT_S option and cover the behaviour with unit tests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_providers.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6a15ebc688321afa75ff11360ee04