### PR TITLE
Document retry policy and test rate limit backoff

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -1,4 +1,10 @@
-"""Error hierarchy for the minimal LLM adapter."""
+"""Error hierarchy for the minimal LLM adapter.
+
+Runner retry policy:
+- ``RateLimitError`` → waits 0.05 seconds before continuing with the next provider.
+- ``TimeoutError`` / ``RetriableError`` → immediately try the next provider with no delay.
+- ``ProviderSkip`` → simply recorded as a skip event; control moves on without retrying.
+"""
 
 from __future__ import annotations
 
@@ -8,11 +14,11 @@ class AdapterError(Exception):
 
 
 class TimeoutError(AdapterError):
-    """Raised when a provider does not respond within the expected window."""
+    """Raised when a provider does not respond within the expected window (instant fallback)."""
 
 
 class RateLimitError(AdapterError):
-    """Raised when a provider rejects the request due to rate limiting."""
+    """Raised when a provider rejects the request due to rate limiting (0.05 s backoff)."""
 
 
 class AuthError(AdapterError):
@@ -20,7 +26,7 @@ class AuthError(AdapterError):
 
 
 class RetriableError(AdapterError):
-    """Raised for transient issues where retrying with another provider may help."""
+    """Raised for transient issues where retrying with another provider may help (instant fallback)."""
 
 
 class FatalError(AdapterError):
@@ -28,7 +34,7 @@ class FatalError(AdapterError):
 
 
 class ProviderSkip(AdapterError):
-    """Raised when a provider should be skipped without counting as a failure."""
+    """Raised when a provider should be skipped without counting as a failure (logged only)."""
 
     def __init__(self, message: str, *, reason: str | None = None) -> None:
         super().__init__(message)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -26,7 +26,10 @@ class AuthError(AdapterError):
 
 
 class RetriableError(AdapterError):
-    """Raised for transient issues where retrying with another provider may help (instant fallback)."""
+    """Raised for transient issues where retrying with another provider may help.
+
+    Runner instantly falls back to the next provider when this error is encountered.
+    """
 
 
 class FatalError(AdapterError):


### PR DESCRIPTION
## Summary
- document provider retry policy in the README and error hierarchy docstrings, including the ProviderSkip behavior
- add pytest coverage that monkeypatches time.sleep to assert rate-limit backoff and timeout fast-fail semantics

## Testing
- pytest tests/test_err_cases.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7cc5e6cac8321b5ee305c376b7edb