### PR TITLE
Refactor Ollama provider to use client abstraction

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from ._requests_compat import ResponseProtocol, SessionProtocol, requests_exceptions
+
+
+def _combine_host(base: str, path: str) -> str:
+    return f"{base[:-1] if base.endswith('/') else base}{path}"
+
+
+class OllamaClient:
+    __slots__ = ("_host", "_session", "_timeout", "_pull_timeout")
+
+    def __init__(self, *, host: str, session: SessionProtocol, timeout: float, pull_timeout: float) -> None:
+        self._host = host
+        self._session = session
+        self._timeout = timeout
+        self._pull_timeout = pull_timeout
+
+    def show(self, payload: Mapping[str, object]) -> ResponseProtocol:
+        return self._post("/api/show", payload)
+
+    def pull(self, payload: Mapping[str, object]) -> ResponseProtocol:
+        return self._ensure_success(
+            "/api/pull",
+            self._post("/api/pull", payload, stream=True, timeout=self._pull_timeout),
+        )
+
+    def chat(self, payload: Mapping[str, object], *, timeout: float | None = None) -> ResponseProtocol:
+        return self._ensure_success(
+            "/api/chat",
+            self._post("/api/chat", payload, timeout=timeout),
+        )
+
+    def _post(
+        self,
+        path: str,
+        payload: Mapping[str, object],
+        *,
+        stream: bool = False,
+        timeout: float | None = None,
+    ) -> ResponseProtocol:
+        url = _combine_host(self._host, path)
+        try:
+            return self._session.post(
+                url,
+                json=payload,
+                stream=stream,
+                timeout=timeout or self._timeout,
+            )
+        except requests_exceptions.Timeout as exc:  # pragma: no cover - passthrough
+            raise TimeoutError(f"Ollama request timed out: {url}") from exc
+        except requests_exceptions.RequestException as exc:  # pragma: no cover - passthrough
+            raise RetriableError(f"Ollama request failed: {url}") from exc
+
+    def _ensure_success(self, path: str, response: ResponseProtocol) -> ResponseProtocol:
+        try:
+            response.raise_for_status()
+        except requests_exceptions.HTTPError as exc:
+            response.close()
+            self._raise_http_error(path, response.status_code, exc)
+        return response
+
+    @staticmethod
+    def _raise_http_error(path: str, status: int, exc: Exception) -> None:
+        message = f"Ollama request failed ({status}): {path}"
+        if status in {401, 403}:
+            raise AuthError(message) from exc
+        if status == 429:
+            raise RateLimitError(message) from exc
+        if status in {408, 504}:
+            raise TimeoutError(message) from exc
+        raise RetriableError(message) from exc
+
+
+__all__ = ["OllamaClient"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -13,7 +13,14 @@ def _combine_host(base: str, path: str) -> str:
 class OllamaClient:
     __slots__ = ("_host", "_session", "_timeout", "_pull_timeout")
 
-    def __init__(self, *, host: str, session: SessionProtocol, timeout: float, pull_timeout: float) -> None:
+    def __init__(
+        self,
+        *,
+        host: str,
+        session: SessionProtocol,
+        timeout: float,
+        pull_timeout: float,
+    ) -> None:
         self._host = host
         self._session = session
         self._timeout = timeout
@@ -28,7 +35,12 @@ class OllamaClient:
             self._post("/api/pull", payload, stream=True, timeout=self._pull_timeout),
         )
 
-    def chat(self, payload: Mapping[str, object], *, timeout: float | None = None) -> ResponseProtocol:
+    def chat(
+        self,
+        payload: Mapping[str, object],
+        *,
+        timeout: float | None = None,
+    ) -> ResponseProtocol:
         return self._ensure_success(
             "/api/chat",
             self._post("/api/chat", payload, timeout=timeout),

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
+from src.llm_adapter.providers._requests_compat import requests_exceptions
+from src.llm_adapter.providers.ollama_client import OllamaClient
+
+from tests.helpers.fakes import FakeResponse, FakeSession
+
+
+def test_ollama_client_success_paths():
+    class Session(FakeSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.timeouts: list[float | None] = []
+
+        def post(self, url, json=None, stream=False, timeout=None):
+            self.calls.append((url, json, stream))
+            self.timeouts.append(timeout)
+            if url.endswith("/api/show"):
+                return FakeResponse(status_code=200, payload={"result": "ok"})
+            if url.endswith("/api/pull"):
+                return FakeResponse(status_code=200, payload={"done": True})
+            if url.endswith("/api/chat"):
+                return FakeResponse(status_code=200, payload={"message": {"content": "hi"}})
+            raise AssertionError(url)
+
+    session = Session()
+    client = OllamaClient(
+        host="http://localhost/",
+        session=session,
+        timeout=12.5,
+        pull_timeout=45.0,
+    )
+
+    assert client.show({"model": "m"}).json()["result"] == "ok"
+    assert client.pull({"model": "m"}).json()["done"] is True
+    assert (
+        client.chat({"messages": []}, timeout=2.5).json()["message"]["content"] == "hi"
+    )
+
+    assert [url for url, *_ in session.calls] == [
+        "http://localhost/api/show",
+        "http://localhost/api/pull",
+        "http://localhost/api/chat",
+    ]
+    assert session.timeouts == [12.5, 45.0, 2.5]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected"),
+    [
+        (requests_exceptions.ConnectionError, RetriableError),
+        (requests_exceptions.Timeout, TimeoutError),
+    ],
+)
+def test_ollama_client_normalizes_session_errors(factory, expected):
+    class Session(FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):
+            raise factory()
+
+    client = OllamaClient(host="http://h", session=Session(), timeout=10.0, pull_timeout=10.0)
+
+    with pytest.raises(expected):
+        client.chat({"messages": []})
+
+
+@pytest.mark.parametrize(
+    ("method_name", "path", "status", "payload", "kwargs", "expected"),
+    [
+        ("chat", "/api/chat", 429, {"messages": []}, {}, RateLimitError),
+        ("pull", "/api/pull", 500, {"model": "m"}, {}, RetriableError),
+    ],
+)
+def test_ollama_client_closes_responses_on_http_error(
+    method_name, path, status, payload, kwargs, expected
+):
+    class Session(FakeSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.last_response: FakeResponse | None = None
+
+        def post(self, url, json=None, stream=False, timeout=None):
+            if url.endswith(path):
+                response = FakeResponse(status_code=status, payload={})
+                self.last_response = response
+                return response
+            return FakeResponse(status_code=200, payload={})
+
+    session = Session()
+    client = OllamaClient(host="http://h", session=session, timeout=10.0, pull_timeout=5.0)
+
+    with pytest.raises(expected):
+        getattr(client, method_name)(payload, **kwargs)
+
+    assert session.last_response is not None
+    assert session.last_response.closed is True


### PR DESCRIPTION
## Summary
- add an OllamaClient wrapper that normalises request exceptions
- refactor OllamaProvider to build on the client while preserving the session-based path and requests_exceptions export

## Testing
- pytest tests/providers/test_ollama_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d7cc5ba1008321a30d54c413f84704