### PR TITLE
refactor: add BaseProvider abstraction

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/base.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/base.py
@@ -1,0 +1,41 @@
+"""共通プロバイダ基底クラス。"""
+
+from __future__ import annotations
+
+from abc import ABC
+
+from ..provider_spi import ProviderSPI
+
+__all__ = ["BaseProvider"]
+
+
+class BaseProvider(ProviderSPI, ABC):
+    """ProviderSPI 実装向けの共通ユーティリティ。"""
+
+    _name: str
+    _model: str | None
+
+    def __init__(self, *, name: str, model: str | None = None) -> None:
+        name_text = name.strip()
+        if not name_text:
+            raise ValueError("provider name must be a non-empty string")
+        self._name = name_text
+
+        if model is None:
+            self._model = None
+        else:
+            model_text = model.strip()
+            if not model_text:
+                raise ValueError("provider model must be a non-empty string")
+            self._model = model_text
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    @property
+    def model(self) -> str | None:
+        return self._model
+

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -14,8 +14,8 @@ from ._requests_compat import (
     create_session,
     requests_exceptions,
 )
-from .ollama_client import OllamaClient
 from .base import BaseProvider
+from .ollama_client import OllamaClient
 
 DEFAULT_HOST = "http://127.0.0.1:11434"
 __all__ = ["OllamaProvider", "DEFAULT_HOST", "requests_exceptions"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -8,13 +8,14 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ..errors import ConfigError, RetriableError
-from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI, TokenUsage
+from ..provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from ._requests_compat import (
     SessionProtocol,
     create_session,
     requests_exceptions,
 )
 from .ollama_client import OllamaClient
+from .base import BaseProvider
 
 DEFAULT_HOST = "http://127.0.0.1:11434"
 __all__ = ["OllamaProvider", "DEFAULT_HOST", "requests_exceptions"]
@@ -26,7 +27,7 @@ def _token_usage_from_payload(payload: Mapping[str, Any]) -> TokenUsage:
     return TokenUsage(prompt=prompt_tokens, completion=completion_tokens)
 
 
-class OllamaProvider(ProviderSPI):
+class OllamaProvider(BaseProvider):
     """Provider backed by the local Ollama HTTP API."""
 
     def __init__(
@@ -41,9 +42,8 @@ class OllamaProvider(ProviderSPI):
         pull_timeout: float = 300.0,
         auto_pull: bool = True,
     ) -> None:
-        # Factory/CLI で ``ProviderRequest.model`` に設定される推奨デフォルトを保持。
-        self._model = model
-        self._name = name or f"ollama:{model}"
+        provider_name = name or f"ollama:{model}"
+        super().__init__(name=provider_name, model=model)
         env_host = os.environ.get("OLLAMA_BASE_URL") or os.environ.get("OLLAMA_HOST")
         self._host: str = host or env_host or DEFAULT_HOST
         self._timeout = timeout
@@ -60,12 +60,6 @@ class OllamaProvider(ProviderSPI):
                 pull_timeout=self._pull_timeout,
             )
         self._client = client
-
-    def name(self) -> str:
-        return self._name
-
-    def capabilities(self) -> set[str]:
-        return {"chat"}
 
     def _ensure_model(self, model_name: str) -> None:
         if model_name in self._ready_models:

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -59,13 +59,6 @@ class Runner:
                 error_message=str(err),
             )
 
-        def _provider_model(provider: ProviderSPI) -> str | None:
-            for attr in ("model", "_model"):
-                value = getattr(provider, attr, None)
-                if isinstance(value, str) and value:
-                    return value
-            return None
-
         def _elapsed_ms(start_ts: float) -> int:
             return max(0, int((time.time() - start_ts) * 1000))
 
@@ -85,6 +78,10 @@ class Runner:
             error_type = type(error).__name__ if error is not None else None
             error_message = str(error) if error is not None else None
 
+            provider_model = getattr(provider, "model", None)
+            if not isinstance(provider_model, str) or not provider_model:
+                provider_model = None
+
             log_event(
                 "provider_call",
                 metrics_path_str,
@@ -96,7 +93,7 @@ class Runner:
                     request.max_tokens,
                 ),
                 provider=provider.name(),
-                model=_provider_model(provider),
+                model=provider_model,
                 attempt=attempt,
                 total_providers=len(self.providers),
                 status=status,

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -13,6 +13,8 @@ def test_shadow_exec_records_metrics(tmp_path: Path) -> None:
     shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
     runner = Runner([primary])
 
+    assert primary.model is None
+
     metrics_path = tmp_path / "metrics.jsonl"
     metadata = {"trace_id": "trace-123", "project_id": "proj-789"}
 


### PR DESCRIPTION
## Summary
- add a shared BaseProvider with name/model validation for provider implementations
- refactor Mock, Gemini, and Ollama providers to use the shared base and simplify Runner metrics logging
- adjust the shadow test to assert the Mock provider exposes the expected model interface

## Testing
- pytest projects/04-llm-adapter-shadow/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7e0071ed08321bbc6db5ccdccd904