### PR TITLE
Ensure ProviderRequest uses explicit models

### DIFF
--- a/projects/04-llm-adapter-shadow/demo_shadow.py
+++ b/projects/04-llm-adapter-shadow/demo_shadow.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         raise SystemExit(1) from exc
 
     runner = Runner([primary])
-    request = ProviderRequest(prompt="こんにちは、世界")
+    request = ProviderRequest(prompt="こんにちは、世界", model="gemini-2.5-flash")
 
     try:
         response = runner.run(request, shadow=shadow)

--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -2,12 +2,18 @@
 import json
 from pathlib import Path
 from typing import Any
+
 import pytest
 
 from src.llm_adapter.errors import TimeoutError
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import Runner
 from src.llm_adapter.provider_spi import ProviderRequest
+
+
+@pytest.fixture(scope="module")
+def provider_request_model() -> str:
+    return "gemini:test-model"
 
 
 def _providers_for(marker: str):
@@ -20,37 +26,43 @@ def _read_metrics(path: Path) -> list[dict[str, Any]]:
     return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
 
 
-def test_timeout_fallback():
+def test_timeout_fallback(provider_request_model):
     p1, p2 = _providers_for("[TIMEOUT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[TIMEOUT] hello"))
+    response = runner.run(
+        ProviderRequest(prompt="[TIMEOUT] hello", model=provider_request_model)
+    )
     assert response.text.startswith("echo(p2):")
 
 
-def test_ratelimit_retry_fallback():
+def test_ratelimit_retry_fallback(provider_request_model):
     p1, p2 = _providers_for("[RATELIMIT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[RATELIMIT] test"))
+    response = runner.run(
+        ProviderRequest(prompt="[RATELIMIT] test", model=provider_request_model)
+    )
     assert response.text.startswith("echo(p2):")
 
 
-def test_invalid_json_fallback():
+def test_invalid_json_fallback(provider_request_model):
     p1, p2 = _providers_for("[INVALID_JSON]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[INVALID_JSON] test"))
+    response = runner.run(
+        ProviderRequest(prompt="[INVALID_JSON] test", model=provider_request_model)
+    )
     assert response.text.startswith("echo(p2):")
 
 
-def test_timeout_fallback_records_metrics(tmp_path):
+def test_timeout_fallback_records_metrics(tmp_path, provider_request_model):
     p1, p2 = _providers_for("[TIMEOUT]")
     runner = Runner([p1, p2])
 
     metrics_path = tmp_path / "fallback.jsonl"
     response = runner.run(
-        ProviderRequest(prompt="[TIMEOUT] metrics"),
+        ProviderRequest(prompt="[TIMEOUT] metrics", model=provider_request_model),
         shadow=None,
         shadow_metrics_path=metrics_path,
     )
@@ -78,7 +90,7 @@ def test_timeout_fallback_records_metrics(tmp_path):
     assert success_event["tokens_out"] == response.token_usage.completion
 
 
-def test_runner_emits_chain_failed_metric(tmp_path):
+def test_runner_emits_chain_failed_metric(tmp_path, provider_request_model):
     failing1 = MockProvider("p1", base_latency_ms=5, error_markers={"[TIMEOUT]"})
     failing2 = MockProvider("p2", base_latency_ms=5, error_markers={"[TIMEOUT]"})
     runner = Runner([failing1, failing2])
@@ -87,7 +99,7 @@ def test_runner_emits_chain_failed_metric(tmp_path):
 
     with pytest.raises(TimeoutError):
         runner.run(
-            ProviderRequest(prompt="[TIMEOUT] hard"),
+            ProviderRequest(prompt="[TIMEOUT] hard", model=provider_request_model),
             shadow=None,
             shadow_metrics_path=metrics_path,
         )

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -23,6 +23,11 @@ from src.llm_adapter.providers.ollama import OllamaProvider
 from src.llm_adapter.providers import ollama as ollama_module
 
 
