### PR TITLE
docs: rename Gemini API env var

### DIFF
--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -106,7 +106,7 @@ projects/04-llm-adapter-shadow/
 - `PRIMARY_PROVIDER` — 形式は `"<prefix>:<model-id>"`。デフォルトは `gemini:gemini-2.5-flash`。
 - `SHADOW_PROVIDER` — 影実行用。デフォルトは `ollama:gemma3n:e2b`。`none` や空文字で無効化できます。
 - `OLLAMA_BASE_URL` — Ollama API のベースURL（未指定時は `http://127.0.0.1:11434`。旧名の `OLLAMA_HOST` もフォールバックとして解釈されます）。
-- `GOOGLE_API_KEY` — Gemini SDK が参照するAPIキー。未設定の場合、Gemini プロバイダは安全にスキップされます。
+- `GEMINI_API_KEY` — Gemini SDK が参照するAPIキー。未設定の場合、Gemini プロバイダは安全にスキップされます。
 
 
 プロバイダ文字列は最初のコロンのみを区切り文字として扱うため、`ollama:gemma3n:e2b` のようにモデルIDにコロンを含めても問題ありません。`mock:foo` を指定するとモックプロバイダで簡易動作確認が可能です。
@@ -116,7 +116,7 @@ projects/04-llm-adapter-shadow/
 ```bash
 export PRIMARY_PROVIDER="gemini:gemini-2.5-flash"
 export SHADOW_PROVIDER="ollama:gemma3n:e2b"
-export GOOGLE_API_KEY="<YOUR_GEMINI_KEY>"
+export GEMINI_API_KEY="<YOUR_GEMINI_KEY>"
 export OLLAMA_BASE_URL="http://127.0.0.1:11434"
 
 ```

--- a/projects/04-llm-adapter/README.md
+++ b/projects/04-llm-adapter/README.md
@@ -109,10 +109,10 @@ Windows で環境変数を毎回設定する手間を省くため、`--env .env`
 
 ### Google Gemini を利用する
 
-実プロバイダとして Google Gemini を呼び出す場合は、API キーを `GOOGLE_API_KEY` に設定し、Gemini 用の設定ファイルを指定します。
+実プロバイダとして Google Gemini を呼び出す場合は、API キーを `GEMINI_API_KEY` に設定し、Gemini 用の設定ファイルを指定します。
 
 ```bash
-export GOOGLE_API_KEY="<取得したAPIキー>"
+export GEMINI_API_KEY="<取得したAPIキー>"
 python adapter/run_compare.py \
   --providers adapter/config/providers/gemini.yaml \
   --prompts datasets/golden/tasks.jsonl

--- a/projects/04-llm-adapter/adapter/config/providers/gemini.yaml
+++ b/projects/04-llm-adapter/adapter/config/providers/gemini.yaml
@@ -1,7 +1,7 @@
 provider: gemini
 endpoint: null
 model: gemini-1.5-flash
-auth_env: GOOGLE_API_KEY
+auth_env: GEMINI_API_KEY
 seed: 0
 temperature: 0.2
 top_p: 1.0

--- a/projects/04-llm-adapter/examples/providers/gemini.yml
+++ b/projects/04-llm-adapter/examples/providers/gemini.yml
@@ -1,7 +1,7 @@
 # サンプル: Google Gemini API 用プロバイダ設定
 provider: gemini
 model: gemini-1.5-flash
-auth_env: GOOGLE_API_KEY
+auth_env: GEMINI_API_KEY
 seed: 0
 temperature: 0.2
 top_p: 1.0

--- a/projects/04-llm-adapter/scripts/windows/setup.ps1
+++ b/projects/04-llm-adapter/scripts/windows/setup.ps1
@@ -18,7 +18,7 @@ Write-Host "OpenAI/Gemini の API キーを .env に記入してください" -F
 if (-not (Test-Path .env)) {
     @(
         "OPENAI_API_KEY=",
-        "GOOGLE_API_KEY="
+        "GEMINI_API_KEY="
     ) | Set-Content -Encoding UTF8 .env
 }
 


### PR DESCRIPTION
## Summary
- rename the documented Gemini API environment variable to GEMINI_API_KEY in the shadow adapter README
- update the main adapter docs, sample configs, and Windows setup script to match the provider implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bf3ebedc8321921070d4156760f5