### PR TITLE
Fix B005 lint violation in Gemini provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from types import ModuleType
@@ -410,7 +411,7 @@ class GeminiProvider(ProviderSPI):
             token = text.split()[0]
             if "." in token:
                 token = token.split(".")[-1]
-            token = token.strip(" <>:,'\"")
+            token = re.sub(r"^[ <>:,\'\"]+|[ <>:,\'\"]+$", "", token)
             return token.upper()
 
         status_value: Any = None


### PR DESCRIPTION
## Summary
- replace the token cleanup helper in the Gemini provider with a regex-based implementation to satisfy lint

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py

------
https://chatgpt.com/codex/tasks/task_e_68d77660c7608321afe9e5399768e98c