### PR TITLE
Fix Windows openInBrowser command

### DIFF
--- a/projects/03-ci-flaky/src/commands/utils.js
+++ b/projects/03-ci-flaky/src/commands/utils.js
@@ -54,8 +54,8 @@ export function openInBrowser(filePath) {
     command = 'open';
     commandArgs = [resolved];
   } else if (process.platform === 'win32') {
-    command = 'cmd';
-    commandArgs = ['/c', 'start', '""', resolved];
+    command = 'explorer.exe';
+    commandArgs = [resolved];
   } else {
     command = 'xdg-open';
     commandArgs = [resolved];


### PR DESCRIPTION
## Summary
- update the Windows branch of openInBrowser to launch explorer.exe directly

## Testing
- npm run lint:js
- npm test -- --runTestsByPath projects/03-ci-flaky

------
https://chatgpt.com/codex/tasks/task_e_68d7a77800d8832194251dcd08143b6a