### PR TITLE
Enforce non-empty model on ProviderRequest

### DIFF
--- a/projects/04-llm-adapter-shadow/demo_shadow.py
+++ b/projects/04-llm-adapter-shadow/demo_shadow.py
@@ -22,7 +22,12 @@ if __name__ == "__main__":
         raise SystemExit(1) from exc
 
     runner = Runner([primary])
-    request = ProviderRequest(prompt="こんにちは、世界")
+    model_name = getattr(primary, "model", None)
+    if not isinstance(model_name, str) or not model_name.strip():
+        model_name = getattr(primary, "_model", None)
+    if not isinstance(model_name, str) or not model_name.strip():
+        model_name = "primary-model"
+    request = ProviderRequest(prompt="こんにちは、世界", model=model_name)
 
     try:
         response = runner.run(request, shadow=shadow)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -27,7 +27,7 @@ def _normalize_message(entry: Mapping[str, Any]) -> Mapping[str, Any] | None:
         if not text:
             return None
         return {"role": role, "content": text}
-    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
+    if isinstance(content, Sequence) and not isinstance(content, bytes | bytearray):
         parts = [part.strip() for part in content if isinstance(part, str) and part.strip()]
         if not parts:
             return None
@@ -45,7 +45,7 @@ def _extract_prompt_from_messages(messages: Sequence[Mapping[str, Any]]) -> str:
         content = message.get("content")
         if isinstance(content, str) and content.strip():
             return content.strip()
-        if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
+        if isinstance(content, Sequence) and not isinstance(content, bytes | bytearray):
             for part in content:
                 if isinstance(part, str) and part.strip():
                     return part.strip()
@@ -54,8 +54,8 @@ def _extract_prompt_from_messages(messages: Sequence[Mapping[str, Any]]) -> str:
 
 @dataclass
 class ProviderRequest:
+    model: str
     prompt: str = ""
-    model: str | None = None
     messages: Sequence[Mapping[str, Any]] | None = None
     max_tokens: int | None = 256
     temperature: float | None = None
@@ -66,6 +66,11 @@ class ProviderRequest:
     options: dict[str, Any] | None = field(default=None)
 
     def __post_init__(self) -> None:
+        model = (self.model or "").strip()
+        if not model:
+            raise ValueError("ProviderRequest.model must be a non-empty string")
+        self.model = model
+
         self.prompt = (self.prompt or "").strip()
 
         normalized_messages: list[Mapping[str, Any]] = []

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -1,11 +1,12 @@
 import json
+from pathlib import Path
 
+from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import Runner
-from src.llm_adapter.provider_spi import ProviderRequest
 
 
-def test_shadow_exec_records_metrics(tmp_path):
+def test_shadow_exec_records_metrics(tmp_path: Path) -> None:
     primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
     shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
     runner = Runner([primary])
@@ -13,7 +14,7 @@ def test_shadow_exec_records_metrics(tmp_path):
     metrics_path = tmp_path / "metrics.jsonl"
     metadata = {"trace_id": "trace-123", "project_id": "proj-789"}
     response = runner.run(
-        ProviderRequest(prompt="hello", metadata=metadata),
+        ProviderRequest(prompt="hello", metadata=metadata, model="mock-model"),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -29,7 +30,10 @@ def test_shadow_exec_records_metrics(tmp_path):
     assert diff_event["shadow_provider"] == "shadow"
     assert diff_event["shadow_ok"] is True
     assert diff_event["primary_text_len"] == len(response.text)
-    assert diff_event["primary_token_usage_total"] == response.token_usage.total
+    token_usage = response.token_usage
+    assert token_usage is not None
+
+    assert diff_event["primary_token_usage_total"] == token_usage.total
     assert diff_event["request_fingerprint"]
 
     assert call_event["provider"] == "primary"
@@ -37,8 +41,8 @@ def test_shadow_exec_records_metrics(tmp_path):
     assert call_event["shadow_used"] is True
     assert call_event["status"] == "ok"
     assert call_event["latency_ms"] == response.latency_ms
-    assert call_event["tokens_in"] == response.token_usage.prompt
-    assert call_event["tokens_out"] == response.token_usage.completion
+    assert call_event["tokens_in"] == token_usage.prompt
+    assert call_event["tokens_out"] == token_usage.completion
     assert call_event["trace_id"] == metadata["trace_id"]
     assert call_event["project_id"] == metadata["project_id"]
     assert call_event.get("model") is None
@@ -48,14 +52,14 @@ def test_shadow_exec_records_metrics(tmp_path):
     assert diff_event["shadow_text_len"] == len("echo(shadow): hello")
 
 
-def test_shadow_error_records_metrics(tmp_path):
+def test_shadow_error_records_metrics(tmp_path: Path) -> None:
     primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
     shadow = MockProvider("shadow", base_latency_ms=5, error_markers={"[TIMEOUT]"})
     runner = Runner([primary])
 
     metrics_path = tmp_path / "metrics.jsonl"
     runner.run(
-        ProviderRequest(prompt="[TIMEOUT] hello"),
+        ProviderRequest(prompt="[TIMEOUT] hello", model="mock-model"),
         shadow=shadow,
         shadow_metrics_path=metrics_path,
     )
@@ -69,18 +73,18 @@ def test_shadow_error_records_metrics(tmp_path):
     assert diff_event["shadow_duration_ms"] >= 0
 
 
-def test_request_hash_includes_max_tokens(tmp_path):
+def test_request_hash_includes_max_tokens(tmp_path: Path) -> None:
     provider = MockProvider("primary", base_latency_ms=1, error_markers=set())
     runner = Runner([provider])
 
     metrics_path = tmp_path / "metrics.jsonl"
 
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=32),
+        ProviderRequest(prompt="hello", max_tokens=32, model="mock-model"),
         shadow_metrics_path=metrics_path,
     )
     runner.run(
-        ProviderRequest(prompt="hello", max_tokens=64),
+        ProviderRequest(prompt="hello", max_tokens=64, model="mock-model"),
         shadow_metrics_path=metrics_path,
     )
 


### PR DESCRIPTION
## Summary
- require `ProviderRequest.model` to be a non-empty string and normalize whitespace
- update demo and tests to always provide a model and add regression coverage for empty model inputs
- adjust helper code where necessary so linting and static analysis accept the stricter contract

## Testing
- pytest projects/04-llm-adapter-shadow/tests
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py projects/04-llm-adapter-shadow/tests/test_providers.py projects/04-llm-adapter-shadow/tests/test_shadow.py projects/04-llm-adapter-shadow/tests/test_err_cases.py projects/04-llm-adapter-shadow/demo_shadow.py
- mypy projects/04-llm-adapter-shadow/src

------
https://chatgpt.com/codex/tasks/task_e_68d75c6778708321891a91754dd08bfd