### PR TITLE
Refactor spec2cases parsing and validation modules

### DIFF
--- a/projects/01-spec2cases-md2json/scripts/spec2cases.mjs
+++ b/projects/01-spec2cases-md2json/scripts/spec2cases.mjs
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
-import fs from 'node:fs';
 import path from 'node:path';
 
+import {
+  parseSpecFile,
+  saveCases,
+  resolveInputPath,
+} from '../src/index.js';
+import { validateCasesSchema } from '../src/validate-schema.js';
 import { SPEC2CASES_SAMPLE_CASES_PATH } from '../../../scripts/paths.mjs';
 
 function usage() {
@@ -9,271 +14,21 @@ function usage() {
   console.error(`       (no args) -> defaults to ${SPEC2CASES_SAMPLE_CASES_PATH}`);
 }
 
-function readFile(filePath) {
-  try {
-    return fs.readFileSync(filePath, 'utf8');
-  } catch (error) {
-    const message = error && typeof error.message === 'string' ? error.message : String(error);
-    throw new Error(`Failed to read "${filePath}": ${message}`);
-  }
-}
-
-function normaliseBullet(line) {
-  return line
-    .replace(/^[-*\d.\)\s]+/, '')
-    .trim();
-}
-
-function parseListSection(lines, startIndex) {
-  const values = [];
-  let index = startIndex;
-  for (; index < lines.length; index += 1) {
-    const raw = lines[index];
-    const trimmed = raw.trim();
-    if (!trimmed) continue;
-
-    if (/^(suite|case|title|pre|steps?|expected|tags)\s*:/i.test(trimmed)) {
-      break;
-    }
-    if (/^[-*\d]/.test(trimmed)) {
-      const normalised = normaliseBullet(trimmed);
-      if (normalised) values.push(normalised);
-      continue;
-    }
-    if (values.length) {
-      const merged = `${values[values.length - 1]} ${trimmed}`.trim();
-      values[values.length - 1] = merged;
-      continue;
-    }
-    values.push(trimmed);
-  }
-  return { values, nextIndex: index - 1 };
-}
-
-function parseSpecText(text) {
-  const lines = text.split(/\r?\n/);
-  let suite = '';
-  const cases = [];
-  let current = null;
-  let currentSection = null;
-
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i];
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-
-    const suiteMatch =
-      trimmed.match(/^suite\s*:\s*(.+)$/i) || trimmed.match(/^#\s+(.+)$/);
-    if (suiteMatch) {
-      suite = suiteMatch[1].trim();
-      continue;
-    }
-
-    const caseHeadingMatch = trimmed.match(/^##\s+(\S+)(?:\s+(.+))?$/);
-    if (caseHeadingMatch) {
-      if (current) cases.push(current);
-      const [, headingId, headingTitle = ''] = caseHeadingMatch;
-      current = {
-        id: headingId.trim(),
-        title: headingTitle.trim(),
-        pre: [],
-        steps: [],
-        expected: [],
-        tags: [],
-      };
-      currentSection = null;
-      continue;
-    }
-
-    const caseMatch = trimmed.match(/^case\s*:\s*(.+)$/i);
-    if (caseMatch) {
-      if (current) cases.push(current);
-      current = {
-        id: caseMatch[1].trim(),
-        title: '',
-        pre: [],
-        steps: [],
-        expected: [],
-        tags: [],
-      };
-      currentSection = null;
-      continue;
-    }
-
-    if (!current) continue;
-
-    const normalisedLine = normaliseBullet(trimmed);
-
-    const titleMatch = normalisedLine.match(/^title\s*:\s*(.+)$/i);
-    if (titleMatch) {
-      current.title = titleMatch[1].trim();
-      currentSection = null;
-      continue;
-    }
-
-    if (/^pre\s*:/i.test(normalisedLine)) {
-      currentSection = 'pre';
-      const inlineValue = normalisedLine.replace(/^pre\s*:\s*/i, '').trim();
-      if (inlineValue) {
-        current.pre.push(inlineValue);
-      } else {
-        const { values, nextIndex } = parseListSection(lines, i + 1);
-        current.pre.push(...values);
-        i = nextIndex;
-      }
-      continue;
-    }
-
-    if (/^steps?\s*:/i.test(normalisedLine)) {
-      currentSection = 'steps';
-      const inlineValue = normalisedLine.replace(/^steps?\s*:\s*/i, '').trim();
-      if (inlineValue) {
-        current.steps.push(inlineValue);
-      } else {
-        const { values, nextIndex } = parseListSection(lines, i + 1);
-        current.steps.push(...values);
-        i = nextIndex;
-      }
-      continue;
-    }
-
-    if (/^expected\s*:/i.test(normalisedLine)) {
-      currentSection = 'expected';
-      const inlineValue = normalisedLine.replace(/^expected\s*:\s*/i, '').trim();
-      if (inlineValue) {
-        current.expected.push(inlineValue);
-      } else {
-        const { values, nextIndex } = parseListSection(lines, i + 1);
-        current.expected.push(...values);
-        i = nextIndex;
-      }
-      continue;
-    }
-
-    const tagsMatch = normalisedLine.match(/^(tags?)\s*:\s*(.+)$/i);
-    if (tagsMatch) {
-      const [, label, value] = tagsMatch;
-      const tokens = value
-        .split(/[\s,\u3001]+/)
-        .map((token) => token.trim())
-        .filter(Boolean);
-      if (label.toLowerCase() === 'tag') {
-        current.tags.push(...tokens);
-      } else {
-        current.tags = tokens;
-      }
-      currentSection = null;
-      continue;
-    }
-
-    if (currentSection) {
-      const targetArray = current[currentSection];
-      const normalised = normalisedLine;
-      if (!normalised) continue;
-
-      if (targetArray.length) {
-        const merged = `${targetArray[targetArray.length - 1]} ${normalised}`.trim();
-        targetArray[targetArray.length - 1] = merged;
-      } else {
-        targetArray.push(normalised);
-      }
-    }
-  }
-
-  if (current) cases.push(current);
-  return { suite: suite.trim(), cases };
-}
-
-function ensureArrayOfStrings(value) {
-  if (!Array.isArray(value)) return false;
-  return value.every((item) => typeof item === 'string' && item.trim().length > 0);
-}
-
-function validateCaseStructure(testCase, index, errors) {
-  const prefix = `cases[${index}]`;
-  if (!testCase || typeof testCase !== 'object') {
-    errors.push(`${prefix} must be an object`);
-    return;
-  }
-
-  if (typeof testCase.id !== 'string' || testCase.id.trim().length === 0) {
-    errors.push(`${prefix}.id must be a non-empty string`);
-  }
-  if (typeof testCase.title !== 'string' || testCase.title.trim().length === 0) {
-    errors.push(`${prefix}.title must be a non-empty string`);
-  }
-  if (!ensureArrayOfStrings(testCase.pre)) {
-    errors.push(`${prefix}.pre must be an array of non-empty strings`);
-  }
-  if (!ensureArrayOfStrings(testCase.steps)) {
-    errors.push(`${prefix}.steps must be an array of non-empty strings`);
-  }
-  if (!ensureArrayOfStrings(testCase.expected)) {
-    errors.push(`${prefix}.expected must be an array of non-empty strings`);
-  }
-  if (!ensureArrayOfStrings(testCase.tags)) {
-    errors.push(`${prefix}.tags must be an array of non-empty strings`);
-  }
-}
-
-export function validateCasesSchema(data) {
-  const errors = [];
-  if (!data || typeof data !== 'object') {
-    errors.push('root must be an object');
-    return errors;
-  }
-  if (typeof data.suite !== 'string' || data.suite.trim().length === 0) {
-    errors.push('suite must be a non-empty string');
-  }
-  if (!Array.isArray(data.cases)) {
-    errors.push('cases must be an array');
-  } else if (data.cases.length === 0) {
-    errors.push('cases must contain at least one item');
-  } else {
-    data.cases.forEach((testCase, index) => {
-      validateCaseStructure(testCase, index, errors);
-    });
-  }
-  return errors;
-}
-
-export function parseSpecFile(filePath) {
-  const ext = path.extname(filePath).toLowerCase();
-  const raw = readFile(filePath);
-  if (ext === '.json') {
-    let parsed;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (error) {
-      throw new Error(`Invalid JSON: ${(error && error.message) || error}`);
-    }
-    return parsed;
-  }
-  if (ext === '.txt' || ext === '.md') {
-    return parseSpecText(raw);
-  }
-  throw new Error(`Unsupported file extension for "${filePath}"`);
-}
-
-export function saveCases(result, outputPath) {
-  const json = `${JSON.stringify(result, null, 2)}\n`;
-  fs.writeFileSync(outputPath, json, 'utf8');
-}
-
 function main(argv) {
-  let [, , inputPath, outputPath] = argv;
+  let [, , rawInputPath, outputPath] = argv;
 
-  // Default to sample file if no input provided (retains main-branch behavior)
-  if (!inputPath) {
-    if (fs.existsSync(SPEC2CASES_SAMPLE_CASES_PATH)) {
-      console.log(
-        `ℹ️  No path provided. Defaulting to sample cases: ${SPEC2CASES_SAMPLE_CASES_PATH}`,
-      );
-      inputPath = SPEC2CASES_SAMPLE_CASES_PATH;
-    } else {
-      usage();
-      process.exit(2);
-    }
+  let resolution;
+  try {
+    resolution = resolveInputPath(rawInputPath, SPEC2CASES_SAMPLE_CASES_PATH);
+  } catch (error) {
+    usage();
+    console.error(error.message);
+    process.exit(2);
+  }
+
+  const { path: inputPath, usedDefault } = resolution;
+  if (usedDefault) {
+    console.log(`ℹ️  No path provided. Defaulting to sample cases: ${SPEC2CASES_SAMPLE_CASES_PATH}`);
   }
 
   let parsed;
@@ -295,7 +50,6 @@ function main(argv) {
     saveCases(parsed, outputPath);
     console.log(`📝 Wrote ${parsed.cases.length} cases to ${outputPath}`);
   } else if (path.extname(inputPath).toLowerCase() !== '.json') {
-    // When parsing from text/markdown and no output is specified, print the JSON to stdout
     console.log(JSON.stringify(parsed, null, 2));
   }
 

--- a/projects/01-spec2cases-md2json/src/index.js
+++ b/projects/01-spec2cases-md2json/src/index.js
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { parseSpecText } from './parse-spec.js';
+
+function readFile(filePath, fsModule = fs) {
+  try {
+    return fsModule.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    const message = error && typeof error.message === 'string' ? error.message : String(error);
+    throw new Error(`Failed to read "${filePath}": ${message}`);
+  }
+}
+
+export function parseSpecFile(filePath, fsModule = fs) {
+  const ext = path.extname(filePath).toLowerCase();
+  const raw = readFile(filePath, fsModule);
+  if (ext === '.json') {
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Invalid JSON: ${(error && error.message) || error}`);
+    }
+  }
+  if (ext === '.txt' || ext === '.md') {
+    return parseSpecText(raw);
+  }
+  throw new Error(`Unsupported file extension for "${filePath}"`);
+}
+
+export function saveCases(result, outputPath, fsModule = fs) {
+  const json = `${JSON.stringify(result, null, 2)}\n`;
+  fsModule.writeFileSync(outputPath, json, 'utf8');
+}
+
+export function resolveInputPath(inputPath, fallbackPath, fsModule = fs) {
+  if (inputPath) {
+    return { path: inputPath, usedDefault: false };
+  }
+  if (fallbackPath && fsModule.existsSync(fallbackPath)) {
+    return { path: fallbackPath, usedDefault: true };
+  }
+  throw new Error('Input path is required and no default sample was found');
+}
+
+export { parseSpecText } from './parse-spec.js';

--- a/projects/01-spec2cases-md2json/src/parse-spec.js
+++ b/projects/01-spec2cases-md2json/src/parse-spec.js
@@ -1,0 +1,163 @@
+function normaliseBullet(line) {
+  return line.replace(/^[-*\d.\)\s]+/, '').trim();
+}
+
+function parseListSection(lines, startIndex) {
+  const values = [];
+  let index = startIndex;
+  for (; index < lines.length; index += 1) {
+    const raw = lines[index];
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    if (/^(suite|case|title|pre|steps?|expected|tags)\s*:/i.test(trimmed)) {
+      break;
+    }
+    if (/^[-*\d]/.test(trimmed)) {
+      const normalised = normaliseBullet(trimmed);
+      if (normalised) values.push(normalised);
+      continue;
+    }
+    if (values.length) {
+      const merged = `${values[values.length - 1]} ${trimmed}`.trim();
+      values[values.length - 1] = merged;
+      continue;
+    }
+    values.push(trimmed);
+  }
+  return { values, nextIndex: index - 1 };
+}
+
+export function parseSpecText(text) {
+  const lines = text.split(/\r?\n/);
+  let suite = '';
+  const cases = [];
+  let current = null;
+  let currentSection = null;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const suiteMatch =
+      trimmed.match(/^suite\s*:\s*(.+)$/i) || trimmed.match(/^#\s+(.+)$/);
+    if (suiteMatch) {
+      suite = suiteMatch[1].trim();
+      continue;
+    }
+
+    const caseHeadingMatch = trimmed.match(/^##\s+(\S+)(?:\s+(.+))?$/);
+    if (caseHeadingMatch) {
+      if (current) cases.push(current);
+      const [, headingId, headingTitle = ''] = caseHeadingMatch;
+      current = {
+        id: headingId.trim(),
+        title: headingTitle.trim(),
+        pre: [],
+        steps: [],
+        expected: [],
+        tags: [],
+      };
+      currentSection = null;
+      continue;
+    }
+
+    const caseMatch = trimmed.match(/^case\s*:\s*(.+)$/i);
+    if (caseMatch) {
+      if (current) cases.push(current);
+      current = {
+        id: caseMatch[1].trim(),
+        title: '',
+        pre: [],
+        steps: [],
+        expected: [],
+        tags: [],
+      };
+      currentSection = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    const normalisedLine = normaliseBullet(trimmed);
+
+    const titleMatch = normalisedLine.match(/^title\s*:\s*(.+)$/i);
+    if (titleMatch) {
+      current.title = titleMatch[1].trim();
+      currentSection = null;
+      continue;
+    }
+
+    if (/^pre\s*:/i.test(normalisedLine)) {
+      currentSection = 'pre';
+      const inlineValue = normalisedLine.replace(/^pre\s*:\s*/i, '').trim();
+      if (inlineValue) {
+        current.pre.push(inlineValue);
+      } else {
+        const { values, nextIndex } = parseListSection(lines, i + 1);
+        current.pre.push(...values);
+        i = nextIndex;
+      }
+      continue;
+    }
+
+    if (/^steps?\s*:/i.test(normalisedLine)) {
+      currentSection = 'steps';
+      const inlineValue = normalisedLine.replace(/^steps?\s*:\s*/i, '').trim();
+      if (inlineValue) {
+        current.steps.push(inlineValue);
+      } else {
+        const { values, nextIndex } = parseListSection(lines, i + 1);
+        current.steps.push(...values);
+        i = nextIndex;
+      }
+      continue;
+    }
+
+    if (/^expected\s*:/i.test(normalisedLine)) {
+      currentSection = 'expected';
+      const inlineValue = normalisedLine.replace(/^expected\s*:\s*/i, '').trim();
+      if (inlineValue) {
+        current.expected.push(inlineValue);
+      } else {
+        const { values, nextIndex } = parseListSection(lines, i + 1);
+        current.expected.push(...values);
+        i = nextIndex;
+      }
+      continue;
+    }
+
+    const tagsMatch = normalisedLine.match(/^(tags?)\s*:\s*(.+)$/i);
+    if (tagsMatch) {
+      const [, label, value] = tagsMatch;
+      const tokens = value
+        .split(/[\s,\u3001]+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+      if (label.toLowerCase() === 'tag') {
+        current.tags.push(...tokens);
+      } else {
+        current.tags = tokens;
+      }
+      currentSection = null;
+      continue;
+    }
+
+    if (currentSection) {
+      const targetArray = current[currentSection];
+      const normalised = normalisedLine;
+      if (!normalised) continue;
+
+      if (targetArray.length) {
+        const merged = `${targetArray[targetArray.length - 1]} ${normalised}`.trim();
+        targetArray[targetArray.length - 1] = merged;
+      } else {
+        targetArray.push(normalised);
+      }
+    }
+  }
+
+  if (current) cases.push(current);
+  return { suite: suite.trim(), cases };
+}

--- a/projects/01-spec2cases-md2json/src/validate-schema.js
+++ b/projects/01-spec2cases-md2json/src/validate-schema.js
@@ -1,0 +1,52 @@
+export function ensureArrayOfStrings(value) {
+  if (!Array.isArray(value)) return false;
+  return value.every((item) => typeof item === 'string' && item.trim().length > 0);
+}
+
+export function validateCaseStructure(testCase, index, errors) {
+  const prefix = `cases[${index}]`;
+  if (!testCase || typeof testCase !== 'object') {
+    errors.push(`${prefix} must be an object`);
+    return;
+  }
+
+  if (typeof testCase.id !== 'string' || testCase.id.trim().length === 0) {
+    errors.push(`${prefix}.id must be a non-empty string`);
+  }
+  if (typeof testCase.title !== 'string' || testCase.title.trim().length === 0) {
+    errors.push(`${prefix}.title must be a non-empty string`);
+  }
+  if (!ensureArrayOfStrings(testCase.pre)) {
+    errors.push(`${prefix}.pre must be an array of non-empty strings`);
+  }
+  if (!ensureArrayOfStrings(testCase.steps)) {
+    errors.push(`${prefix}.steps must be an array of non-empty strings`);
+  }
+  if (!ensureArrayOfStrings(testCase.expected)) {
+    errors.push(`${prefix}.expected must be an array of non-empty strings`);
+  }
+  if (!ensureArrayOfStrings(testCase.tags)) {
+    errors.push(`${prefix}.tags must be an array of non-empty strings`);
+  }
+}
+
+export function validateCasesSchema(data) {
+  const errors = [];
+  if (!data || typeof data !== 'object') {
+    errors.push('root must be an object');
+    return errors;
+  }
+  if (typeof data.suite !== 'string' || data.suite.trim().length === 0) {
+    errors.push('suite must be a non-empty string');
+  }
+  if (!Array.isArray(data.cases)) {
+    errors.push('cases must be an array');
+  } else if (data.cases.length === 0) {
+    errors.push('cases must contain at least one item');
+  } else {
+    data.cases.forEach((testCase, index) => {
+      validateCaseStructure(testCase, index, errors);
+    });
+  }
+  return errors;
+}

--- a/tests/spec2cases.test.mjs
+++ b/tests/spec2cases.test.mjs
@@ -1,10 +1,30 @@
+import test from 'node:test';
 import assert from 'node:assert';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-import { parseSpecFile, validateCasesSchema } from '../projects/01-spec2cases-md2json/scripts/spec2cases.mjs';
-import { SPEC2CASES_SAMPLE_SPEC_MD_PATH } from '../scripts/paths.mjs';
+import {
+  parseSpecText,
+  parseSpecFile,
+} from '../projects/01-spec2cases-md2json/src/index.js';
+import {
+  ensureArrayOfStrings,
+  validateCasesSchema,
+} from '../projects/01-spec2cases-md2json/src/validate-schema.js';
+import {
+  SPEC2CASES_SAMPLE_CASES_PATH,
+  SPEC2CASES_SAMPLE_SPEC_MD_PATH,
+} from '../scripts/paths.mjs';
 
-test('markdown specs with headings are parsed into cases', () => {
-  const result = parseSpecFile(SPEC2CASES_SAMPLE_SPEC_MD_PATH);
+const CLI_PATH = fileURLToPath(
+  new URL('../projects/01-spec2cases-md2json/scripts/spec2cases.mjs', import.meta.url),
+);
+
+const SAMPLE_SPEC_TEXT = fs.readFileSync(SPEC2CASES_SAMPLE_SPEC_MD_PATH, 'utf8');
+
+test('parseSpecText transforms markdown specs into structured cases', () => {
+  const result = parseSpecText(SAMPLE_SPEC_TEXT);
 
   assert.equal(result.suite, 'ログイン機能');
   assert.equal(result.cases.length, 2);
@@ -28,7 +48,51 @@ test('markdown specs with headings are parsed into cases', () => {
   ]);
   assert.deepEqual(second.expected, ["エラートースト 'Invalid credentials'"]);
   assert.deepEqual(second.tags, ['negative']);
+});
 
-  const errors = validateCasesSchema(result);
-  assert.deepEqual(errors, []);
+test('parseSpecFile reads json and markdown formats', () => {
+  const markdownResult = parseSpecFile(SPEC2CASES_SAMPLE_SPEC_MD_PATH);
+  assert.equal(markdownResult.cases.length, 2);
+
+  const jsonResult = parseSpecFile(SPEC2CASES_SAMPLE_CASES_PATH);
+  assert.equal(jsonResult.cases.length, 2);
+});
+
+test('validateCasesSchema reports detailed errors', () => {
+  const invalid = {
+    suite: '',
+    cases: [
+      {
+        id: '',
+        title: ' ',
+        pre: [''],
+        steps: null,
+        expected: [' '],
+        tags: [1],
+      },
+      'not-object',
+    ],
+  };
+
+  const errors = validateCasesSchema(invalid);
+  assert(errors.includes('suite must be a non-empty string'));
+  assert(errors.includes('cases[0].id must be a non-empty string'));
+  assert(errors.includes('cases[0].steps must be an array of non-empty strings'));
+  assert(errors.includes('cases[0].expected must be an array of non-empty strings'));
+  assert(errors.includes('cases[0].tags must be an array of non-empty strings'));
+  assert(errors.includes('cases[1] must be an object'));
+
+  assert.equal(ensureArrayOfStrings(['a', 'b']), true);
+  assert.equal(ensureArrayOfStrings(['a', '']), false);
+  assert.equal(ensureArrayOfStrings('nope'), false);
+});
+
+test('CLI validates inputs and prints summary', () => {
+  const result = spawnSync(process.execPath, [CLI_PATH, SPEC2CASES_SAMPLE_SPEC_MD_PATH], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /✅ Valid cases/);
+  assert.match(result.stdout, /"ログイン機能"/);
 });


### PR DESCRIPTION
## Summary
- extract markdown parsing into projects/01-spec2cases-md2json/src/parse-spec.js and expose file helpers from src/index.js
- move schema validation helpers into src/validate-schema.js and update the CLI wrapper to use the new modules
- expand spec2cases tests with parser, validator, and CLI coverage via node --test

## Testing
- node --test tests/spec2cases.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d7a316d9f88321b0c30be3d82f31ec