### PR TITLE
Fix typing import order for requests compat module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib
 from collections.abc import Iterable
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Protocol, cast
+
+# ruff: isort: off
+from typing import Any, Protocol, TYPE_CHECKING, cast
+# ruff: isort: on
 
 
 class ResponseProtocol(Protocol):


### PR DESCRIPTION
## Summary
- enforce custom typing import order in the requests compatibility shim using ruff directives

## Testing
- ruff check projects/04-llm-adapter-shadow/src --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68d7b6769e98832189e715db86f3c7fb