### PR TITLE
Refine Ollama provider import ordering

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import (
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 


### PR DESCRIPTION
## Summary
- format the collections.abc imports in the Ollama provider to follow Ruff's import style
- ensure typing.Any is imported alongside cast for the token usage helper

## Testing
- ruff check projects/04-llm-adapter-shadow/src --select I001,UP035,F821

------
https://chatgpt.com/codex/tasks/task_e_68d7763e903c8321af57181efc49c0ed