### PR TITLE
Add provider_call metrics logging for runner attempts

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -9,6 +9,7 @@ class ProviderRequest:
     prompt: str
     max_tokens: int = 256
     options: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
 
 
 @dataclass

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -48,23 +48,6 @@ class Runner:
             "runner", request.prompt, request.options, request.max_tokens
         )
 
-        def _record_error(err: Exception, attempt: int, provider: ProviderSPI) -> None:
-            if not metrics_path_str:
-                return
-            log_event(
-                "provider_error",
-                metrics_path_str,
-                request_fingerprint=request_fingerprint,
-                request_hash=content_hash(
-                    provider.name(), request.prompt, request.options, request.max_tokens
-                ),
-                provider=provider.name(),
-                attempt=attempt,
-                total_providers=len(self.providers),
-                error_type=type(err).__name__,
-                error_message=str(err),
-            )
-
         def _record_skip(err: ProviderSkip, attempt: int, provider: ProviderSPI) -> None:
             if not metrics_path_str:
                 return
@@ -82,39 +65,106 @@ class Runner:
                 error_message=str(err),
             )
 
+        def _provider_model(provider: ProviderSPI) -> str | None:
+            for attr in ("model", "_model"):
+                value = getattr(provider, attr, None)
+                if isinstance(value, str) and value:
+                    return value
+            return None
+
+        def _elapsed_ms(start_ts: float) -> int:
+            return max(0, int((time.time() - start_ts) * 1000))
+
+        def _log_provider_call(
+            provider: ProviderSPI,
+            attempt: int,
+            *,
+            status: str,
+            latency_ms: int | None,
+            tokens_in: int | None,
+            tokens_out: int | None,
+            error: Exception | None = None,
+        ) -> None:
+            if not metrics_path_str:
+                return
+
+            metadata = request.metadata or {}
+            error_type = type(error).__name__ if error is not None else None
+            error_message = str(error) if error is not None else None
+
+            log_event(
+                "provider_call",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                request_hash=content_hash(
+                    provider.name(), request.prompt, request.options, request.max_tokens
+                ),
+                provider=provider.name(),
+                model=_provider_model(provider),
+                attempt=attempt,
+                total_providers=len(self.providers),
+                status=status,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                error_type=error_type,
+                error_message=error_message,
+                shadow_used=shadow is not None,
+                trace_id=metadata.get("trace_id"),
+                project_id=metadata.get("project_id"),
+            )
+
         for attempt_index, provider in enumerate(self.providers, start=1):
+            attempt_started = time.time()
             try:
                 response = run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
             except ProviderSkip as err:
                 last_err = err
                 _record_skip(err, attempt_index, provider)
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
                 continue
             except RateLimitError as err:
                 last_err = err
-                _record_error(err, attempt_index, provider)
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
                 time.sleep(0.05)
             except (TimeoutError, RetriableError) as err:
                 last_err = err
-                _record_error(err, attempt_index, provider)
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
                 continue
             else:
-                if metrics_path_str:
-                    log_event(
-                        "provider_success",
-                        metrics_path_str,
-                        request_fingerprint=request_fingerprint,
-                        request_hash=content_hash(
-                            provider.name(),
-                            request.prompt,
-                            request.options,
-                            request.max_tokens,
-                        ),
-                        provider=provider.name(),
-                        attempt=attempt_index,
-                        total_providers=len(self.providers),
-                        latency_ms=response.latency_ms,
-                        shadow_used=shadow is not None,
-                    )
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="ok",
+                    latency_ms=response.latency_ms,
+                    tokens_in=response.input_tokens,
+                    tokens_out=response.output_tokens,
+                    error=None,
+                )
                 return response
         if metrics_path_str:
             log_event(

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -11,8 +11,9 @@ def test_shadow_exec_records_metrics(tmp_path):
     runner = Runner([primary])
 
     metrics_path = tmp_path / "metrics.jsonl"
+    metadata = {"trace_id": "trace-123", "project_id": "proj-789"}
     response = runner.run(
-        ProviderRequest(prompt="hello"),
+        ProviderRequest(prompt="hello", metadata=metadata),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -22,7 +23,7 @@ def test_shadow_exec_records_metrics(tmp_path):
 
     payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
     diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
-    success_event = next(item for item in payloads if item["event"] == "provider_success")
+    call_event = next(item for item in payloads if item["event"] == "provider_call")
 
     assert diff_event["primary_provider"] == "primary"
     assert diff_event["shadow_provider"] == "shadow"
@@ -31,10 +32,16 @@ def test_shadow_exec_records_metrics(tmp_path):
     assert diff_event["primary_token_usage_total"] == response.token_usage.total
     assert diff_event["request_fingerprint"]
 
-    assert success_event["provider"] == "primary"
-    assert success_event["attempt"] == 1
-    assert success_event["shadow_used"] is True
-    assert success_event["latency_ms"] == response.latency_ms
+    assert call_event["provider"] == "primary"
+    assert call_event["attempt"] == 1
+    assert call_event["shadow_used"] is True
+    assert call_event["status"] == "ok"
+    assert call_event["latency_ms"] == response.latency_ms
+    assert call_event["tokens_in"] == response.token_usage.prompt
+    assert call_event["tokens_out"] == response.token_usage.completion
+    assert call_event["trace_id"] == metadata["trace_id"]
+    assert call_event["project_id"] == metadata["project_id"]
+    assert call_event.get("model") is None
 
     expected_tokens = max(1, len("hello") // 4) + 16
     assert diff_event["shadow_token_usage_total"] == expected_tokens
@@ -78,7 +85,11 @@ def test_request_hash_includes_max_tokens(tmp_path):
     )
 
     payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
-    success_events = [item for item in payloads if item["event"] == "provider_success"]
+    success_events = [
+        item
+        for item in payloads
+        if item["event"] == "provider_call" and item["status"] == "ok"
+    ]
 
     assert len(success_events) == 2
     request_hashes = {event["request_hash"] for event in success_events}


### PR DESCRIPTION
## Summary
- add optional metadata to `ProviderRequest` for passing trace and project identifiers
- log a single `provider_call` metrics event per provider attempt with latency, tokens, status, and metadata
- refresh metrics-oriented tests to assert on the new event schema

## Testing
- pytest projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68d6a15ff5948321ac799fadee7cd762