### PR TITLE
Refactor CLI prompt orchestration

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/__init__.py
+++ b/projects/04-llm-adapter/adapter/cli/__init__.py
@@ -5,14 +5,11 @@ import socket as _socket
 import sys
 from typing import List, Optional
 
+from adapter.core import providers as provider_module
+
 from .doctor import run_doctor
-from .prompts import (
-    PromptResult as _PromptResult,
-    ProviderFactory as _ProviderFactory,
-    ProviderResponse as _ProviderResponse,
-    RateLimiter as _RateLimiter,
-    run_prompts,
-)
+from .prompt_runner import PromptResult as _PromptResult, RateLimiter as _RateLimiter
+from .prompts import ProviderFactory as _ProviderFactory, run_prompts
 from .utils import (
     EXIT_ENV_ERROR,
     EXIT_INPUT_ERROR,
@@ -25,7 +22,7 @@ from .utils import (
 http = _http
 socket = _socket
 ProviderFactory = _ProviderFactory
-ProviderResponse = _ProviderResponse
+ProviderResponse = provider_module.ProviderResponse
 RateLimiter = _RateLimiter
 PromptResult = _PromptResult
 

--- a/projects/04-llm-adapter/adapter/cli/prompt_io.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_io.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List, TYPE_CHECKING
+
+from .utils import LOGGER, _msg, _sanitize_message
+
+if TYPE_CHECKING:
+    from .prompt_runner import PromptResult
+
+
+def read_jsonl_prompts(path: Path, lang: str) -> List[str]:
+    prompts: List[str] = []
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            for line_no, raw_line in enumerate(fp, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if isinstance(obj, str):
+                    prompts.append(obj)
+                    continue
+                if isinstance(obj, dict):
+                    for key in ("prompt", "text", "input"):
+                        value = obj.get(key)
+                        if isinstance(value, str):
+                            prompts.append(value)
+                            break
+                    else:
+                        raise ValueError(
+                            _msg(lang, "jsonl_invalid_object", path=path, line=line_no)
+                        )
+                    continue
+                raise ValueError(_msg(lang, "jsonl_unsupported", path=path, line=line_no))
+    except FileNotFoundError as exc:
+        raise SystemExit(_msg(lang, "jsonl_missing", path=path)) from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(_msg(lang, "jsonl_decode_error", path=path, line=exc.lineno)) from exc
+    return prompts
+
+
+def collect_prompts(args: argparse.Namespace, parser: argparse.ArgumentParser, lang: str) -> List[str]:
+    prompts: List[str] = []
+    if args.prompt is not None:
+        prompts.append(args.prompt)
+    if args.prompt_file:
+        path = Path(args.prompt_file).expanduser().resolve()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            parser.error(_msg(lang, "jsonl_missing", path=path))
+            raise SystemExit from exc
+        prompts.append(text.rstrip("\n"))
+    if args.prompts:
+        prompts.extend(read_jsonl_prompts(Path(args.prompts).expanduser().resolve(), lang))
+    if not prompts:
+        parser.error(_msg(lang, "prompt_sources_missing"))
+    return prompts
+
+
+def emit_results(results: Iterable["PromptResult"], output_format: str, include_prompts: bool) -> None:
+    metrics = []
+    for res in results:
+        payload = res.metric.model_dump()
+        if include_prompts:
+            payload["prompt"] = res.prompt
+        metrics.append(payload)
+    if output_format == "text":
+        for res in results:
+            if res.error:
+                continue
+            text = res.output_text
+            if text:
+                print(text)
+        return
+    if output_format == "json":
+        print(json.dumps(metrics, ensure_ascii=False, indent=2))
+        return
+    for payload in metrics:
+        print(json.dumps(payload, ensure_ascii=False))
+
+
+def write_metrics(
+    out_dir: Path,
+    results: Iterable["PromptResult"],
+    include_prompts: bool,
+    lang: str,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "metrics.jsonl"
+    with path.open("a", encoding="utf-8") as fp:
+        for res in results:
+            payload = res.metric.model_dump()
+            if include_prompts:
+                payload["prompt"] = res.prompt
+            fp.write(json.dumps(payload, ensure_ascii=False))
+            fp.write("\n")
+    LOGGER.info(_sanitize_message(_msg(lang, "metrics_written", path=path)))
+
+
+__all__ = ["collect_prompts", "emit_results", "read_jsonl_prompts", "write_metrics"]

--- a/projects/04-llm-adapter/adapter/cli/prompt_runner.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_runner.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
+
+from adapter.core import providers as provider_module
+from adapter.core.config import ProviderConfig
+from adapter.core.metrics import RunMetric, estimate_cost
+
+from .utils import LOGGER, _sanitize_message
+
+ProviderResponse = provider_module.ProviderResponse
+Classifier = Callable[[Exception, ProviderConfig, str], Tuple[str, str]]
+
+
+class RateLimiter:
+    """簡易 RPM 制御。"""
+
+    def __init__(self, rpm: int) -> None:
+        self._rpm = max(0, int(rpm or 0))
+        self._timestamps: deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def wait(self) -> None:
+        if self._rpm <= 0:
+            return
+        window = 60.0
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                while self._timestamps and now - self._timestamps[0] >= window:
+                    self._timestamps.popleft()
+                if len(self._timestamps) < self._rpm:
+                    self._timestamps.append(now)
+                    return
+                wait = window - (now - self._timestamps[0])
+            await asyncio.sleep(max(wait, 0.0))
+
+
+@dataclass
+class PromptResult:
+    index: int
+    prompt: str
+    response: Optional[ProviderResponse]
+    metric: RunMetric
+    output_text: str
+    error: Optional[str]
+    error_kind: Optional[str] = None
+
+
+async def _process_prompt(
+    index: int,
+    prompt: str,
+    provider: object,
+    config: ProviderConfig,
+    limiter: RateLimiter,
+    semaphore: asyncio.Semaphore,
+    lang: str,
+    classify_error: Classifier,
+) -> PromptResult:
+    async with semaphore:
+        await limiter.wait()
+        loop = asyncio.get_running_loop()
+        start = time.perf_counter()
+        try:
+            response: ProviderResponse = await loop.run_in_executor(
+                None, provider.generate, prompt
+            )
+        except Exception as exc:  # pragma: no cover - 実 API 呼び出し向けの防御
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            friendly, error_kind = classify_error(exc, config, lang)
+            LOGGER.error(_sanitize_message(friendly))
+            LOGGER.debug("provider error", exc_info=True)
+            stub = ProviderResponse(
+                output_text="",
+                input_tokens=0,
+                output_tokens=0,
+                latency_ms=latency_ms,
+            )
+            metric = RunMetric.from_resp(config, stub, prompt, cost_usd=0.0, error=friendly)
+            return PromptResult(
+                index=index,
+                prompt=prompt,
+                response=None,
+                metric=metric,
+                output_text="",
+                error=friendly,
+                error_kind=error_kind,
+            )
+        cost = estimate_cost(
+            config,
+            getattr(response, "input_tokens", 0),
+            getattr(response, "output_tokens", 0),
+        )
+        metric = RunMetric.from_resp(config, response, prompt, cost_usd=cost)
+        return PromptResult(
+            index=index,
+            prompt=prompt,
+            response=response,
+            metric=metric,
+            output_text=getattr(response, "output_text", ""),
+            error=None,
+        )
+
+
+async def execute_prompts(
+    prompts: List[str],
+    provider: object,
+    config: ProviderConfig,
+    concurrency: int,
+    rpm: int,
+    lang: str,
+    classify_error: Classifier,
+) -> List[PromptResult]:
+    limiter = RateLimiter(rpm)
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+    tasks = [
+        asyncio.create_task(
+            _process_prompt(idx, prompt, provider, config, limiter, semaphore, lang, classify_error)
+        )
+        for idx, prompt in enumerate(prompts)
+    ]
+    results = await asyncio.gather(*tasks)
+    return sorted(results, key=lambda item: item.index)
+
+
+__all__ = ["RateLimiter", "PromptResult", "execute_prompts"]

--- a/projects/04-llm-adapter/adapter/cli/prompts.py
+++ b/projects/04-llm-adapter/adapter/cli/prompts.py
@@ -2,19 +2,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import os
 import socket
-import time
-from collections import deque
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
 from adapter.core import providers as provider_module
 from adapter.core.config import ProviderConfig, load_provider_config
-from adapter.core.metrics import RunMetric, estimate_cost
 
+from .prompt_io import collect_prompts, emit_results, write_metrics
+from .prompt_runner import PromptResult, RateLimiter, execute_prompts
 from .utils import (
     EXIT_ENV_ERROR,
     EXIT_INPUT_ERROR,
@@ -31,42 +28,6 @@ from .utils import (
 )
 
 ProviderFactory = provider_module.ProviderFactory
-ProviderResponse = provider_module.ProviderResponse
-
-
-class RateLimiter:
-    """簡易 RPM 制御。"""
-
-    def __init__(self, rpm: int) -> None:
-        self._rpm = max(0, int(rpm or 0))
-        self._timestamps: deque[float] = deque()
-        self._lock = asyncio.Lock()
-
-    async def wait(self) -> None:
-        if self._rpm <= 0:
-            return
-        window = 60.0
-        while True:
-            async with self._lock:
-                now = time.monotonic()
-                while self._timestamps and now - self._timestamps[0] >= window:
-                    self._timestamps.popleft()
-                if len(self._timestamps) < self._rpm:
-                    self._timestamps.append(now)
-                    return
-                wait = window - (now - self._timestamps[0])
-            await asyncio.sleep(max(wait, 0.0))
-
-
-@dataclass
-class PromptResult:
-    index: int
-    prompt: str
-    response: Optional[ProviderResponse]
-    metric: RunMetric
-    output_text: str
-    error: Optional[str]
-    error_kind: Optional[str] = None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -105,53 +66,6 @@ def _load_env_file(path: Path, lang: str) -> None:
     LOGGER.info(_sanitize_message(_msg(lang, "env_loaded", path=path)))
 
 
-def _read_jsonl_prompts(path: Path, lang: str) -> List[str]:
-    prompts: List[str] = []
-    try:
-        with path.open("r", encoding="utf-8") as fp:
-            for line_no, raw_line in enumerate(fp, start=1):
-                line = raw_line.strip()
-                if not line:
-                    continue
-                obj = json.loads(line)
-                if isinstance(obj, str):
-                    prompts.append(obj)
-                elif isinstance(obj, dict):
-                    for key in ("prompt", "text", "input"):
-                        value = obj.get(key)
-                        if isinstance(value, str):
-                            prompts.append(value)
-                            break
-                    else:
-                        raise ValueError(_msg(lang, "jsonl_invalid_object", path=path, line=line_no))
-                else:
-                    raise ValueError(_msg(lang, "jsonl_unsupported", path=path, line=line_no))
-    except FileNotFoundError as exc:
-        raise SystemExit(_msg(lang, "jsonl_missing", path=path)) from exc
-    except json.JSONDecodeError as exc:
-        raise SystemExit(_msg(lang, "jsonl_decode_error", path=path, line=exc.lineno)) from exc
-    return prompts
-
-
-def _collect_prompts(args: argparse.Namespace, parser: argparse.ArgumentParser, lang: str) -> List[str]:
-    prompts: List[str] = []
-    if args.prompt is not None:
-        prompts.append(args.prompt)
-    if args.prompt_file:
-        path = Path(args.prompt_file).expanduser().resolve()
-        try:
-            text = path.read_text(encoding="utf-8")
-        except FileNotFoundError as exc:
-            parser.error(_msg(lang, "jsonl_missing", path=path))
-            raise SystemExit from exc
-        prompts.append(text.rstrip("\n"))
-    if args.prompts:
-        prompts.extend(_read_jsonl_prompts(Path(args.prompts).expanduser().resolve(), lang))
-    if not prompts:
-        parser.error(_msg(lang, "prompt_sources_missing"))
-    return prompts
-
-
 def _classify_error(
     exc: Exception,
     config: ProviderConfig,
@@ -182,110 +96,6 @@ def _classify_error(
         return _msg(lang, "api_key_missing", env=auth_env), "env"
     sanitized = _sanitize_message(raw_message)
     return _msg(lang, "provider_error", error=sanitized), "provider"
-
-
-async def _process_prompt(
-    index: int,
-    prompt: str,
-    provider: object,
-    config: ProviderConfig,
-    limiter: RateLimiter,
-    semaphore: asyncio.Semaphore,
-    lang: str,
-) -> PromptResult:
-    async with semaphore:
-        await limiter.wait()
-        loop = asyncio.get_running_loop()
-        start = time.perf_counter()
-        try:
-            response: ProviderResponse = await loop.run_in_executor(None, provider.generate, prompt)
-        except Exception as exc:  # pragma: no cover - 実 API 呼び出し向けの防御
-            latency_ms = int((time.perf_counter() - start) * 1000)
-            friendly, error_kind = _classify_error(exc, config, lang)
-            LOGGER.error(_sanitize_message(friendly))
-            LOGGER.debug("provider error", exc_info=True)
-            stub = ProviderResponse(
-                output_text="",
-                input_tokens=0,
-                output_tokens=0,
-                latency_ms=latency_ms,
-            )
-            metric = RunMetric.from_resp(config, stub, prompt, cost_usd=0.0, error=friendly)
-            return PromptResult(
-                index=index,
-                prompt=prompt,
-                response=None,
-                metric=metric,
-                output_text="",
-                error=friendly,
-                error_kind=error_kind,
-            )
-        cost = estimate_cost(
-            config,
-            getattr(response, "input_tokens", 0),
-            getattr(response, "output_tokens", 0),
-        )
-        metric = RunMetric.from_resp(config, response, prompt, cost_usd=cost)
-        return PromptResult(
-            index=index,
-            prompt=prompt,
-            response=response,
-            metric=metric,
-            output_text=getattr(response, "output_text", ""),
-            error=None,
-        )
-
-
-async def _execute_prompts(
-    prompts: List[str],
-    provider: object,
-    config: ProviderConfig,
-    concurrency: int,
-    rpm: int,
-    lang: str,
-) -> List[PromptResult]:
-    limiter = RateLimiter(rpm)
-    semaphore = asyncio.Semaphore(max(1, concurrency))
-    tasks = [
-        asyncio.create_task(_process_prompt(idx, prompt, provider, config, limiter, semaphore, lang))
-        for idx, prompt in enumerate(prompts)
-    ]
-    results = await asyncio.gather(*tasks)
-    return sorted(results, key=lambda item: item.index)
-
-
-def _emit_results(results: Iterable[PromptResult], output_format: str, include_prompts: bool) -> None:
-    metrics = []
-    for res in results:
-        payload = res.metric.model_dump()
-        if include_prompts:
-            payload["prompt"] = res.prompt
-        metrics.append(payload)
-    if output_format == "text":
-        for res in results:
-            if res.error:
-                continue
-            text = res.output_text
-            if text:
-                print(text)
-    elif output_format == "json":
-        print(json.dumps(metrics, ensure_ascii=False, indent=2))
-    else:
-        for payload in metrics:
-            print(json.dumps(payload, ensure_ascii=False))
-
-
-def _write_metrics(out_dir: Path, results: Iterable[PromptResult], include_prompts: bool, lang: str) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / "metrics.jsonl"
-    with path.open("a", encoding="utf-8") as fp:
-        for res in results:
-            payload = res.metric.model_dump()
-            if include_prompts:
-                payload["prompt"] = res.prompt
-            fp.write(json.dumps(payload, ensure_ascii=False))
-            fp.write("\n")
-    LOGGER.info(_sanitize_message(_msg(lang, "metrics_written", path=path)))
 
 
 def _determine_concurrency(parallel: bool, prompt_count: int) -> int:
@@ -350,7 +160,7 @@ def run_prompts(argv: Optional[List[str]], provider_factory: Optional[object] = 
         return EXIT_PROVIDER_ERROR
 
     try:
-        prompts = _collect_prompts(args, parser, lang)
+        prompts = collect_prompts(args, parser, lang)
     except SystemExit as exc:
         return _coerce_exit_code(getattr(exc, "code", None))
 
@@ -358,15 +168,15 @@ def run_prompts(argv: Optional[List[str]], provider_factory: Optional[object] = 
     concurrency = _determine_concurrency(args.parallel, len(prompts))
     try:
         results = asyncio.run(
-            _execute_prompts(prompts, provider, config, concurrency, args.rpm, lang)
+            execute_prompts(prompts, provider, config, concurrency, args.rpm, lang, _classify_error)
         )
     except KeyboardInterrupt:  # pragma: no cover - ユーザー中断
         LOGGER.warning(_msg(lang, "interrupt"))
         return 130
 
     if args.out:
-        _write_metrics(Path(args.out).expanduser().resolve(), results, args.log_prompts, lang)
-    _emit_results(results, args.format, args.log_prompts)
+        write_metrics(Path(args.out).expanduser().resolve(), results, args.log_prompts, lang)
+    emit_results(results, args.format, args.log_prompts)
     has_error = any(res.error for res in results)
     if has_error:
         LOGGER.error(_sanitize_message(_msg(lang, "prompt_errors")))


### PR DESCRIPTION
## Summary
- extract prompt collection and output helpers into `adapter/cli/prompt_io.py`
- move rate limiting and asynchronous execution into `adapter/cli/prompt_runner.py`
- update CLI entrypoint wiring to use the new modules while keeping public exports stable

## Testing
- pytest tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68d7850a4ecc8321b2e82c008256f8e6