### PR TITLE
Ensure ProviderRequest requires explicit model

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -54,7 +54,7 @@ def _extract_prompt_from_messages(messages: Sequence[Mapping[str, Any]]) -> str:
 
 @dataclass
 class ProviderRequest:
-    model: str
+    model: str = field(default="")
     prompt: str = ""
     messages: Sequence[Mapping[str, Any]] | None = None
     max_tokens: int | None = 256

--- a/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
@@ -36,6 +36,11 @@ def test_provider_request_rejects_empty_model():
         ProviderRequest(model="   ", prompt="hello")
 
 
+def test_provider_request_requires_model_argument():
+    with pytest.raises(ValueError):
+        ProviderRequest(prompt="hello")
+
+
 def test_provider_response_populates_token_usage_from_inputs():
     response = ProviderResponse(text="ok", latency_ms=10, tokens_in=3, tokens_out=4)
     assert response.token_usage.prompt == 3


### PR DESCRIPTION
## Summary
- default ProviderRequest.model to an empty string so __post_init__ validation handles missing arguments
- add a provider SPI contract test covering the missing-model ValueError

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d7cc5bbc348321a4efb11d5010aa93