### PR TITLE
Adjust typing import order for ollama provider

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -1,3 +1,4 @@
+# ruff: noqa: I001
 """Ollama provider with automatic model management."""
 
 from __future__ import annotations
@@ -11,8 +12,7 @@ from collections.abc import (
     Sequence,
 )
 from types import TracebackType
-
-from typing import Any, Protocol, TYPE_CHECKING, cast  # isort: skip
+from typing import Any, Protocol, TYPE_CHECKING, cast
 
 from ..errors import AuthError, ConfigError, RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage


### PR DESCRIPTION
## Summary
- remove the isort suppression from the typing import in the Ollama provider and enforce the desired symbol order
- mark the module to ignore Ruff's I001 rule to keep the requested import sequence

## Testing
- ruff check projects/04-llm-adapter-shadow/src --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68d7aa1a9c50832191604ad5fac317d6