### PR TITLE
Refactor JUnit stream parser extraction

### DIFF
--- a/projects/03-ci-flaky/src/junit-parser.js
+++ b/projects/03-ci-flaky/src/junit-parser.js
@@ -1,22 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { createJUnitStreamParser } from './junit/stream-parser.js';
 import { classifyFailureByMessage, createFailureSignature, applyTimeoutClassification } from './classification.js';
-
-const ATTRIBUTE_REGEX = /([:\w.-]+)(?:\s*=\s*("([^"]*)"|'([^']*)'|([^\s'"=<>`]+)))?/g;
-
-function parseAttributes(raw) {
-  const attrs = {};
-  let match;
-  while ((match = ATTRIBUTE_REGEX.exec(raw)) !== null) {
-    const [, key, , dbl, sgl, bare] = match;
-    if (dbl !== undefined) attrs[key] = dbl;
-    else if (sgl !== undefined) attrs[key] = sgl;
-    else if (bare !== undefined) attrs[key] = bare;
-    else attrs[key] = '';
-  }
-  return attrs;
-}
 
 function buildSuiteName(stack) {
   const names = stack.map((entry) => entry.fullName).filter(Boolean);
@@ -69,224 +55,106 @@ function decodeEntities(text) {
   });
 }
 
+function normaliseText(node) {
+  if (!node) return node;
+  const text = decodeEntities(node.text || '').trim();
+  return { ...node, text };
+}
+
+function mapOutput(nodes) {
+  return nodes
+    .map((item) => decodeEntities(item.text || '').trim())
+    .filter(Boolean);
+}
+
+function finaliseTestcase(node, suiteStack, suiteDurations) {
+  const suiteName = buildSuiteName(suiteStack);
+  const className = buildClassName(node.attrs, suiteStack);
+  const params = node.attrs.parameters || node.attrs.params || node.attrs.param || null;
+  const testName = node.attrs.name || node.attrs.id || 'unknown-test';
+  const canonicalId = buildCanonicalId({ suite: suiteName, className, testName, params });
+  const durationMs = node.attrs.time ? Number(node.attrs.time) * 1000 : 0;
+  const status = node.skipped
+    ? 'skipped'
+    : node.errors.length
+      ? 'error'
+      : node.failures.length
+        ? 'fail'
+        : 'pass';
+
+  if (!suiteDurations.has(suiteName)) suiteDurations.set(suiteName, []);
+  if (status !== 'skipped') suiteDurations.get(suiteName).push(durationMs);
+
+  const failureNodes = status === 'fail' ? node.failures : status === 'error' ? node.errors : [];
+  let failureMessage = null;
+  let failureDetails = null;
+  if (failureNodes.length) {
+    const texts = [];
+    const messages = [];
+    for (const failure of failureNodes) {
+      const normalised = normaliseText(failure);
+      const message = normalised.attrs.message || normalised.attrs.type || '';
+      if (message) messages.push(message);
+      if (normalised.text) texts.push(normalised.text);
+    }
+    failureMessage = messages.join(' | ') || null;
+    failureDetails = texts.join('\n\n') || null;
+  }
+
+  const signature = createFailureSignature(failureMessage, failureDetails);
+  const failureKind = failureNodes.length
+    ? classifyFailureByMessage(failureMessage, failureDetails) || 'nondeterministic'
+    : null;
+
+  return {
+    suite: suiteName,
+    class: className,
+    name: testName,
+    params: params || null,
+    canonical_id: canonicalId,
+    status,
+    duration_ms: Number.isFinite(durationMs) ? Math.round(durationMs) : 0,
+    failure_kind: failureKind,
+    failure_signature: signature,
+    failure_message: failureMessage,
+    failure_details: failureDetails,
+    system_out: mapOutput(node.systemOut),
+    system_err: mapOutput(node.systemErr),
+    retries: Number.parseInt(node.attrs.retries ?? node.attrs.retry ?? node.attrs.rerun ?? '0', 10) || 0,
+  };
+}
+
 export async function parseJUnitStream(readable, options = {}) {
   const {
     onTestcase,
     filename = '<stdin>',
   } = options;
 
-  const suiteStack = [];
-  const nodeStack = [];
   const attempts = [];
   const suiteDurations = new Map();
 
-  const pushSuite = (attrs) => {
-    const parent = suiteStack[suiteStack.length - 1];
-    const baseName = attrs.name || attrs.id || attrs.package || attrs.file || 'suite';
-    const fullName = parent && parent.fullName ? `${parent.fullName}.${baseName}` : baseName;
-    const entry = { name: baseName, fullName, attrs };
-    suiteStack.push(entry);
-  };
-
-  const popSuite = () => {
-    suiteStack.pop();
-  };
-
-  const attachChildNode = (node) => {
-    const parent = nodeStack[nodeStack.length - 1];
-    if (!parent) return;
-    const textContent = decodeEntities(node.text || '').trim();
-    if (parent.type === 'testcase') {
-      if (node.type === 'failure') parent.failures.push({ ...node, text: textContent });
-      else if (node.type === 'error') parent.errors.push({ ...node, text: textContent });
-      else if (node.type === 'skipped') parent.skipped = { ...node, text: textContent };
-      else if (node.type === 'system-out') parent.systemOut.push({ ...node, text: textContent });
-      else if (node.type === 'system-err') parent.systemErr.push({ ...node, text: textContent });
-    }
-  };
-
-  const finaliseTestcase = (node) => {
-    const suiteName = buildSuiteName(suiteStack);
-    const className = buildClassName(node.attrs, suiteStack);
-    const params = node.attrs.parameters || node.attrs.params || node.attrs.param || null;
-    const testName = node.attrs.name || node.attrs.id || 'unknown-test';
-    const canonicalId = buildCanonicalId({ suite: suiteName, className, testName, params });
-    const durationMs = node.attrs.time ? Number(node.attrs.time) * 1000 : 0;
-    const status = node.skipped
-      ? 'skipped'
-      : node.errors.length
-        ? 'error'
-        : node.failures.length
-          ? 'fail'
-          : 'pass';
-
-    if (!suiteDurations.has(suiteName)) suiteDurations.set(suiteName, []);
-    if (status !== 'skipped') suiteDurations.get(suiteName).push(durationMs);
-
-    const failureNodes = status === 'fail' ? node.failures : status === 'error' ? node.errors : [];
-    let failureMessage = null;
-    let failureDetails = null;
-    if (failureNodes.length) {
-      const texts = [];
-      const messages = [];
-      for (const failure of failureNodes) {
-        const message = failure.attrs.message || failure.attrs.type || '';
-        if (message) messages.push(message);
-        const text = decodeEntities(failure.text || '');
-        if (text) texts.push(text.trim());
-      }
-      failureMessage = messages.join(' | ') || null;
-      failureDetails = texts.join('\n\n') || null;
-    }
-
-    const signature = createFailureSignature(failureMessage, failureDetails);
-    const failureKind = failureNodes.length
-      ? classifyFailureByMessage(failureMessage, failureDetails) || 'nondeterministic'
-      : null;
-
-    const attempt = {
-      suite: suiteName,
-      class: className,
-      name: testName,
-      params: params || null,
-      canonical_id: canonicalId,
-      status,
-      duration_ms: Number.isFinite(durationMs) ? Math.round(durationMs) : 0,
-      failure_kind: failureKind,
-      failure_signature: signature,
-      failure_message: failureMessage,
-      failure_details: failureDetails,
-      system_out: node.systemOut.map((item) => item.text).filter(Boolean),
-      system_err: node.systemErr.map((item) => item.text).filter(Boolean),
-      retries: Number.parseInt(node.attrs.retries ?? node.attrs.retry ?? node.attrs.rerun ?? '0', 10) || 0,
-    };
-
-    attempts.push(attempt);
-    if (typeof onTestcase === 'function') onTestcase(attempt);
-  };
-
-  const processClosingTag = (name) => {
-    const node = nodeStack.pop();
-    if (!node || node.name !== name) {
-      throw new Error(`Unexpected closing tag </${name}> while parsing ${filename}`);
-    }
-    if (node.type === 'testsuite') {
-      popSuite();
-    } else if (node.type === 'testcase') {
-      finaliseTestcase(node);
-    } else {
-      attachChildNode(node);
-    }
-  };
-
-  const processOpeningTag = (name, attrs, selfClosing) => {
-    if (name === 'testsuite') {
-      pushSuite(attrs);
-      const node = { type: 'testsuite', name, attrs, text: '' };
-      nodeStack.push(node);
-      if (selfClosing) processClosingTag(name);
-      return;
-    }
-    if (name === 'testcase') {
-      const node = {
-        type: 'testcase',
-        name,
-        attrs,
-        text: '',
-        failures: [],
-        errors: [],
-        skipped: null,
-        systemOut: [],
-        systemErr: [],
+  const parser = createJUnitStreamParser({
+    filename,
+    onTestcase: ({ node, suiteStack }) => {
+      const testcaseNode = {
+        ...node,
+        failures: node.failures.map(normaliseText),
+        errors: node.errors.map(normaliseText),
+        skipped: normaliseText(node.skipped),
+        systemOut: node.systemOut.map(normaliseText),
+        systemErr: node.systemErr.map(normaliseText),
       };
-      nodeStack.push(node);
-      if (selfClosing) processClosingTag(name);
-      return;
-    }
+      const attempt = finaliseTestcase(testcaseNode, suiteStack, suiteDurations);
+      attempts.push(attempt);
+      if (typeof onTestcase === 'function') onTestcase(attempt);
+    },
+  });
 
-    const typeMap = {
-      failure: 'failure',
-      error: 'error',
-      skipped: 'skipped',
-      'system-out': 'system-out',
-      'system-err': 'system-err',
-    };
-    const mapped = typeMap[name] || 'generic';
-    const node = { type: mapped, name, attrs, text: '' };
-    nodeStack.push(node);
-    if (selfClosing) processClosingTag(name);
-  };
-
-  let buffer = '';
   for await (const chunk of readable) {
-    buffer += chunk;
-    let index = 0;
-    while (index < buffer.length) {
-      const next = buffer.indexOf('<', index);
-      if (next === -1) {
-        buffer = buffer.slice(index);
-        break;
-      }
-      if (next > index) {
-        const text = buffer.slice(index, next);
-        if (text.trim()) {
-          const current = nodeStack[nodeStack.length - 1];
-          if (current && typeof current.text === 'string') {
-            current.text += text;
-          }
-        }
-      }
-      if (buffer.startsWith('<!--', next)) {
-        const end = buffer.indexOf('-->', next + 4);
-        if (end === -1) {
-          buffer = buffer.slice(next);
-          break;
-        }
-        index = end + 3;
-        continue;
-      }
-      if (buffer.startsWith('<![CDATA[', next)) {
-        const end = buffer.indexOf(']]>', next + 9);
-        if (end === -1) {
-          buffer = buffer.slice(next);
-          break;
-        }
-        const content = buffer.slice(next + 9, end);
-        const current = nodeStack[nodeStack.length - 1];
-        if (current && typeof current.text === 'string') {
-          current.text += content;
-        }
-        index = end + 3;
-        continue;
-      }
-      const tagEnd = buffer.indexOf('>', next + 1);
-      if (tagEnd === -1) {
-        buffer = buffer.slice(next);
-        break;
-      }
-      const rawTag = buffer.slice(next + 1, tagEnd).trim();
-      index = tagEnd + 1;
-      if (!rawTag) continue;
-      if (rawTag.startsWith('?') || rawTag.startsWith('!')) continue;
-      if (rawTag.startsWith('/')) {
-        const name = rawTag.slice(1).trim();
-        processClosingTag(name);
-        continue;
-      }
-      const selfClosing = rawTag.endsWith('/');
-      const body = selfClosing ? rawTag.slice(0, -1).trim() : rawTag;
-      const spaceIndex = body.search(/\s/);
-      const name = spaceIndex === -1 ? body : body.slice(0, spaceIndex);
-      const attrString = spaceIndex === -1 ? '' : body.slice(spaceIndex + 1);
-      const attrs = parseAttributes(attrString);
-      processOpeningTag(name, attrs, selfClosing);
-    }
+    parser.consume(chunk);
   }
 
-  if (nodeStack.length) {
-    const last = nodeStack[nodeStack.length - 1];
-    throw new Error(`Unclosed tag <${last.name}> detected while parsing ${filename}`);
-  }
+  parser.finish();
 
   applyTimeoutClassification(attempts, suiteDurations, options.timeoutFactor ?? 3.0);
 

--- a/projects/03-ci-flaky/src/junit/stream-parser.js
+++ b/projects/03-ci-flaky/src/junit/stream-parser.js
@@ -1,0 +1,190 @@
+const ATTRIBUTE_REGEX = /([:\\w.-]+)(?:\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s'"=<>`]+)))?/g;
+
+function parseAttributes(raw) {
+  const attrs = {};
+  let match;
+  while ((match = ATTRIBUTE_REGEX.exec(raw)) !== null) {
+    const [, key, , dbl, sgl, bare] = match;
+    if (dbl !== undefined) attrs[key] = dbl;
+    else if (sgl !== undefined) attrs[key] = sgl;
+    else if (bare !== undefined) attrs[key] = bare;
+    else attrs[key] = '';
+  }
+  return attrs;
+}
+
+function createSuiteEntry(attrs, parent) {
+  const baseName = attrs.name || attrs.id || attrs.package || attrs.file || 'suite';
+  const fullName = parent && parent.fullName ? `${parent.fullName}.${baseName}` : baseName;
+  return { name: baseName, fullName, attrs };
+}
+
+export function createJUnitStreamParser({
+  filename = '<stdin>',
+  onSuiteStart,
+  onSuiteEnd,
+  onTestcase,
+} = {}) {
+  const suiteStack = [];
+  const nodeStack = [];
+  let buffer = '';
+
+  const emitSuiteStart = (entry) => {
+    if (typeof onSuiteStart === 'function') onSuiteStart(entry, suiteStack.slice());
+  };
+
+  const emitSuiteEnd = (entry) => {
+    if (typeof onSuiteEnd === 'function') onSuiteEnd(entry, suiteStack.slice());
+  };
+
+  const emitTestcase = (node) => {
+    if (typeof onTestcase === 'function') {
+      onTestcase({ node, suiteStack: suiteStack.slice() });
+    }
+  };
+
+  const attachChildNode = (node) => {
+    const parent = nodeStack[nodeStack.length - 1];
+    if (!parent) return;
+    const textContent = (node.text || '').trim();
+    if (parent.type === 'testcase') {
+      if (node.type === 'failure') parent.failures.push({ ...node, text: textContent });
+      else if (node.type === 'error') parent.errors.push({ ...node, text: textContent });
+      else if (node.type === 'skipped') parent.skipped = { ...node, text: textContent };
+      else if (node.type === 'system-out') parent.systemOut.push({ ...node, text: textContent });
+      else if (node.type === 'system-err') parent.systemErr.push({ ...node, text: textContent });
+    }
+  };
+
+  const processClosingTag = (name) => {
+    const node = nodeStack.pop();
+    if (!node || node.name !== name) {
+      throw new Error(`Unexpected closing tag </${name}> while parsing ${filename}`);
+    }
+    if (node.type === 'testsuite') {
+      suiteStack.pop();
+      emitSuiteEnd(node);
+    } else if (node.type === 'testcase') {
+      emitTestcase(node);
+    } else {
+      attachChildNode(node);
+    }
+  };
+
+  const processOpeningTag = (name, attrs, selfClosing) => {
+    if (name === 'testsuite') {
+      const parent = suiteStack[suiteStack.length - 1];
+      const entry = createSuiteEntry(attrs, parent);
+      suiteStack.push(entry);
+      emitSuiteStart(entry);
+      const node = { type: 'testsuite', name, attrs, text: '' };
+      nodeStack.push(node);
+      if (selfClosing) processClosingTag(name);
+      return;
+    }
+    if (name === 'testcase') {
+      const node = {
+        type: 'testcase',
+        name,
+        attrs,
+        text: '',
+        failures: [],
+        errors: [],
+        skipped: null,
+        systemOut: [],
+        systemErr: [],
+      };
+      nodeStack.push(node);
+      if (selfClosing) processClosingTag(name);
+      return;
+    }
+    const typeMap = {
+      failure: 'failure',
+      error: 'error',
+      skipped: 'skipped',
+      'system-out': 'system-out',
+      'system-err': 'system-err',
+    };
+    const mapped = typeMap[name] || 'generic';
+    const node = { type: mapped, name, attrs, text: '' };
+    nodeStack.push(node);
+    if (selfClosing) processClosingTag(name);
+  };
+
+  const consume = (chunk) => {
+    buffer += chunk;
+    let index = 0;
+    while (index < buffer.length) {
+      const next = buffer.indexOf('<', index);
+      if (next === -1) {
+        buffer = buffer.slice(index);
+        break;
+      }
+      if (next > index) {
+        const text = buffer.slice(index, next);
+        if (text.trim()) {
+          const current = nodeStack[nodeStack.length - 1];
+          if (current && typeof current.text === 'string') {
+            current.text += text;
+          }
+        }
+      }
+      if (buffer.startsWith('<!--', next)) {
+        const end = buffer.indexOf('-->', next + 4);
+        if (end === -1) {
+          buffer = buffer.slice(next);
+          break;
+        }
+        index = end + 3;
+        continue;
+      }
+      if (buffer.startsWith('<![CDATA[', next)) {
+        const end = buffer.indexOf(']]>', next + 9);
+        if (end === -1) {
+          buffer = buffer.slice(next);
+          break;
+        }
+        const content = buffer.slice(next + 9, end);
+        const current = nodeStack[nodeStack.length - 1];
+        if (current && typeof current.text === 'string') {
+          current.text += content;
+        }
+        index = end + 3;
+        continue;
+      }
+      const tagEnd = buffer.indexOf('>', next + 1);
+      if (tagEnd === -1) {
+        buffer = buffer.slice(next);
+        break;
+      }
+      const rawTag = buffer.slice(next + 1, tagEnd).trim();
+      index = tagEnd + 1;
+      if (!rawTag) continue;
+      if (rawTag.startsWith('?') || rawTag.startsWith('!')) continue;
+      if (rawTag.startsWith('/')) {
+        const name = rawTag.slice(1).trim();
+        processClosingTag(name);
+        continue;
+      }
+      const selfClosing = rawTag.endsWith('/');
+      const body = selfClosing ? rawTag.slice(0, -1).trim() : rawTag;
+      const spaceIndex = body.search(/\s/);
+      const name = spaceIndex === -1 ? body : body.slice(0, spaceIndex);
+      const attrString = spaceIndex === -1 ? '' : body.slice(spaceIndex + 1);
+      const attrs = parseAttributes(attrString);
+      processOpeningTag(name, attrs, selfClosing);
+    }
+  };
+
+  const finish = () => {
+    if (nodeStack.length) {
+      const last = nodeStack[nodeStack.length - 1];
+      throw new Error(`Unclosed tag <${last.name}> detected while parsing ${filename}`);
+    }
+  };
+
+  return {
+    consume,
+    finish,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the low-level XML stack handling into a new junit/stream-parser module that surfaces suite and testcase events
- update the main junit parser to consume the new event API while keeping attempt aggregation logic intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a3179378832180c31c7fb4d99534