### PR TITLE
Make provider request model mandatory

### DIFF
--- a/projects/04-llm-adapter-shadow/demo_shadow.py
+++ b/projects/04-llm-adapter-shadow/demo_shadow.py
@@ -22,7 +22,10 @@ if __name__ == "__main__":
         raise SystemExit(1) from exc
 
     runner = Runner([primary])
-    request = ProviderRequest(prompt="こんにちは、世界")
+    model_name = getattr(primary, "model", None) or getattr(primary, "_model", None)
+    if not isinstance(model_name, str) or not model_name:
+        model_name = primary.name()
+    request = ProviderRequest(model=model_name, prompt="こんにちは、世界")
 
     try:
         response = runner.run(request, shadow=shadow)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -96,6 +96,23 @@ class ProviderRequest:
     def prompt_text(self) -> str:
         return self.prompt
 
+    @property
+    def timeout(self) -> float:
+        """互換用のタイムアウト秒数アクセス。未指定時は 30 秒を返す。"""
+
+        return 30.0 if self.timeout_s is None else float(self.timeout_s)
+
+    @timeout.setter
+    def timeout(self, value: float | int | None) -> None:
+        if value is None:
+            self.timeout_s = None
+            return
+
+        try:
+            self.timeout_s = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+            raise ValueError("timeout must be a number or None") from exc
+
 
 @dataclass
 class TokenUsage:

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -52,10 +52,10 @@ def _extract_prompt_from_messages(messages: Sequence[Mapping[str, Any]]) -> str:
     return ""
 
 
-@dataclass
+@dataclass(kw_only=True)
 class ProviderRequest:
+    model: str
     prompt: str = ""
-    model: str | None = None
     messages: Sequence[Mapping[str, Any]] | None = None
     max_tokens: int | None = 256
     temperature: float | None = None

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -479,7 +479,7 @@ class GeminiProvider(ProviderSPI):
         ts0 = time.time()
         try:
             client = self._resolve_client()
-            model_name = request.model or self._model
+            model_name = request.model
             response = _invoke_gemini(client, model_name, messages, config, safety_settings)
         except ProviderSkip:
             raise
@@ -496,7 +496,7 @@ class GeminiProvider(ProviderSPI):
             text=text,
             token_usage=usage,
             latency_ms=latency_ms,
-            model=(request.model or self._model),
+            model=request.model,
             finish_reason=finish_reason,
             raw=response,
         )

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
@@ -75,7 +75,7 @@ class MockProvider(ProviderSPI):
             text=f"echo({self._name}): {text}",
             latency_ms=latency,
             token_usage=TokenUsage(prompt=prompt_tokens, completion=completion_tokens),
-            model=request.model or self._name,
+            model=request.model,
             finish_reason="stop",
             raw={
                 "echo": text,

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -215,7 +215,7 @@ class OllamaProvider(ProviderSPI):
     # ProviderSPI implementation
     # ------------------------------------------------------------------
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        model_name = request.model or self._model
+        model_name = request.model
         self._ensure_model(model_name)
 
         def _coerce_content(entry: Mapping[str, Any]) -> str:

--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -24,7 +24,7 @@ def test_timeout_fallback():
     p1, p2 = _providers_for("[TIMEOUT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[TIMEOUT] hello"))
+    response = runner.run(ProviderRequest(model="mock-model", prompt="[TIMEOUT] hello"))
     assert response.text.startswith("echo(p2):")
 
 
@@ -32,7 +32,7 @@ def test_ratelimit_retry_fallback():
     p1, p2 = _providers_for("[RATELIMIT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[RATELIMIT] test"))
+    response = runner.run(ProviderRequest(model="mock-model", prompt="[RATELIMIT] test"))
     assert response.text.startswith("echo(p2):")
 
 
@@ -40,7 +40,7 @@ def test_invalid_json_fallback():
     p1, p2 = _providers_for("[INVALID_JSON]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[INVALID_JSON] test"))
+    response = runner.run(ProviderRequest(model="mock-model", prompt="[INVALID_JSON] test"))
     assert response.text.startswith("echo(p2):")
 
 
