### PR TITLE
refactor: introduce Ollama client abstraction

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -2,146 +2,20 @@
 
 from __future__ import annotations
 
-import importlib
 import os
-import time
-from collections.abc import (
-    Iterable,
-    Mapping,
-    Sequence,
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ..errors import ConfigError
+from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from .ollama_client import (
+    OllamaClient,
+    _SessionProtocol,
+    requests_exceptions as _requests_exceptions,
 )
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Protocol, cast
-
-from ..errors import AuthError, ConfigError, RateLimitError, RetriableError, TimeoutError
-from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
-
-
-class _ResponseProtocol(Protocol):
-    status_code: int
-
-    def close(self) -> None: ...
-    def __enter__(self) -> _ResponseProtocol: ...
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: TracebackType | None,
-    ) -> bool | None: ...
-    def json(self) -> Any: ...
-    def raise_for_status(self) -> None: ...
-    def iter_lines(self) -> Iterable[bytes]: ...
-
-
-class _SessionProtocol(Protocol):
-    def post(self, url: str, *args: Any, **kwargs: Any) -> _ResponseProtocol: ...
-
-
-class _RequestsExceptionsProtocol(Protocol):
-    Timeout: type[Exception]
-    RequestException: type[Exception]
-    HTTPError: type[Exception]
-
-
-class _RequestsModuleProtocol(Protocol):
-    def Session(self) -> _SessionProtocol: ...
-
-    exceptions: _RequestsExceptionsProtocol
-    Response: type[_ResponseProtocol]
-
-
-requests: _RequestsModuleProtocol | None = None
-Response: type[_ResponseProtocol]
-requests_exceptions: _RequestsExceptionsProtocol
-
-
-if TYPE_CHECKING:  # pragma: no cover - typing time placeholders
-    import requests as _requests_mod  # type: ignore[import-untyped]  # noqa: F401
-    from requests import Response as _RequestsResponse  # noqa: F401
-    from requests import exceptions as _RequestsExceptions  # noqa: F401
-
-
-def _initialize_requests() -> tuple[
-    _RequestsModuleProtocol | None,
-    type[_ResponseProtocol],
-    _RequestsExceptionsProtocol,
-]:
-    try:
-        _requests_module = importlib.import_module("requests")
-    except ModuleNotFoundError:
-
-        class _FallbackRequestsExceptions:  # pragma: no cover - trivial container
-            class RequestException(Exception): ...
-            class Timeout(RequestException): ...
-            class HTTPError(RequestException):
-                def __init__(self, message: str | None = None, response: Any | None = None):
-                    super().__init__(message or "HTTP error")
-                    self.response = response
-
-        fallback_exceptions = cast(
-            _RequestsExceptionsProtocol, _FallbackRequestsExceptions()
-        )
-
-        class _FallbackResponse:
-            """Very small stub mimicking the subset of Response we rely on."""
-
-            status_code: int
-
-            def __init__(self, status_code: int = 200) -> None:
-                self.status_code = status_code
-
-            def close(self) -> None:  # pragma: no cover - trivial stub
-                return None
-
-            def __enter__(self) -> _FallbackResponse:  # pragma: no cover - stub
-                return self
-
-            def __exit__(
-                self,
-                exc_type: type[BaseException] | None,
-                exc: BaseException | None,
-                tb: TracebackType | None,
-            ) -> bool | None:  # pragma: no cover - stub
-                return None
-
-            def json(self) -> Any:  # pragma: no cover - tests supply payloads
-                return {}
-
-            def raise_for_status(self) -> None:  # pragma: no cover - stub
-                if self.status_code >= 400:
-                    raise cast(Any, fallback_exceptions.HTTPError)(response=self)
-
-            def iter_lines(self) -> Iterable[bytes]:  # pragma: no cover - stub
-                return []
-
-        return (
-            None,
-            cast(type[_ResponseProtocol], _FallbackResponse),
-            fallback_exceptions,
-        )
-
-    _typed_requests = cast(_RequestsModuleProtocol, _requests_module)
-    response_type = cast(type[_ResponseProtocol], _requests_module.Response)
-    exceptions = cast(_RequestsExceptionsProtocol, _requests_module.exceptions)
-    return _typed_requests, response_type, exceptions
-
-
-requests, Response, requests_exceptions = _initialize_requests()
 
 DEFAULT_HOST = "http://127.0.0.1:11434"
 __all__ = ["OllamaProvider", "DEFAULT_HOST"]
