### PR TITLE
Require explicit model selection for providers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
@@ -75,7 +75,7 @@ class MockProvider(ProviderSPI):
             text=f"echo({self._name}): {text}",
             latency_ms=latency,
             token_usage=TokenUsage(prompt=prompt_tokens, completion=completion_tokens),
-            model=request.model or self._name,
+            model=request.model,
             finish_reason="stop",
             raw={
                 "echo": text,

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -119,6 +119,7 @@ class OllamaProvider(ProviderSPI):
         pull_timeout: float = 300.0,
         auto_pull: bool = True,
     ) -> None:
+        # Factory/CLI で ``ProviderRequest.model`` に設定される推奨デフォルトを保持。
         self._model = model
         self._name = name or f"ollama:{model}"
         env_host = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_HOST")
@@ -215,7 +216,12 @@ class OllamaProvider(ProviderSPI):
     # ProviderSPI implementation
     # ------------------------------------------------------------------
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        model_name = request.model or self._model
+        model_name = request.model
+        if not isinstance(model_name, str):
+            raise ConfigError("OllamaProvider requires request.model to be set")
+        model_name = model_name.strip()
+        if not model_name:
+            raise ConfigError("OllamaProvider requires request.model to be set")
         self._ensure_model(model_name)
 
         def _coerce_content(entry: Mapping[str, Any]) -> str:

--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -24,15 +24,17 @@ def test_timeout_fallback():
     p1, p2 = _providers_for("[TIMEOUT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[TIMEOUT] hello"))
+    request = ProviderRequest(prompt="[TIMEOUT] hello", model="fallback-model")
+    response = runner.run(request)
     assert response.text.startswith("echo(p2):")
+    assert response.model == "fallback-model"
 
 
 def test_ratelimit_retry_fallback():
     p1, p2 = _providers_for("[RATELIMIT]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[RATELIMIT] test"))
+    response = runner.run(ProviderRequest(prompt="[RATELIMIT] test", model="fallback-model"))
     assert response.text.startswith("echo(p2):")
 
 
@@ -40,7 +42,7 @@ def test_invalid_json_fallback():
     p1, p2 = _providers_for("[INVALID_JSON]")
     runner = Runner([p1, p2])
 
-    response = runner.run(ProviderRequest(prompt="[INVALID_JSON] test"))
+    response = runner.run(ProviderRequest(prompt="[INVALID_JSON] test", model="fallback-model"))
     assert response.text.startswith("echo(p2):")
 
 
@@ -50,7 +52,7 @@ def test_timeout_fallback_records_metrics(tmp_path):
 
     metrics_path = tmp_path / "fallback.jsonl"
     response = runner.run(
-        ProviderRequest(prompt="[TIMEOUT] metrics"),
+        ProviderRequest(prompt="[TIMEOUT] metrics", model="fallback-model"),
         shadow=None,
         shadow_metrics_path=metrics_path,
     )
@@ -87,7 +89,7 @@ def test_runner_emits_chain_failed_metric(tmp_path):
 
     with pytest.raises(TimeoutError):
         runner.run(
-            ProviderRequest(prompt="[TIMEOUT] hard"),
+            ProviderRequest(prompt="[TIMEOUT] hard", model="fallback-model"),
             shadow=None,
             shadow_metrics_path=metrics_path,
         )

--- a/projects/04-llm-adapter-shadow/tests/test_providers.py
+++ b/projects/04-llm-adapter-shadow/tests/test_providers.py
@@ -222,6 +222,7 @@ def test_gemini_provider_invokes_client_with_config():
         temperature=0.4,
         top_p=0.85,
         stop=["END"],
+        model="gemini-2.5-flash",
     )
     response = provider.invoke(request)
 
@@ -318,7 +319,7 @@ def test_gemini_provider_skips_without_api_key(monkeypatch):
     provider = GeminiProvider("gemini-2.5-flash")
 
     with pytest.raises(ProviderSkip) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
     assert excinfo.value.reason == "missing_gemini_api_key"
 
