### PR TITLE
Update CI concurrency for workflow_dispatch runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on: [push, pull_request]
 
 # 同じブランチで複数実行されたら古い方をキャンセル
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || '' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- adjust concurrency group to include run id only for workflow_dispatch events
- disable cancel-in-progress for workflow_dispatch while retaining it for push and pull_request events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7995f5180832180eefe6f5e25ce11