### PR TITLE
Add pre-commit configuration for shadow adapter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        name: ruff import order
+        args: ["--select", "I", "--fix"]
+        files: ^projects/04-llm-adapter-shadow/src/.*\\.py$
+      - id: ruff-format
+        files: ^projects/04-llm-adapter-shadow/src/.*\\.py$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        name: mypy strict shadow adapter
+        args:
+          ["--strict", "projects/04-llm-adapter-shadow/src", "--pretty"]
+        pass_filenames: false
+        files: ^projects/04-llm-adapter-shadow/src/.*\\.py$

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Quick Start で触れた `just` コマンドを詳しく説明します。セッ
    * Node 側: 仕様ケースの検証 → E2E テスト生成 → デモサーバー起動 → Playwright スタブ実行 → JUnit 解析/レポート生成。
    * Python 側: `projects/04-llm-adapter-shadow` の pytest を実行。
 3. `just lint` / `just report` でワンコマンド lint / カバレッジ計測が可能です。
+4. `pre-commit install` で Git フックを有効化し、初回は `pre-commit run --all-files` で一括検証できます。
 
 VS Code Dev Container を利用する場合は `devcontainer.json` の postCreateCommand で自動的に `just setup` が走ります。
 


### PR DESCRIPTION
## Summary
- add a repository-level pre-commit configuration that runs Ruff import sorting, Ruff formatting, and strict mypy against the shadow adapter sources
- extend the local onboarding guide so contributors enable the new Git hooks via `pre-commit install` and `pre-commit run --all-files`

## Testing
- mypy --strict projects/04-llm-adapter-shadow/src --pretty
- pre-commit run --all-files *(unavailable: `pre-commit` command not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d6da1b908321adf7e9b379e7a28a