@@ -50,7 +50,7 @@ def test_timeout_fallback_records_metrics(tmp_path):
 
     metrics_path = tmp_path / "fallback.jsonl"
     response = runner.run(
-        ProviderRequest(prompt="[TIMEOUT] metrics"),
+        ProviderRequest(model="mock-model", prompt="[TIMEOUT] metrics"),
         shadow=None,
         shadow_metrics_path=metrics_path,
     )
@@ -87,7 +87,7 @@ def test_runner_emits_chain_failed_metric(tmp_path):
 
     with pytest.raises(TimeoutError):
         runner.run(
-            ProviderRequest(prompt="[TIMEOUT] hard"),
+            ProviderRequest(model="mock-model", prompt="[TIMEOUT] hard"),
             shadow=None,
             shadow_metrics_path=metrics_path,
         )

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -26,6 +26,13 @@ from src.llm_adapter.providers import ollama as ollama_module
 DEFAULT_MODEL = "test-model"
 
 
+def test_provider_request_timeout_defaults_to_30_seconds():
+    request = ProviderRequest(model=DEFAULT_MODEL)
+
+    assert request.timeout == 30
+    assert request.timeout_s is None
+
+
 def test_parse_provider_spec_allows_colons_in_model():
     prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
     assert prefix == "ollama"

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -26,13 +26,6 @@ from src.llm_adapter.providers import ollama as ollama_module
 DEFAULT_MODEL = "test-model"
 
 
-def test_provider_request_timeout_defaults_to_30_seconds():
-    request = ProviderRequest(model=DEFAULT_MODEL)
-
-    assert request.timeout == 30
-    assert request.timeout_s is None
-
-
 def test_parse_provider_spec_allows_colons_in_model():
     prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
     assert prefix == "ollama"

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -23,6 +23,9 @@ from src.llm_adapter.providers.ollama import OllamaProvider
 from src.llm_adapter.providers import ollama as ollama_module
 
 
+DEFAULT_MODEL = "test-model"
+
+
 def test_parse_provider_spec_allows_colons_in_model():
     prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
     assert prefix == "ollama"
@@ -35,7 +38,7 @@ def test_parse_provider_spec_requires_separator():
 
 
 def test_provider_request_builds_messages_from_prompt():
-    request = ProviderRequest(prompt="  hello ")
+    request = ProviderRequest(model=DEFAULT_MODEL, prompt="  hello ")
 
     assert request.prompt_text == "hello"
     assert request.chat_messages == [{"role": "user", "content": "hello"}]
