### PR TITLE
chore: tighten python workflows and pages deploy

### DIFF
--- a/.github/workflows/adapter-tests.yml
+++ b/.github/workflows/adapter-tests.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Install dependencies
         working-directory: projects/04-llm-adapter-shadow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Install Python dependencies
         if: always()
         run: |
           python -m pip install --upgrade pip
           pip install -r projects/04-llm-adapter-shadow/requirements.txt
+          pip install ruff mypy
+
+      - name: Ruff lint (fix mode)
+        if: always()
+        run: |
+          ruff check projects/04-llm-adapter-shadow/src \
+            --output-format=full \
+            --fix \
+            --exit-non-zero-on-fix
+
+      - name: Mypy type check (strict)
+        if: always()
+        run: mypy projects/04-llm-adapter-shadow/src --pretty --strict
 
       - name: Run shadow pipeline integration test
         if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Install dependencies
         run: |
@@ -44,7 +46,7 @@ jobs:
           pip install ruff mypy
 
       - name: Ruff lint
-        run: ruff check projects/04-llm-adapter-shadow/src --output-format=full
+        run: ruff check projects/04-llm-adapter-shadow/src --output-format=full --fix --exit-non-zero-on-fix
 
       - name: Mypy type check
-        run: mypy projects/04-llm-adapter-shadow/src --pretty
+        run: mypy projects/04-llm-adapter-shadow/src --pretty --strict

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,14 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
-          base_path: ${{ steps.pages.outputs.base_path }}
       - name: Copy bundled CI reports
         run: |
           for dir in coverage flaky junit; do
@@ -41,6 +39,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
+          name: github-pages
           path: ./_site
 
   deploy:
@@ -53,3 +52,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages

--- a/.github/workflows/python-llm-adapter-shadow.yml
+++ b/.github/workflows/python-llm-adapter-shadow.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
       - name: Install deps
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/weekly-qa-summary.yml
+++ b/.github/workflows/weekly-qa-summary.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: python -m pip install --upgrade pip
       - name: Generate weekly summary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: v0.5.6
     hooks:
       - id: ruff
-        name: ruff import order
-        args: ["--select", "I", "--fix"]
+        name: ruff lint (fix)
+        args: ["--fix", "--exit-non-zero-on-fix"]
         files: ^projects/04-llm-adapter-shadow/src/.*\\.py$
       - id: ruff-format
         files: ^projects/04-llm-adapter-shadow/src/.*\\.py$


### PR DESCRIPTION
## Summary
- enable pip dependency caching across Python-based workflows
- run ruff --fix and mypy --strict in CI and lint pipelines while matching pre-commit checks
- align the Pages workflow with the recommended upload/deploy artifact sequence

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d7e00202f48321b5824fe8542fe129