### PR TITLE
docs: refresh pages workflow and add llm adapter example

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,12 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
+          base_path: ${{ steps.pages.outputs.base_path }}
       - name: Copy bundled CI reports
         run: |
           for dir in coverage flaky junit; do

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Hands-on portfolio showcasing QA × SDET × LLM automation pipelines, continuous
 
 - 公開 URL: <https://ryosuke4219.github.io/portfolio/>
 - 復旧手順:
-  1. GitHub Actions → Pages ワークフローを `Run workflow` で再実行し、`Build with Jekyll` が `Completed` になることをログで確認。
+  1. GitHub Actions → Pages ワークフローを `Run workflow` で再実行し、`Build with Jekyll` と `Deploy to GitHub Pages` の両ステップが `Completed` になったことを実行ログで確認。
   2. ビルド失敗時はローカルで `bundle exec jekyll build --source docs --destination _site` を実行しエラー箇所を修正。
   3. 修正を `main` ブランチへプッシュすると自動でデプロイが再開されます。
 
@@ -89,8 +89,27 @@ New automation pipelines and LLM-driven PoCs are published regularly, with a per
 3. **03: ci-flaky-analyzer — JUnit → HTML/CSV（決定的）**  
    CIのJUnitログを取り込み、flaky挙動を集計・可視化します。
 
-4. **04: llm-adapter-shadow — LLMモデル選択/比較（唯一のLLM使用箇所）**  
+4. **04: llm-adapter-shadow — LLMモデル選択/比較（唯一のLLM使用箇所）**
    *primary* と *shadow* の2系統LLMを並走させ、差分・フォールバック・異常系を検証します。
+
+   **最短コマンドと入出力例:**
+
+   ```bash
+   llm-adapter --provider adapter/config/providers/openai.yaml \
+     --prompts examples/prompts/ja_one_liner.jsonl --out out.jsonl
+   ```
+
+   * `examples/prompts/ja_one_liner.jsonl`
+
+     ```jsonl
+     {"prompt": "日本語で1行、自己紹介して"}
+     ```
+
+   * `out.jsonl`（一例）
+
+     ```jsonl
+     {"provider": "openai", "model": "gpt-4o-mini", "latency_ms": 812, "status": "ok", "prompt_sha256": "d16a2c…", "output": "こんにちは、QAエンジニアのRyです。"}
+     ```
 
 ### LLM使用ポリシー（重要）
 


### PR DESCRIPTION
## Summary
- document the minimal llm-adapter batch command with sample JSONL I/O in the portfolio README
- clarify GitHub Pages recovery steps to check both build and deploy stages in the Actions logs
- refresh the Pages workflow to align with the latest template while keeping the Jekyll build step

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ddcdb21c83218ef50ff39de1e563