@@ -44,6 +47,7 @@ def test_provider_request_builds_messages_from_prompt():
 
 def test_provider_request_normalizes_messages_and_stop():
     request = ProviderRequest(
+        model=DEFAULT_MODEL,
         prompt="",
         messages=[{"role": "User", "content": [" hi ", " there "]}],
         stop=[" END ", ""],
@@ -210,6 +214,7 @@ def test_gemini_provider_invokes_client_with_config():
     )
 
     request = ProviderRequest(
+        model="gemini-2.5-flash",
         prompt="テスト",
         max_tokens=128,
         metadata={"system": "you are helpful"},
@@ -312,7 +317,7 @@ def test_gemini_provider_skips_without_api_key(monkeypatch):
     provider = GeminiProvider("gemini-2.5-flash")
 
     with pytest.raises(ProviderSkip) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
     assert excinfo.value.reason == "missing_gemini_api_key"
 
@@ -331,7 +336,7 @@ def test_gemini_provider_translates_rate_limit():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 def test_gemini_provider_translates_rate_limit_status_object():
@@ -355,7 +360,7 @@ def test_gemini_provider_translates_rate_limit_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 def test_gemini_provider_preserves_rate_limit_error_instances():
@@ -372,7 +377,7 @@ def test_gemini_provider_preserves_rate_limit_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
     assert excinfo.value is raised_error
 
@@ -398,7 +403,7 @@ def test_gemini_provider_translates_timeout_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 def test_gemini_provider_preserves_timeout_error_instances():
@@ -415,7 +420,7 @@ def test_gemini_provider_preserves_timeout_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
     assert excinfo.value is raised_error
 
@@ -462,7 +467,7 @@ def test_gemini_provider_translates_callable_code_status(
     )
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 def test_gemini_provider_translates_named_timeout_exception():
@@ -480,7 +485,7 @@ def test_gemini_provider_translates_named_timeout_exception():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 @pytest.mark.parametrize(
@@ -510,7 +515,7 @@ def test_gemini_provider_translates_http_errors(status_code: int, expected: type
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemini-2.5-flash", prompt="hello"))
 
 
 def test_ollama_provider_auto_pull_and_chat():
@@ -549,7 +554,7 @@ def test_ollama_provider_auto_pull_and_chat():
     session = Session()
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
-    response = provider.invoke(ProviderRequest(prompt="hello"))
+    response = provider.invoke(ProviderRequest(model="gemma3n:e2b", prompt="hello"))
 
     assert response.text == "hello"
     assert response.token_usage.prompt == 3
@@ -596,6 +601,7 @@ def test_ollama_provider_merges_request_options():
     provider = OllamaProvider("gemma3", session=session, host="http://localhost")
 
     request = ProviderRequest(
+        model="gemma3",
         prompt="hi",
         max_tokens=32,
         temperature=0.4,
@@ -651,7 +657,7 @@ def test_ollama_provider_auto_pull_error_mapping(status_code: int, expected: typ
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemma3n:e2b", prompt="hello"))
 
     assert session.pull_response is not None
     assert session.pull_response.closed
@@ -681,6 +687,7 @@ def test_ollama_provider_request_timeout_override():
 
     response = provider.invoke(
         ProviderRequest(
+            model="gemma3n:e2b",
             prompt="hello",
             options={"REQUEST_TIMEOUT_S": "2.5", "extra": True},
         )
@@ -720,7 +727,7 @@ def test_ollama_provider_maps_auth_error(status_code: int, expected: type[Except
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(model="gemma3n:e2b", prompt="hello"))
 
     assert session.last_chat_response is not None
     assert session.last_chat_response.closed

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -13,7 +13,7 @@ def test_shadow_exec_records_metrics(tmp_path):
     metrics_path = tmp_path / "metrics.jsonl"
     metadata = {"trace_id": "trace-123", "project_id": "proj-789"}
     response = runner.run(
-        ProviderRequest(prompt="hello", metadata=metadata),
+        ProviderRequest(model="mock-model", prompt="hello", metadata=metadata),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -55,7 +55,7 @@ def test_shadow_error_records_metrics(tmp_path):
 
     metrics_path = tmp_path / "metrics.jsonl"
     runner.run(
-        ProviderRequest(prompt="[TIMEOUT] hello"),
+        ProviderRequest(model="mock-model", prompt="[TIMEOUT] hello"),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -76,11 +76,11 @@ def test_request_hash_includes_max_tokens(tmp_path):
     metrics_path = tmp_path / "metrics.jsonl"
 
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=32),
+        ProviderRequest(model="mock-model", prompt="hello", max_tokens=32),
         shadow_metrics_path=metrics_path,
     )
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=64),
+        ProviderRequest(model="mock-model", prompt="hello", max_tokens=64),
         shadow_metrics_path=metrics_path,
     )
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "projects"
+    / "04-llm-adapter-shadow"
+    / "src"
+    / "llm_adapter"
+    / "provider_spi.py"
+)
+
+spec = importlib.util.spec_from_file_location("shadow_provider_spi", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+ProviderRequest = module.ProviderRequest
+
+
+def test_provider_request_timeout_defaults_to_30_seconds() -> None:
+    request = ProviderRequest(model="test-model")
+
+    assert request.timeout == 30
+    assert request.timeout_s is None


### PR DESCRIPTION
## Summary
- require the ProviderRequest model parameter and remove provider-side fallbacks
- update provider implementations and the demo to use the explicit request model
- adjust tests to supply concrete model names and verify new behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6bf3cd1f08321a2596206b218e73a