-
-
-def _combine_host(base: str, path: str) -> str:
-    if base.endswith("/"):
-        base = base[:-1]
-    return f"{base}{path}"
-
-
-def _token_usage_from_payload(payload: Mapping[str, Any]) -> TokenUsage:
-    prompt_tokens = int(payload.get("prompt_eval_count", 0) or 0)
-    completion_tokens = int(payload.get("eval_count", 0) or 0)
-    return TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
 
 
 class OllamaProvider(ProviderSPI):
@@ -157,21 +31,22 @@ class OllamaProvider(ProviderSPI):
         timeout: float = 60.0,
         pull_timeout: float = 300.0,
         auto_pull: bool = True,
+        client: OllamaClient | None = None,
     ) -> None:
-        # Factory/CLI で ``ProviderRequest.model`` に設定される推奨デフォルトを保持。
         self._model = model
         self._name = name or f"ollama:{model}"
         env_host = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_HOST")
-        self._host: str = host or env_host or DEFAULT_HOST
-        if session is None:
-            if requests is None:  # pragma: no cover - defensive branch
-                raise ImportError("requests is required unless a session is provided")
-            session = requests.Session()
-        self._session = session
-        self._timeout = timeout
-        self._pull_timeout = pull_timeout
-        self._auto_pull = auto_pull
-        self._ready_models: set[str] = set()
+        base_host = host or env_host or DEFAULT_HOST
+        if client is None:
+            client = OllamaClient(
+                base_host,
+                session=session,
+                timeout=timeout,
+                pull_timeout=pull_timeout,
+                auto_pull=auto_pull,
+            )
+        self._client = client
+        self._host = client.host
 
     def name(self) -> str:
         return self._name
@@ -179,81 +54,6 @@ class OllamaProvider(ProviderSPI):
     def capabilities(self) -> set[str]:
         return {"chat"}
 
-    # ------------------------------------------------------------------
-    # HTTP helpers
-    # ------------------------------------------------------------------
-    def _request(
-        self,
-        path: str,
-        payload: Mapping[str, Any],
-        *,
-        stream: bool = False,
-        timeout: float | None = None,
-    ) -> _ResponseProtocol:
-        url = _combine_host(self._host, path)
-        try:
-            response = self._session.post(
-                url,
-                json=payload,
-                stream=stream,
-                timeout=timeout or self._timeout,
-            )
-        except requests_exceptions.Timeout as exc:  # pragma: no cover - error handling
-            raise TimeoutError(f"Ollama request timed out: {url}") from exc
-        except requests_exceptions.RequestException as exc:  # pragma: no cover
-            raise RetriableError(f"Ollama request failed: {url}") from exc
-        return response
-
-    def _ensure_model(self, model_name: str) -> None:
-        if model_name in self._ready_models:
-            return
-
-        show_response = self._request("/api/show", {"model": model_name})
-        if show_response.status_code == 200:
-            self._ready_models.add(model_name)
-            show_response.close()
-            return
-        show_response.close()
-
-        if not self._auto_pull:
-            raise RetriableError(f"ollama model not available: {model_name}")
-
-        with self._request(
-            "/api/pull",
-            {"model": model_name},
-            stream=True,
-            timeout=self._pull_timeout,
-        ) as pull_response:
-            try:
-                pull_response.raise_for_status()
-            except requests_exceptions.HTTPError as exc:
-                status = pull_response.status_code
-                if status in {401, 403}:
-                    raise AuthError(str(exc)) from exc
-                if status == 429:
-                    raise RateLimitError(str(exc)) from exc
-                if status in {408, 504}:
-                    raise TimeoutError(str(exc)) from exc
-                raise RetriableError(str(exc)) from exc
-            # Drain the streaming response to complete the pull.
-            for _ in pull_response.iter_lines():  # pragma: no cover - network interaction
-                pass
-
-        # Verify again with a short retry window.
-        for _ in range(10):
-            show_after = self._request("/api/show", {"model": model_name})
-            if show_after.status_code == 200:
-                self._ready_models.add(model_name)
-                show_after.close()
-                return
-            show_after.close()
-            time.sleep(1)
-
-        raise RetriableError(f"failed to pull ollama model: {model_name}")
-
-    # ------------------------------------------------------------------
-    # ProviderSPI implementation
-    # ------------------------------------------------------------------
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
         model_name = request.model
         if not isinstance(model_name, str):
@@ -261,13 +61,13 @@ class OllamaProvider(ProviderSPI):
         model_name = model_name.strip()
         if not model_name:
             raise ConfigError("OllamaProvider requires request.model to be set")
