### PR TITLE
refactor: extract compare runner api

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -1,0 +1,84 @@
+"""共通ランナー API."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Literal, Sequence
+
+from .budgets import BudgetManager
+from .config import load_budget_book, load_provider_configs
+from .datasets import load_golden_tasks
+from .runners import CompareRunner
+
+Mode = Literal["parallel", "serial"]
+
+
+def default_budgets_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "config" / "budgets.yaml"
+
+
+def default_metrics_path() -> Path:
+    return Path(__file__).resolve().parent.parent.parent / "data" / "runs-metrics.jsonl"
+
+
+def run_compare(
+    provider_paths: Sequence[Path],
+    prompt_path: Path,
+    *,
+    budgets_path: Path,
+    metrics_path: Path,
+    repeat: int = 1,
+    mode: Mode = "parallel",
+    allow_overrun: bool = False,
+    log_level: str = "INFO",
+) -> int:
+    logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
+
+    provider_configs = load_provider_configs(list(provider_paths))
+    tasks = load_golden_tasks(prompt_path)
+    budget_book = load_budget_book(budgets_path)
+    budget_manager = BudgetManager(budget_book)
+
+    runner = CompareRunner(
+        provider_configs,
+        tasks,
+        budget_manager,
+        metrics_path,
+        allow_overrun=allow_overrun,
+    )
+    results = runner.run(repeat=max(repeat, 1), mode=mode)
+    logging.getLogger(__name__).info("%d 件の試行を記録しました", len(results))
+    return 0
+
+
+def run_batch(provider_specs: Iterable[str], prompts_path: str) -> int:
+    provider_paths: List[Path] = [
+        Path(spec).expanduser().resolve() for spec in provider_specs if spec
+    ]
+    if not provider_paths:
+        raise ValueError("provider_specs must include at least one path")
+
+    prompt_path = Path(prompts_path).expanduser().resolve()
+    if not prompt_path.exists():
+        raise FileNotFoundError(f"ゴールデンタスクが見つかりません: {prompt_path}")
+
+    return run_compare(
+        provider_paths,
+        prompt_path,
+        budgets_path=default_budgets_path(),
+        metrics_path=default_metrics_path(),
+        repeat=1,
+        mode="parallel",
+        allow_overrun=False,
+        log_level="INFO",
+    )
+
+
+__all__ = [
+    "Mode",
+    "default_budgets_path",
+    "default_metrics_path",
+    "run_batch",
+    "run_compare",
+]

--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -3,25 +3,17 @@
 from __future__ import annotations
 
 import argparse
-import logging
-import sys
 from pathlib import Path
 
 try:
-    from .core.budgets import BudgetManager
-    from .core.config import load_budget_book, load_provider_configs
-    from .core.datasets import load_golden_tasks
-    from .core.runners import CompareRunner
+    from .core import runner_api
 except ImportError:  # pragma: no cover - 直接実行時のフォールバック
+    import sys
+
     PACKAGE_ROOT = Path(__file__).resolve().parent.parent
     if str(PACKAGE_ROOT) not in sys.path:
         sys.path.insert(0, str(PACKAGE_ROOT))
-    from adapter.core.budgets import BudgetManager
-    from adapter.core.config import load_budget_book, load_provider_configs
-    from adapter.core.datasets import load_golden_tasks
-    from adapter.core.runners import CompareRunner
-
-LOGGER = logging.getLogger(__name__)
+    from adapter.core import runner_api
 
 
 def _parse_args() -> argparse.Namespace:
@@ -71,65 +63,6 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _default_budgets_path() -> Path:
-    return Path(__file__).resolve().parent / "config" / "budgets.yaml"
-
-
-def _default_metrics_path() -> Path:
-    return Path(__file__).resolve().parent.parent / "data" / "runs-metrics.jsonl"
-
-
-def _run(
-    provider_paths: list[Path],
-    prompt_path: Path,
-    budgets_path: Path,
-    metrics_path: Path,
-    *,
-    repeat: int,
-    mode: str,
-    allow_overrun: bool,
-    log_level: str,
-) -> int:
-    logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
-
-    provider_configs = load_provider_configs(provider_paths)
-    tasks = load_golden_tasks(prompt_path)
-    budget_book = load_budget_book(budgets_path)
-    budget_manager = BudgetManager(budget_book)
-
-    runner = CompareRunner(
-        provider_configs,
-        tasks,
-        budget_manager,
-        metrics_path,
-        allow_overrun=allow_overrun,
-    )
-    results = runner.run(repeat=max(repeat, 1), mode=mode)
-    LOGGER.info("%d 件の試行を記録しました", len(results))
-    return 0
-
-
-def run_batch(provider_specs: list[str], prompts_path: str) -> int:
-    provider_paths = [Path(spec).expanduser().resolve() for spec in provider_specs if spec]
-    if not provider_paths:
-        raise ValueError("provider_specs must include at least one path")
-    prompt_path = Path(prompts_path).expanduser().resolve()
-    if not prompt_path.exists():
-        raise FileNotFoundError(f"ゴールデンタスクが見つかりません: {prompt_path}")
-    budgets_path = _default_budgets_path()
-    metrics_path = _default_metrics_path()
-    return _run(
-        provider_paths,
-        prompt_path,
-        budgets_path,
-        metrics_path,
-        repeat=1,
-        mode="parallel",
-        allow_overrun=False,
-        log_level="INFO",
-    )
-
-
 def main() -> int:
     args = _parse_args()
 
@@ -142,24 +75,27 @@ def main() -> int:
     budgets_path = (
         Path(args.budgets).expanduser().resolve()
         if args.budgets
-        else _default_budgets_path()
+        else runner_api.default_budgets_path()
     )
     metrics_path = (
         Path(args.metrics).expanduser().resolve()
         if args.metrics
-        else _default_metrics_path()
+        else runner_api.default_metrics_path()
     )
 
-    return _run(
+    return runner_api.run_compare(
         provider_paths,
         prompt_path,
-        budgets_path,
-        metrics_path,
+        budgets_path=budgets_path,
+        metrics_path=metrics_path,
         repeat=args.repeat,
         mode=args.mode,
         allow_overrun=args.allow_overrun,
         log_level=args.log_level,
     )
+
+
+run_batch = runner_api.run_batch
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI エントリポイント


### PR DESCRIPTION
## Summary
- extract shared compare runner logic into `adapter.core.runner_api`
- update the legacy `run_compare` CLI to reuse the shared API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e001bbec8321b1869c929796eb1e