### PR TITLE
Fix Ollama chat message variable naming collision

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -247,11 +247,11 @@ class OllamaProvider(ProviderSPI):
             return str(content)
 
         messages_payload: list[dict[str, str]] = []
-        for message in request.chat_messages:
-            if not isinstance(message, Mapping):
+        for chat_message in request.chat_messages:
+            if not isinstance(chat_message, Mapping):
                 continue
-            role = str(message.get("role", "user")) or "user"
-            text = _coerce_content(message).strip()
+            role = str(chat_message.get("role", "user")) or "user"
+            text = _coerce_content(chat_message).strip()
             if text:
                 messages_payload.append({"role": role, "content": text})
 


### PR DESCRIPTION
## Summary
- rename the chat message loop variable so it no longer clashes with payload parsing
- update content coercion usage to match the new variable name

## Testing
- mypy projects/04-llm-adapter-shadow/src --pretty

------
https://chatgpt.com/codex/tasks/task_e_68d78c673dfc83218061bbffe114eaf6