@@ -337,7 +338,7 @@ def test_gemini_provider_translates_rate_limit():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 def test_gemini_provider_translates_rate_limit_status_object():
@@ -361,7 +362,7 @@ def test_gemini_provider_translates_rate_limit_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 def test_gemini_provider_preserves_rate_limit_error_instances():
@@ -378,7 +379,7 @@ def test_gemini_provider_preserves_rate_limit_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(RateLimitError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
     assert excinfo.value is raised_error
 
@@ -404,7 +405,7 @@ def test_gemini_provider_translates_timeout_status_object():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 def test_gemini_provider_preserves_timeout_error_instances():
@@ -421,7 +422,7 @@ def test_gemini_provider_preserves_timeout_error_instances():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError) as excinfo:
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
     assert excinfo.value is raised_error
 
@@ -468,7 +469,7 @@ def test_gemini_provider_translates_callable_code_status(
     )
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 def test_gemini_provider_translates_named_timeout_exception():
@@ -486,7 +487,7 @@ def test_gemini_provider_translates_named_timeout_exception():
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(TimeoutError):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 @pytest.mark.parametrize(
@@ -516,7 +517,7 @@ def test_gemini_provider_translates_http_errors(status_code: int, expected: type
     provider = GeminiProvider("gemini-2.5-flash", client=_Client())  # type: ignore[arg-type]
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemini-2.5-flash"))
 
 
 def test_ollama_provider_auto_pull_and_chat():
@@ -555,7 +556,7 @@ def test_ollama_provider_auto_pull_and_chat():
     session = Session()
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
-    response = provider.invoke(ProviderRequest(prompt="hello"))
+    response = provider.invoke(ProviderRequest(prompt="hello", model="gemma3n:e2b"))
 
     assert response.text == "hello"
     assert response.token_usage.prompt == 3
@@ -609,6 +610,7 @@ def test_ollama_provider_merges_request_options():
         stop=["END"],
         timeout_s=5.0,
         options={"options": {"stop": ["ALT"], "seed": 99}, "stream": True},
+        model="gemma3",
     )
     provider.invoke(request)
 
@@ -657,7 +659,7 @@ def test_ollama_provider_auto_pull_error_mapping(status_code: int, expected: typ
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemma3n:e2b"))
 
     assert session.pull_response is not None
     assert session.pull_response.closed
@@ -690,6 +692,7 @@ def test_ollama_provider_request_timeout_override():
             prompt="hello",
             timeout_s=None,
             options={"REQUEST_TIMEOUT_S": "2.5", "extra": True},
+            model="gemma3n:e2b",
         )
     )
 
@@ -727,7 +730,7 @@ def test_ollama_provider_maps_auth_error(status_code: int, expected: type[Except
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")
 
     with pytest.raises(expected):
-        provider.invoke(ProviderRequest(prompt="hello"))
+        provider.invoke(ProviderRequest(prompt="hello", model="gemma3n:e2b"))
 
     assert session.last_chat_response is not None
     assert session.last_chat_response.closed

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -12,13 +12,15 @@ def test_shadow_exec_records_metrics(tmp_path):
 
     metrics_path = tmp_path / "metrics.jsonl"
     metadata = {"trace_id": "trace-123", "project_id": "proj-789"}
+    request = ProviderRequest(prompt="hello", metadata=metadata, model="primary-model")
     response = runner.run(
-        ProviderRequest(prompt="hello", metadata=metadata),
+        request,
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
 
     assert response.text.startswith("echo(primary):")
+    assert response.model == "primary-model"
     assert metrics_path.exists()
 
     payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
@@ -55,7 +57,7 @@ def test_shadow_error_records_metrics(tmp_path):
 
     metrics_path = tmp_path / "metrics.jsonl"
     runner.run(
-        ProviderRequest(prompt="[TIMEOUT] hello"),
+        ProviderRequest(prompt="[TIMEOUT] hello", model="primary-model"),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -76,11 +78,11 @@ def test_request_hash_includes_max_tokens(tmp_path):
     metrics_path = tmp_path / "metrics.jsonl"
 
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=32),
+        ProviderRequest(prompt="hello", max_tokens=32, model="primary-model"),
         shadow_metrics_path=metrics_path,
     )
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=64),
+        ProviderRequest(prompt="hello", max_tokens=64, model="primary-model"),
         shadow_metrics_path=metrics_path,
     )
 


### PR DESCRIPTION
## Summary
- require Gemini and Ollama providers to receive an explicit `ProviderRequest.model`, keeping the constructor default only as metadata
- remove the mock provider’s fallback model and update unit tests to pass explicit models and validate the echoed value
- refresh shadow and fallback tests so requests carry models and continue to assert expected behaviour

## Testing
- pytest projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68d75c6cdc108321966abd0883c2ef9f