-        self._ensure_model(model_name)
+        self._client.ensure_model(model_name)
 
         def _coerce_content(entry: Mapping[str, Any]) -> str:
             content = entry.get("content")
             if isinstance(content, str):
                 return content
-            if isinstance(content, Sequence) and not isinstance(content, bytes | bytearray):
+            if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
                 parts = [part for part in content if isinstance(part, str)]
                 return "\n".join(parts)
             if content is None:
@@ -292,7 +92,6 @@ class OllamaProvider(ProviderSPI):
             "stream": False,
         }
 
-        # --- options 統合（新SPI + 互換） ---
         options_payload: dict[str, Any] = {}
         if request.max_tokens is not None:
             options_payload["num_predict"] = int(request.max_tokens)
@@ -303,7 +102,6 @@ class OllamaProvider(ProviderSPI):
         if request.stop:
             options_payload["stop"] = list(request.stop)
 
-        # timeout の優先度: request.timeout_s > options.request_timeout_s > default
         timeout_override: float | None = None
         if request.timeout_s is not None:
             timeout_override = float(request.timeout_s)
@@ -311,7 +109,6 @@ class OllamaProvider(ProviderSPI):
         if request.options and isinstance(request.options, Mapping):
             opt_items = dict(request.options.items())
 
-            # timeout 上書き (options 側)
             for key in ("request_timeout_s", "REQUEST_TIMEOUT_S"):
                 if key in opt_items:
                     raw_timeout = opt_items.pop(key)
@@ -324,45 +121,20 @@ class OllamaProvider(ProviderSPI):
                             ) from exc
                     break
 
-            # 衝突しうるトップレベルは除去
             for k in ("model", "messages", "prompt"):
                 opt_items.pop(k, None)
 
-            # ネストした options をマージ
             nested_opts = opt_items.pop("options", None)
             if isinstance(nested_opts, Mapping):
                 options_payload.update(dict(nested_opts))
 
-            # 残りはトップレベルに反映（Ollamaが理解する追加パラメータ）
             for k, v in opt_items.items():
                 payload[k] = v
 
         if options_payload:
             payload["options"] = {**options_payload, **payload.get("options", {})}
 
-        ts0 = time.time()
-        response = self._request("/api/chat", payload, timeout=timeout_override)
-
-        try:
-            try:
-                response.raise_for_status()
-            except requests_exceptions.HTTPError as exc:
-                status = response.status_code
-                if status in {401, 403}:
-                    raise AuthError(str(exc)) from exc
-                if status == 429:
-                    raise RateLimitError(str(exc)) from exc
-                if status in {408, 504}:
-                    raise TimeoutError(str(exc)) from exc
-                if status >= 500:
-                    raise RetriableError(str(exc)) from exc
-                raise RetriableError(str(exc)) from exc
-
-            payload_json = response.json()
-        except ValueError as exc:
-            raise RetriableError("invalid JSON from Ollama") from exc
-        finally:
-            response.close()
+        payload_json, latency_ms = self._client.chat(payload, timeout=timeout_override)
 
         message = payload_json.get("message")
         text = ""
@@ -373,8 +145,7 @@ class OllamaProvider(ProviderSPI):
         if not isinstance(text, str):
             text = ""
 
-        latency_ms = int((time.time() - ts0) * 1000)
-        usage = _token_usage_from_payload(payload_json)
+        usage = self._client.token_usage_from_payload(payload_json)
 
         return ProviderResponse(
             text=text,
@@ -384,3 +155,5 @@ class OllamaProvider(ProviderSPI):
             finish_reason=payload_json.get("done_reason"),
             raw=payload_json,
         )