+@pytest.fixture(scope="module")
+def provider_request_model() -> str:
+    return "gemini:test-model"
+
+
 def test_parse_provider_spec_allows_colons_in_model():
     prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
     assert prefix == "ollama"
@@ -34,19 +39,20 @@ def test_parse_provider_spec_requires_separator():
         parse_provider_spec("gemini")
 
 
-def test_provider_request_builds_messages_from_prompt():
-    request = ProviderRequest(prompt="  hello ")
+def test_provider_request_builds_messages_from_prompt(provider_request_model):
+    request = ProviderRequest(prompt="  hello ", model=provider_request_model)
 
     assert request.prompt_text == "hello"
     assert request.chat_messages == [{"role": "user", "content": "hello"}]
     assert request.stop is None
 
 
-def test_provider_request_normalizes_messages_and_stop():
+def test_provider_request_normalizes_messages_and_stop(provider_request_model):
     request = ProviderRequest(
         prompt="",
         messages=[{"role": "User", "content": [" hi ", " there "]}],
         stop=[" END ", ""],
+        model=provider_request_model,
     )
 
     assert request.prompt_text == "hi"
@@ -54,8 +60,8 @@ def test_provider_request_normalizes_messages_and_stop():
     assert request.stop == ("END",)
 
 
-def test_provider_request_timeout_defaults_to_30_seconds():
-    request = ProviderRequest()
+def test_provider_request_timeout_defaults_to_30_seconds(provider_request_model):
+    request = ProviderRequest(model=provider_request_model)
 
     assert request.timeout_s == pytest.approx(30.0)
 
@@ -222,6 +228,7 @@ def test_gemini_provider_invokes_client_with_config():
         temperature=0.4,
         top_p=0.85,
         stop=["END"],
+        model="gemini-2.5-flash",
     )
     response = provider.invoke(request)
 
@@ -307,7 +314,7 @@ def test_gemini_provider_uses_request_model_override_and_finish_reason():
     assert response.tokens_out == 3
 
 
-def test_gemini_provider_skips_without_api_key(monkeypatch):
+def test_gemini_provider_skips_without_api_key(monkeypatch, provider_request_model):
     from src.llm_adapter.providers import gemini as gemini_module
 
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -318,12 +325,12 @@ def test_gemini_provider_skips_without_api_key(monkeypatch):
     provider = GeminiProvider("gemini-2.5-flash")
 
     with pytest.raises(ProviderSkip) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
     assert excinfo.value.reason == "missing_gemini_api_key"
 
 
-def test_gemini_provider_translates_rate_limit():
+def test_gemini_provider_translates_rate_limit(provider_request_model):
     class _FailingModels:
         def generate_content(self, **kwargs):
             err = Exception("rate limited")
@@ -337,10 +344,10 @@ def test_gemini_provider_translates_rate_limit():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
-def test_gemini_provider_translates_rate_limit_status_object():
+def test_gemini_provider_translates_rate_limit_status_object(provider_request_model):
     class _StatusCode:
         def __init__(self, name: str):
             self.name = name
@@ -361,10 +368,10 @@ def test_gemini_provider_translates_rate_limit_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
-def test_gemini_provider_preserves_rate_limit_error_instances():
+def test_gemini_provider_preserves_rate_limit_error_instances(provider_request_model):
     raised_error = RateLimitError("rate limited")
 
     class _FailingModels:
@@ -378,12 +385,12 @@ def test_gemini_provider_preserves_rate_limit_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
     assert excinfo.value is raised_error
 
 
-def test_gemini_provider_translates_timeout_status_object():
+def test_gemini_provider_translates_timeout_status_object(provider_request_model):
     class _StatusCode:
         def __init__(self, name: str):
             self.name = name
