### PR TITLE
Update LLM adapter SPI to support chat metadata

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -1,20 +1,105 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Protocol
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+
+def _ensure_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    parts: list[str] = []
+    if isinstance(value, Sequence):
+        for entry in value:
+            if isinstance(entry, str) and entry.strip():
+                parts.append(entry.strip())
+    return parts
+
+
+def _normalize_message(entry: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    role = str(entry.get("role", "user")).strip() or "user"
+    content = entry.get("content")
+    if isinstance(content, str):
+        text = content.strip()
+        if not text:
+            return None
+        return {"role": role, "content": text}
+    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
+        parts = [part.strip() for part in content if isinstance(part, str) and part.strip()]
+        if not parts:
+            return None
+        return {"role": role, "content": parts}
+    if content is None:
+        return None
+    return {"role": role, "content": content}
+
+
+def _extract_prompt_from_messages(messages: Sequence[Mapping[str, Any]]) -> str:
+    for message in reversed(messages):
+        role = str(message.get("role", "")).lower()
+        if role == "assistant":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
+            for part in content:
+                if isinstance(part, str) and part.strip():
+                    return part.strip()
+    return ""
 
 
 @dataclass
 class ProviderRequest:
-    prompt: str
-    max_tokens: int = 256
-    options: dict[str, Any] | None = None
+    prompt: str = ""
+    model: str | None = None
+    messages: Sequence[Mapping[str, Any]] | None = None
+    max_tokens: int | None = 256
+    temperature: float | None = None
+    top_p: float | None = None
+    stop: Sequence[str] | None = None
+    timeout_s: float | None = None
+    metadata: Mapping[str, Any] | None = None
+    options: dict[str, Any] | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        self.prompt = (self.prompt or "").strip()
+
+        normalized_messages: list[Mapping[str, Any]] = []
+        if self.messages:
+            for entry in self.messages:
+                if isinstance(entry, Mapping):
+                    normalized = _normalize_message(entry)
+                    if normalized:
+                        normalized_messages.append(normalized)
+
+        if not normalized_messages and self.prompt:
+            normalized_messages.append({"role": "user", "content": self.prompt})
+
+        self.messages = normalized_messages
+
+        if not self.prompt and normalized_messages:
+            self.prompt = _extract_prompt_from_messages(normalized_messages)
+
+        if self.stop is not None:
+            stop_list = _ensure_list(self.stop)
+            self.stop = tuple(stop_list) if stop_list else None
+
+    @property
+    def chat_messages(self) -> list[Mapping[str, Any]]:
+        return list(self.messages or [])
+
+    @property
+    def prompt_text(self) -> str:
+        return self.prompt
 
 
 @dataclass
 class TokenUsage:
-    prompt: int
-    completion: int
+    prompt: int = 0
+    completion: int = 0
 
     @property
     def total(self) -> int:
@@ -24,8 +109,24 @@ class TokenUsage:
 @dataclass
 class ProviderResponse:
     text: str
-    token_usage: TokenUsage
     latency_ms: int
+    token_usage: TokenUsage | None = None
+    model: str | None = None
+    finish_reason: str | None = None
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    raw: Any | None = None
+
+    def __post_init__(self) -> None:
+        prompt_tokens = int(self.tokens_in or 0)
+        completion_tokens = int(self.tokens_out or 0)
+        if self.token_usage is not None:
+            prompt_tokens = self.token_usage.prompt
+            completion_tokens = self.token_usage.completion
+        else:
+            self.token_usage = TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
+        self.tokens_in = prompt_tokens
+        self.tokens_out = completion_tokens
 
     @property
     def output_text(self) -> str:
@@ -33,11 +134,11 @@ class ProviderResponse:
 
     @property
     def input_tokens(self) -> int:
-        return self.token_usage.prompt
+        return self.tokens_in or 0
 
     @property
     def output_tokens(self) -> int:
-        return self.token_usage.completion
+        return self.tokens_out or 0
 
 
 class ProviderSPI(Protocol):

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -144,6 +144,47 @@ def _coerce_output_text(response: Any) -> str:
     return ""
 
 
+def _coerce_finish_reason(response: Any) -> str | None:
+    def _normalize(value: Any) -> str | None:
+        if value is None:
+            return None
+        if hasattr(value, "name"):
+            candidate = getattr(value, "name")
+            if isinstance(candidate, str):
+                value = candidate
+        if isinstance(value, str):
+            text = value.strip()
+            return text or None
+        return None
+
+    candidates = getattr(response, "candidates", None)
+    first_candidate: Any | None = None
+    if isinstance(candidates, Iterable):
+        for candidate in candidates:
+            first_candidate = candidate
+            break
+
+    if first_candidate is None and hasattr(response, "to_dict"):
+        payload = response.to_dict()
+        if isinstance(payload, Mapping):
+            candidates = payload.get("candidates")
+            if isinstance(candidates, Iterable):
+                for candidate in candidates:
+                    first_candidate = candidate
+                    break
+
+    if first_candidate is None:
+        return None
+
+    if isinstance(first_candidate, Mapping):
+        finish = _normalize(first_candidate.get("finish_reason"))
+        if finish:
+            return finish
+
+    finish_attr = getattr(first_candidate, "finish_reason", None)
+    return _normalize(finish_attr)
+
+
 def parse_gemini_messages(messages: Sequence[Mapping[str, Any]] | None) -> list[Mapping[str, Any]]:
     """Convert chat-style messages into Gemini "Content" entries.
 
@@ -195,6 +236,15 @@ def _merge_generation_config(
 
     if request.max_tokens and "max_output_tokens" not in config:
         config["max_output_tokens"] = int(request.max_tokens)
+
+    if request.temperature is not None and "temperature" not in config:
+        config["temperature"] = float(request.temperature)
+
+    if request.top_p is not None and "top_p" not in config:
+        config["top_p"] = float(request.top_p)
+
+    if request.stop and "stop_sequences" not in config:
+        config["stop_sequences"] = list(request.stop)
 
     return config or None
 
@@ -396,19 +446,32 @@ class GeminiProvider(ProviderSPI):
         return RetriableError(message)
 
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        messages = []
-        if request.options and isinstance(request.options, Mapping):
+        messages = parse_gemini_messages(request.chat_messages)
+
+        if not messages and request.options and isinstance(request.options, Mapping):
             messages = parse_gemini_messages(request.options.get("messages"))
-            system_message = request.options.get("system")
-            if isinstance(system_message, str) and system_message.strip():
-                system_content = system_message.strip()
-                if messages:
-                    messages.insert(0, {"role": "system", "parts": [{"text": system_content}]})
-                else:
-                    messages = [{"role": "system", "parts": [{"text": system_content}]}]
+
+        system_message = None
+        containers: list[Mapping[str, Any]] = []
+        if isinstance(request.metadata, Mapping):
+            containers.append(request.metadata)
+        if request.options and isinstance(request.options, Mapping):
+            containers.append(request.options)
+        for container in containers:
+            candidate = container.get("system")
+            if isinstance(candidate, str) and candidate.strip():
+                system_message = candidate.strip()
+                break
+
+        if system_message:
+            has_system = any(entry.get("role") == "system" for entry in messages)
+            if has_system:
+                messages = [entry for entry in messages if entry.get("role") != "system"]
+            system_entry = {"role": "system", "parts": [{"text": system_message}]}
+            messages.insert(0, system_entry)
 
         if not messages:
-            messages = [{"role": "user", "parts": [{"text": request.prompt}]}]
+            messages = [{"role": "user", "parts": [{"text": request.prompt_text}]}]
 
         config = _merge_generation_config(self._generation_config, request)
         safety_settings = _select_safety_settings(self._safety_settings, request)
@@ -416,7 +479,8 @@ class GeminiProvider(ProviderSPI):
         ts0 = time.time()
         try:
             client = self._resolve_client()
-            response = _invoke_gemini(client, self._model, messages, config, safety_settings)
+            model_name = request.model or self._model
+            response = _invoke_gemini(client, model_name, messages, config, safety_settings)
         except ProviderSkip:
             raise
         except Exception as exc:  # pragma: no cover - translated in unit tests
@@ -426,8 +490,16 @@ class GeminiProvider(ProviderSPI):
         latency_ms = int((time.time() - ts0) * 1000)
         usage = _coerce_usage(response)
         text = _coerce_output_text(response)
+        finish_reason = _coerce_finish_reason(response)
 
-        return ProviderResponse(text=text, token_usage=usage, latency_ms=latency_ms)
+        return ProviderResponse(
+            text=text,
+            token_usage=usage,
+            latency_ms=latency_ms,
+            model=(request.model or self._model),
+            finish_reason=finish_reason,
+            raw=response,
+        )
 
     def _resolve_client(self) -> _GeminiClient:
         if self._client is not None:

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -45,7 +45,7 @@ class Runner:
         last_err: Exception | None = None
         metrics_path_str = None if shadow_metrics_path is None else str(Path(shadow_metrics_path))
         request_fingerprint = content_hash(
-            "runner", request.prompt, request.options, request.max_tokens
+            "runner", request.prompt_text, request.options, request.max_tokens
         )
 
         def _record_error(err: Exception, attempt: int, provider: ProviderSPI) -> None:
@@ -56,7 +56,10 @@ class Runner:
                 metrics_path_str,
                 request_fingerprint=request_fingerprint,
                 request_hash=content_hash(
-                    provider.name(), request.prompt, request.options, request.max_tokens
+                    provider.name(),
+                    request.prompt_text,
+                    request.options,
+                    request.max_tokens,
                 ),
                 provider=provider.name(),
                 attempt=attempt,
@@ -73,7 +76,10 @@ class Runner:
                 metrics_path_str,
                 request_fingerprint=request_fingerprint,
                 request_hash=content_hash(
-                    provider.name(), request.prompt, request.options, request.max_tokens
+                    provider.name(),
+                    request.prompt_text,
+                    request.options,
+                    request.max_tokens,
                 ),
                 provider=provider.name(),
                 attempt=attempt,
@@ -105,7 +111,7 @@ class Runner:
                         request_fingerprint=request_fingerprint,
                         request_hash=content_hash(
                             provider.name(),
-                            request.prompt,
+                            request.prompt_text,
                             request.options,
                             request.max_tokens,
                         ),

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -87,11 +87,11 @@ def run_with_shadow(
         if metrics_path_str:
             primary_text_len = len(primary_res.text)
             request_fingerprint = content_hash(
-                "runner", req.prompt, req.options, req.max_tokens
+                "runner", req.prompt_text, req.options, req.max_tokens
             )
             record: dict[str, Any] = {
                 "request_hash": content_hash(
-                    primary.name(), req.prompt, req.options, req.max_tokens
+                    primary.name(), req.prompt_text, req.options, req.max_tokens
                 ),
                 "request_fingerprint": request_fingerprint,
                 "primary_provider": primary.name(),


### PR DESCRIPTION
## Summary
- expand the provider SPI to normalize chat messages, surface request metadata, and expose detailed token accounting on responses
- update mock, Gemini, and Ollama providers as well as the runner/shadow helpers to populate model/finish metadata and honor new request fields
- refresh the provider test suite to cover prompt-to-message conversion, response bookkeeping, and provider-specific option handling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6a15d8ab883218dbcbe2a861df903