+
+requests_exceptions = _requests_exceptions

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -1,0 +1,267 @@
+"""HTTP client helpers for the Ollama provider."""
+
+from __future__ import annotations
+
+import importlib
+import time
+from collections.abc import Iterable, Mapping
+from types import TracebackType
+from typing import Any, Protocol, cast
+
+from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from ..provider_spi import TokenUsage
+
+
+class _ResponseProtocol(Protocol):
+    status_code: int
+
+    def close(self) -> None: ...
+    def __enter__(self) -> _ResponseProtocol: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None: ...
+    def json(self) -> Any: ...
+    def raise_for_status(self) -> None: ...
+    def iter_lines(self) -> Iterable[bytes]: ...
+
+
+class _SessionProtocol(Protocol):
+    def post(self, url: str, *args: Any, **kwargs: Any) -> _ResponseProtocol: ...
+
+
+class _RequestsExceptionsProtocol(Protocol):
+    Timeout: type[Exception]
+    RequestException: type[Exception]
+    HTTPError: type[Exception]
+
+
+class _RequestsModuleProtocol(Protocol):
+    def Session(self) -> _SessionProtocol: ...
+
+    exceptions: _RequestsExceptionsProtocol
+    Response: type[_ResponseProtocol]
+
+
+requests: _RequestsModuleProtocol | None
+Response: type[_ResponseProtocol]
+requests_exceptions: _RequestsExceptionsProtocol
+
+
+def _initialize_requests() -> tuple[
+    _RequestsModuleProtocol | None,
+    type[_ResponseProtocol],
+    _RequestsExceptionsProtocol,
+]:
+    try:
+        _requests_module = importlib.import_module("requests")
+    except ModuleNotFoundError:
+
+        class _FallbackRequestsExceptions:  # pragma: no cover - trivial container
+            class RequestException(Exception): ...
+            class Timeout(RequestException): ...
+            class HTTPError(RequestException):
+                def __init__(self, message: str | None = None, response: Any | None = None):
+                    super().__init__(message or "HTTP error")
+                    self.response = response
+
+        fallback_exceptions = cast(
+            _RequestsExceptionsProtocol, _FallbackRequestsExceptions()
+        )
+
+        class _FallbackResponse:
+            """Very small stub mimicking the subset of Response we rely on."""
+
+            status_code: int
+
+            def __init__(self, status_code: int = 200) -> None:
+                self.status_code = status_code
+
+            def close(self) -> None:  # pragma: no cover - trivial stub
+                return None
+
+            def __enter__(self) -> _FallbackResponse:  # pragma: no cover - stub
+                return self
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                tb: TracebackType | None,
+            ) -> bool | None:  # pragma: no cover - stub
+                return None
+
+            def json(self) -> Any:  # pragma: no cover - tests supply payloads
+                return {}
+
+            def raise_for_status(self) -> None:  # pragma: no cover - stub
+                if self.status_code >= 400:
+                    raise cast(Any, fallback_exceptions.HTTPError)(response=self)
+
+            def iter_lines(self) -> Iterable[bytes]:  # pragma: no cover - stub
+                return []
+
+        return (
+            None,
+            cast(type[_ResponseProtocol], _FallbackResponse),
+            fallback_exceptions,
+        )
+
+    _typed_requests = cast(_RequestsModuleProtocol, _requests_module)
+    response_type = cast(type[_ResponseProtocol], _requests_module.Response)
+    exceptions = cast(_RequestsExceptionsProtocol, _requests_module.exceptions)
+    return _typed_requests, response_type, exceptions
+
+
+requests, Response, requests_exceptions = _initialize_requests()
+
+
+def _combine_host(base: str, path: str) -> str:
+    if base.endswith("/"):
+        base = base[:-1]
+    return f"{base}{path}"
+
+
+def _token_usage_from_payload(payload: Mapping[str, Any]) -> TokenUsage:
+    prompt_tokens = int(payload.get("prompt_eval_count", 0) or 0)
+    completion_tokens = int(payload.get("eval_count", 0) or 0)
+    return TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
+
+
+class OllamaClient:
+    def __init__(
+        self,
+        host: str,
+        *,
+        session: _SessionProtocol | None = None,
+        timeout: float = 60.0,
+        pull_timeout: float = 300.0,
+        auto_pull: bool = True,
+    ) -> None:
+        if session is None:
+            if requests is None:  # pragma: no cover - defensive branch
+                raise ImportError("requests is required unless a session is provided")
+            session = requests.Session()
+        self._host = host
+        self._session = session
+        self._timeout = timeout
+        self._pull_timeout = pull_timeout
+        self._auto_pull = auto_pull
+        self._ready_models: set[str] = set()
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    def _request(
+        self,
+        path: str,
+        payload: Mapping[str, Any],
+        *,
+        stream: bool = False,
+        timeout: float | None = None,
+    ) -> _ResponseProtocol:
+        url = _combine_host(self._host, path)
+        try:
+            response = self._session.post(
+                url,
+                json=payload,
+                stream=stream,
+                timeout=timeout or self._timeout,
+            )
+        except requests_exceptions.Timeout as exc:  # pragma: no cover - error handling
+            raise TimeoutError(f"Ollama request timed out: {url}") from exc
+        except requests_exceptions.RequestException as exc:  # pragma: no cover
+            raise RetriableError(f"Ollama request failed: {url}") from exc
+        return response
+
+    def ensure_model(self, model_name: str) -> None:
+        if model_name in self._ready_models:
+            return
+
+        show_response = self._request("/api/show", {"model": model_name})
+        if show_response.status_code == 200:
+            self._ready_models.add(model_name)
+            show_response.close()
+            return
+        show_response.close()
+
+        if not self._auto_pull:
+            raise RetriableError(f"ollama model not available: {model_name}")
+
+        with self._request(
+            "/api/pull",
+            {"model": model_name},
+            stream=True,
+            timeout=self._pull_timeout,
+        ) as pull_response:
+            try:
+                pull_response.raise_for_status()
+            except requests_exceptions.HTTPError as exc:
+                status = pull_response.status_code
+                if status in {401, 403}:
+                    raise AuthError(str(exc)) from exc
+                if status == 429:
+                    raise RateLimitError(str(exc)) from exc
+                if status in {408, 504}:
+                    raise TimeoutError(str(exc)) from exc
+                raise RetriableError(str(exc)) from exc
+            for _ in pull_response.iter_lines():  # pragma: no cover - network interaction
+                pass
+
+        for _ in range(10):
+            show_after = self._request("/api/show", {"model": model_name})
+            if show_after.status_code == 200:
+                self._ready_models.add(model_name)
+                show_after.close()
+                return
+            show_after.close()
+            time.sleep(1)
+
+        raise RetriableError(f"failed to pull ollama model: {model_name}")
+
+    def chat(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> tuple[Mapping[str, Any], int]:
+        ts0 = time.time()
+        response = self._request("/api/chat", payload, timeout=timeout)
+
+        try:
+            try:
+                response.raise_for_status()
+            except requests_exceptions.HTTPError as exc:
+                status = response.status_code
+                if status in {401, 403}:
+                    raise AuthError(str(exc)) from exc
+                if status == 429:
+                    raise RateLimitError(str(exc)) from exc
+                if status in {408, 504}:
+                    raise TimeoutError(str(exc)) from exc
+                if status >= 500:
+                    raise RetriableError(str(exc)) from exc
+                raise RetriableError(str(exc)) from exc
+
+            payload_json = cast(Mapping[str, Any], response.json())
+        except ValueError as exc:
+            raise RetriableError("invalid JSON from Ollama") from exc
+        finally:
+            response.close()
+
+        latency_ms = int((time.time() - ts0) * 1000)
+        return payload_json, latency_ms
+
+    def token_usage_from_payload(self, payload: Mapping[str, Any]) -> TokenUsage:
+        return _token_usage_from_payload(payload)
+
+
+__all__ = [
+    "OllamaClient",
+    "Response",
+    "requests",
+    "requests_exceptions",
+]

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from src.llm_adapter.errors import AuthError
+from src.llm_adapter.providers.ollama_client import (
+    OllamaClient,
+    _combine_host,
+    _token_usage_from_payload,
+)
+from tests.helpers.fakes import FakeResponse, FakeSession
+
+
+def test_combine_host_trims_trailing_slash():
+    assert _combine_host("http://localhost/", "/api") == "http://localhost/api"
+
+
+def test_token_usage_from_payload_extracts_counts():
+    usage = _token_usage_from_payload({"prompt_eval_count": 4, "eval_count": 6})
+    assert usage.prompt == 4
+    assert usage.completion == 6
+
+
+def test_ollama_client_chat_maps_auth_error():
+    class Session(FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):
+            if url.endswith("/api/show"):
+                return FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                return FakeResponse(status_code=401, payload={})
+            raise AssertionError(f"unexpected url: {url}")
+
+    client = OllamaClient("http://localhost", session=Session())
+
+    with pytest.raises(AuthError):
+        client.chat({"model": "foo", "messages": []})
+
+
+def test_ollama_client_chat_success():
+    class Session(FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):
+            if url.endswith("/api/show"):
+                return FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                return FakeResponse(
+                    status_code=200,
+                    payload={
+                        "message": {"content": "hi"},
+                        "prompt_eval_count": 2,
+                        "eval_count": 3,
+                    },
+                )
+            raise AssertionError(f"unexpected url: {url}")
+
+    client = OllamaClient("http://localhost", session=Session())
+
+    payload, latency_ms = client.chat({"model": "foo", "messages": []})
+    assert payload["message"]["content"] == "hi"
+    assert latency_ms >= 0
+    usage = client.token_usage_from_payload(payload)
+    assert usage.prompt == 2
+    assert usage.completion == 3


### PR DESCRIPTION
## Summary
- extract the request protocols and helper utilities into a dedicated `OllamaClient`
- refactor `OllamaProvider` to depend on `OllamaClient`, enabling injection in tests
- cover the new client utilities with unit tests alongside existing provider cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a30e20308321b960ee3ee7ec75ea