@@ -404,10 +411,10 @@ def test_gemini_provider_translates_timeout_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
-def test_gemini_provider_preserves_timeout_error_instances():
+def test_gemini_provider_preserves_timeout_error_instances(provider_request_model):
     raised_error = TimeoutError("took too long")
 
     class _FailingModels:
@@ -421,7 +428,7 @@ def test_gemini_provider_preserves_timeout_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
     assert excinfo.value is raised_error
 
@@ -434,7 +441,7 @@ def test_gemini_provider_preserves_timeout_error_instances():
     ],
 )
 def test_gemini_provider_translates_callable_code_status(
-    code_name: str, expected: type[Exception]
+    code_name: str, expected: type[Exception], provider_request_model
 ):
     class _StatusCode:
         def __init__(self, name: str):
@@ -468,10 +475,10 @@ def test_gemini_provider_translates_callable_code_status(
     )
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
-def test_gemini_provider_translates_named_timeout_exception():
+def test_gemini_provider_translates_named_timeout_exception(provider_request_model):
     class Timeout(Exception):
         """Exception with a Timeout name similar to requests.exceptions.Timeout."""
 
@@ -486,7 +493,7 @@ def test_gemini_provider_translates_named_timeout_exception():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
 @pytest.mark.parametrize(
@@ -499,7 +506,9 @@ def test_gemini_provider_translates_named_timeout_exception():
         (504, TimeoutError),
     ],
 )
-def test_gemini_provider_translates_http_errors(status_code: int, expected: type[Exception]):
+def test_gemini_provider_translates_http_errors(
+    status_code: int, expected: type[Exception], provider_request_model
+):
     class _HttpError(Exception):
         def __init__(self, code: int):
             super().__init__(f"http {code}")
@@ -516,7 +525,7 @@ def test_gemini_provider_translates_http_errors(status_code: int, expected: type
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
 
 def test_ollama_provider_auto_pull_and_chat():
@@ -555,7 +564,7 @@ def test_ollama_provider_auto_pull_and_chat():
     session = Session()
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
-    response = provider.invoke(ProviderRequest(prompt="hello"))
+    response = provider.invoke(ProviderRequest(prompt="hello", model="gemma3n:e2b"))
 
     assert response.text == "hello"
     assert response.token_usage.prompt == 3
@@ -609,6 +618,7 @@ def test_ollama_provider_merges_request_options():
         stop=["END"],
         timeout_s=5.0,
         options={"options": {"stop": ["ALT"], "seed": 99}, "stream": True},
+        model="gemma3",
     )
     provider.invoke(request)
 
@@ -632,7 +642,9 @@ def test_ollama_provider_merges_request_options():
         (504, TimeoutError),
     ],
 )
-def test_ollama_provider_auto_pull_error_mapping(status_code: int, expected: type[Exception]):
+def test_ollama_provider_auto_pull_error_mapping(
+    status_code: int, expected: type[Exception], provider_request_model
+):
     class Session(_FakeSession):
         def __init__(self):
             super().__init__()
@@ -657,7 +669,7 @@ def test_ollama_provider_auto_pull_error_mapping(status_code: int, expected: typ
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
     assert session.pull_response is not None
     assert session.pull_response.closed
@@ -690,6 +702,7 @@ def test_ollama_provider_request_timeout_override():
             prompt="hello",
             timeout_s=None,
             options={"REQUEST_TIMEOUT_S": "2.5", "extra": True},
+            model="gemma3n:e2b",
         )
     )
 
@@ -727,7 +740,7 @@ def test_ollama_provider_maps_auth_error(status_code: int, expected: type[Except
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemma3n:e2b"))
 
     assert session.last_chat_response is not None
     assert session.last_chat_response.closed


### PR DESCRIPTION
## Summary
- add module fixtures so ProviderRequest calls in adapter tests always specify a model
- update all affected tests and the demo script to rely on explicit model selection instead of fallback defaults

## Testing
- pytest projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68d75c6a0bcc8321b51e4473dc9712aa