### PR TITLE
Update GitHub Pages workflow and document recovery guidance

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:
@@ -18,25 +18,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
+          destination: ./_site
       - name: Copy bundled CI reports
         run: |
           for dir in coverage flaky junit; do
             if [ -d "docs/reports/${dir}" ]; then
               mkdir -p "_site/reports/${dir}"
-              rsync -av --delete --omit-dir-times --no-perms --no-owner --no-group --exclude='.gitkeep' "docs/reports/${dir}/" "_site/reports/${dir}/"
-
+              rsync -av --delete --omit-dir-times --no-perms --no-owner --no-group --exclude='.gitkeep' \
+                "docs/reports/${dir}/" "_site/reports/${dir}/"
             fi
           done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: _site
+          path: ./_site
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Hands-on portfolio showcasing QA × SDET × LLM automation pipelines, continuous
 - `just report` — Generate pytest coverage reports for the Python adapter.
 - GitHub Pages: <https://ryosuke4219.github.io/portfolio/>
 
+### GitHub Pages 公開 / 復旧手順
+
+- 公開 URL: <https://ryosuke4219.github.io/portfolio/>
+- 復旧手順:
+  1. GitHub Actions → Pages ワークフローを `Run workflow` で再実行し、`Build with Jekyll` が `Completed` になることをログで確認。
+  2. ビルド失敗時はローカルで `bundle exec jekyll build --source docs --destination _site` を実行しエラー箇所を修正。
+  3. 修正を `main` ブランチへプッシュすると自動でデプロイが再開されます。
+
+---
+
 > [!TIP] Quick Start
 > `just setup` — Node.js / Python 依存と Playwright スタブを初期化します。
 > `just test` — Node＋Python の回帰テストを一括で実行します。
@@ -180,6 +190,20 @@ pip install -r requirements.txt
 # デモ：影実行と差分メトリクスを記録
 python demo_shadow.py
 # => artifacts/runs-metrics.jsonl に1行/リクエストで追記
+```
+
+```bash
+# LLM Adapter 本体の最短バッチ実行
+cat <<'JSONL' > sample.jsonl
+{"prompt": "日本語で1行、自己紹介して"}
+JSONL
+
+llm-adapter --provider projects/04-llm-adapter/adapter/config/providers/openai.yaml \
+  --prompts sample.jsonl --out out.jsonl --format jsonl
+```
+
+```jsonl
+{"prompt_sha256": "d4b8…", "status": "ok", "latency_ms": 480, "model": "gpt-4o-mini", "output_tokens": 34}
 ```
 
 **異常系テストとCI**


### PR DESCRIPTION
## Summary
- refresh the Pages workflow to align with the latest template while keeping the Jekyll build and report bundling
- document the published Pages URL, recovery steps, and the minimal llm-adapter batch command with JSONL I/O examples in the root README

## Testing
- not run (documentation and workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d7cc5dbff48321994378c2311d58d3