### PR TITLE
Refine typing imports in Ollama provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -6,7 +6,12 @@ import os
 import time
 from collections.abc import Iterable, Mapping, Sequence
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol,
+    cast,
+)
 
 from ..errors import AuthError, ConfigError, RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage


### PR DESCRIPTION
## Summary
- format the typing imports in the Ollama provider into a multi-line block ordered according to Ruff

## Testing
- ruff check projects/04-llm-adapter-shadow/src --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68d7763d7e9083219b01720739cff2ec