### PR TITLE
refactor: add typing aliases for ollama provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -10,12 +10,7 @@ from collections.abc import (
     Sequence,
 )
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Protocol,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 
 from ..errors import AuthError, ConfigError, RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
@@ -55,9 +50,13 @@ class _RequestsModuleProtocol(Protocol):
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing time placeholders
-    requests: _RequestsModuleProtocol | None
-    Response: type[_ResponseProtocol]
-    requests_exceptions: _RequestsExceptionsProtocol
+    RequestsModule: TypeAlias = _RequestsModuleProtocol | None
+    ResponseType: TypeAlias = type[_ResponseProtocol]
+    RequestsExceptions: TypeAlias = _RequestsExceptionsProtocol
+
+    requests: RequestsModule
+    Response: ResponseType
+    requests_exceptions: RequestsExceptions
 else:  # pragma: no cover - allow running without the optional dependency
     import importlib
 


### PR DESCRIPTION
## Summary
- introduce type alias placeholders for requests-related symbols under TYPE_CHECKING in ollama provider
- keep runtime import fallback intact while improving static typing for requests module

## Testing
- mypy projects/04-llm-adapter-shadow/src --pretty

------
https://chatgpt.com/codex/tasks/task_e_68d78ede29908321845ddd6ad225559e