### PR TITLE
Refine runner configuration and logging

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -3,181 +3,230 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass, field
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from .errors import ProviderSkip, RateLimitError, RetriableError, TimeoutError
 from .metrics import log_event
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .shadow import DEFAULT_METRICS_PATH, run_with_shadow
-from .utils import content_hash
+from .utils import content_hash, elapsed_ms
 
 MetricsPath = str | Path | None
+
+
+@dataclass(frozen=True)
+class BackoffPolicy:
+    """Backoff configuration applied when providers fail."""
+
+    rate_limit_seconds: float = 0.05
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    """Execution configuration for the provider runner."""
+
+    max_attempts: int | None = None
+    backoff: BackoffPolicy = field(default_factory=BackoffPolicy)
+
+    def attempts_budget(self, total: int) -> int:
+        if self.max_attempts is None:
+            return total
+        return max(0, min(total, self.max_attempts))
+
+
+class EventLogger:
+    """Convenience wrapper for structured logging of runner events."""
+
+    def __init__(
+        self,
+        *,
+        metrics_path: MetricsPath,
+        request: ProviderRequest,
+        total_providers: int,
+        shadow: ProviderSPI | None,
+    ) -> None:
+        self._metrics_path = None if metrics_path is None else str(Path(metrics_path))
+        self._request = request
+        self._total_providers = total_providers
+        self._shadow = shadow
+        self._metadata: dict[str, Any] = request.metadata or {}
+        self._request_fingerprint = content_hash(
+            "runner", request.prompt_text, request.options, request.max_tokens
+        )
+
+    def enabled(self) -> bool:
+        return self._metrics_path is not None
+
+    def _provider_request_hash(self, provider: ProviderSPI | None) -> str | None:
+        if provider is None:
+            return None
+        return content_hash(
+            provider.name(),
+            self._request.prompt_text,
+            self._request.options,
+            self._request.max_tokens,
+        )
+
+    def _provider_model(self, provider: ProviderSPI) -> str | None:
+        for attr in ("model", "_model"):
+            value = getattr(provider, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    def record_skip(self, provider: ProviderSPI, attempt: int, error: ProviderSkip) -> None:
+        if not self.enabled():
+            return
+        log_event(
+            "provider_skipped",
+            self._metrics_path,
+            request_fingerprint=self._request_fingerprint,
+            request_hash=self._provider_request_hash(provider),
+            provider=provider.name(),
+            attempt=attempt,
+            total_providers=self._total_providers,
+            reason=error.reason if hasattr(error, "reason") else None,
+            error_message=str(error),
+        )
+
+    def log_provider_call(
+        self,
+        *,
+        provider: ProviderSPI,
+        attempt: int,
+        status: str,
+        latency_ms: int | None,
+        tokens_in: int | None,
+        tokens_out: int | None,
+        error: Exception | None,
+    ) -> None:
+        if not self.enabled():
+            return
+        error_type = type(error).__name__ if error is not None else None
+        error_message = str(error) if error is not None else None
+        log_event(
+            "provider_call",
+            self._metrics_path,
+            request_fingerprint=self._request_fingerprint,
+            request_hash=self._provider_request_hash(provider),
+            provider=provider.name(),
+            model=self._provider_model(provider),
+            attempt=attempt,
+            total_providers=self._total_providers,
+            status=status,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            error_type=error_type,
+            error_message=error_message,
+            shadow_used=self._shadow is not None,
+            trace_id=self._metadata.get("trace_id"),
+            project_id=self._metadata.get("project_id"),
+        )
+
+    def log_run_metric(
+        self,
+        *,
+        status: str,
+        provider: ProviderSPI | None,
+        attempts: int,
+        latency_ms: int,
+        tokens_in: int | None,
+        tokens_out: int | None,
+        cost_usd: float,
+        error: Exception | None,
+    ) -> None:
+        if not self.enabled():
+            return
+        error_type = type(error).__name__ if error else None
+        error_message = str(error) if error else None
+        provider_name = provider.name() if provider is not None else None
+        log_event(
+            "run_metric",
+            self._metrics_path,
+            request_fingerprint=self._request_fingerprint,
+            request_hash=self._provider_request_hash(provider),
+            provider=provider_name,
+            status=status,
+            attempts=attempts,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=float(cost_usd),
+            error_type=error_type,
+            error_message=error_message,
+            shadow_used=self._shadow is not None,
+            trace_id=self._metadata.get("trace_id"),
+            project_id=self._metadata.get("project_id"),
+        )
+
+    def log_chain_failure(self, providers: Sequence[ProviderSPI], last_error: Exception | None) -> None:
+        if not self.enabled():
+            return
+        log_event(
+            "provider_chain_failed",
+            self._metrics_path,
+            request_fingerprint=self._request_fingerprint,
+            provider_attempts=len(providers),
+            providers=[provider.name() for provider in providers],
+            last_error_type=type(last_error).__name__ if last_error else None,
+            last_error_message=str(last_error) if last_error else None,
+        )
 
 
 class Runner:
     """Attempt providers sequentially until one succeeds."""
 
-    def __init__(self, providers: Sequence[ProviderSPI]):
+    def __init__(
+        self,
+        providers: Sequence[ProviderSPI],
+        *,
+        config: RunnerConfig | None = None,
+    ) -> None:
         if not providers:
             raise ValueError("Runner requires at least one provider")
         self.providers: list[ProviderSPI] = list(providers)
+        self._config = config or RunnerConfig()
 
     def run(
         self,
         request: ProviderRequest,
         shadow: ProviderSPI | None = None,
         shadow_metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+        *,
+        config: RunnerConfig | None = None,
+        event_logger: EventLogger | None = None,
     ) -> ProviderResponse:
         """Execute ``request`` with fallback semantics."""
 
         last_err: Exception | None = None
-        metrics_path_str = None if shadow_metrics_path is None else str(Path(shadow_metrics_path))
         metadata = request.metadata or {}
         run_started = time.time()
-        request_fingerprint = content_hash(
-            "runner", request.prompt_text, request.options, request.max_tokens
+        resolved_config = config or self._config
+        attempts_budget = resolved_config.attempts_budget(len(self.providers))
+        providers = self.providers[:attempts_budget]
+        active_logger = event_logger or EventLogger(
+            metrics_path=shadow_metrics_path,
+            request=request,
+            total_providers=len(self.providers),
+            shadow=shadow,
         )
 
-        def _record_skip(err: ProviderSkip, attempt: int, provider: ProviderSPI) -> None:
-            if not metrics_path_str:
-                return
-            log_event(
-                "provider_skipped",
-                metrics_path_str,
-                request_fingerprint=request_fingerprint,
-                request_hash=content_hash(
-                    provider.name(),
-                    request.prompt_text,
-                    request.options,
-                    request.max_tokens,
-                ),
-                provider=provider.name(),
-                attempt=attempt,
-                total_providers=len(self.providers),
-                reason=err.reason if hasattr(err, "reason") else None,
-                error_message=str(err),
-            )
-
-        def _provider_model(provider: ProviderSPI) -> str | None:
-            for attr in ("model", "_model"):
-                value = getattr(provider, attr, None)
-                if isinstance(value, str) and value:
-                    return value
-            return None
-
-        def _elapsed_ms(start_ts: float) -> int:
-            return max(0, int((time.time() - start_ts) * 1000))
-
-        def _log_provider_call(
-            provider: ProviderSPI,
-            attempt: int,
-            *,
-            status: str,
-            latency_ms: int | None,
-            tokens_in: int | None,
-            tokens_out: int | None,
-            error: Exception | None = None,
-        ) -> None:
-            if not metrics_path_str:
-                return
-
-            error_type = type(error).__name__ if error is not None else None
-            error_message = str(error) if error is not None else None
-
-            log_event(
-                "provider_call",
-                metrics_path_str,
-                request_fingerprint=request_fingerprint,
-                request_hash=content_hash(
-                    provider.name(),
-                    request.prompt_text,
-                    request.options,
-                    request.max_tokens,
-                ),
-                provider=provider.name(),
-                model=_provider_model(provider),
-                attempt=attempt,
-                total_providers=len(self.providers),
-                status=status,
-                latency_ms=latency_ms,
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                error_type=error_type,
-                error_message=error_message,
-                shadow_used=shadow is not None,
-                trace_id=metadata.get("trace_id"),
-                project_id=metadata.get("project_id"),
-            )
-
-        def _estimate_cost(provider: ProviderSPI, tokens_in: int, tokens_out: int) -> float:
-            estimator = getattr(provider, "estimate_cost", None)
-            if callable(estimator):
-                try:
-                    return float(estimator(tokens_in, tokens_out))
-                except Exception:  # pragma: no cover - defensive guard
-                    return 0.0
-            return 0.0
-
-        def _log_run_metric(
-            *,
-            status: str,
-            provider: ProviderSPI | None,
-            attempts: int,
-            latency_ms: int,
-            tokens_in: int | None,
-            tokens_out: int | None,
-            cost_usd: float,
-            error: Exception | None,
-        ) -> None:
-            if not metrics_path_str:
-                return
-
-            error_type = type(error).__name__ if error else None
-            error_message = str(error) if error else None
-            provider_name = provider.name() if provider is not None else None
-            request_hash = (
-                content_hash(
-                    provider_name,
-                    request.prompt_text,
-                    request.options,
-                    request.max_tokens,
-                )
-                if provider_name
-                else None
-            )
-
-            log_event(
-                "run_metric",
-                metrics_path_str,
-                request_fingerprint=request_fingerprint,
-                request_hash=request_hash,
-                provider=provider_name,
-                status=status,
-                attempts=attempts,
-                latency_ms=latency_ms,
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                cost_usd=float(cost_usd),
-                error_type=error_type,
-                error_message=error_message,
-                shadow_used=shadow is not None,
-                trace_id=metadata.get("trace_id"),
-                project_id=metadata.get("project_id"),
-            )
-
-        for attempt_index, provider in enumerate(self.providers, start=1):
+        for attempt_index, provider in enumerate(providers, start=1):
             attempt_started = time.time()
             try:
-                response = run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
+                response = self._invoke_provider(provider, shadow, request, shadow_metrics_path)
             except ProviderSkip as err:
                 last_err = err
-                _record_skip(err, attempt_index, provider)
-                _log_provider_call(
-                    provider,
-                    attempt_index,
+                active_logger.record_skip(provider, attempt_index, err)
+                active_logger.log_provider_call(
+                    provider=provider,
+                    attempt=attempt_index,
                     status="error",
-                    latency_ms=_elapsed_ms(attempt_started),
+                    latency_ms=elapsed_ms(attempt_started),
                     tokens_in=None,
                     tokens_out=None,
                     error=err,
@@ -185,32 +234,32 @@ class Runner:
                 continue
             except RateLimitError as err:
                 last_err = err
-                _log_provider_call(
-                    provider,
-                    attempt_index,
+                active_logger.log_provider_call(
+                    provider=provider,
+                    attempt=attempt_index,
                     status="error",
-                    latency_ms=_elapsed_ms(attempt_started),
+                    latency_ms=elapsed_ms(attempt_started),
                     tokens_in=None,
                     tokens_out=None,
                     error=err,
                 )
-                time.sleep(0.05)
+                self._sleep_on_rate_limit(resolved_config.backoff)
             except (TimeoutError, RetriableError) as err:
                 last_err = err
-                _log_provider_call(
-                    provider,
-                    attempt_index,
+                active_logger.log_provider_call(
+                    provider=provider,
+                    attempt=attempt_index,
                     status="error",
-                    latency_ms=_elapsed_ms(attempt_started),
+                    latency_ms=elapsed_ms(attempt_started),
                     tokens_in=None,
                     tokens_out=None,
                     error=err,
                 )
                 continue
             else:
-                _log_provider_call(
-                    provider,
-                    attempt_index,
+                active_logger.log_provider_call(
+                    provider=provider,
+                    attempt=attempt_index,
                     status="ok",
                     latency_ms=response.latency_ms,
                     tokens_in=response.input_tokens,
@@ -219,12 +268,12 @@ class Runner:
                 )
                 tokens_in = response.input_tokens
                 tokens_out = response.output_tokens
-                cost_usd = _estimate_cost(provider, tokens_in, tokens_out)
-                _log_run_metric(
+                cost_usd = self._estimate_cost(provider, tokens_in, tokens_out)
+                active_logger.log_run_metric(
                     status="ok",
                     provider=provider,
                     attempts=attempt_index,
-                    latency_ms=_elapsed_ms(run_started),
+                    latency_ms=elapsed_ms(run_started),
                     tokens_in=tokens_in,
                     tokens_out=tokens_out,
                     cost_usd=cost_usd,
@@ -232,21 +281,12 @@ class Runner:
                 )
                 return response
 
-        if metrics_path_str:
-            log_event(
-                "provider_chain_failed",
-                metrics_path_str,
-                request_fingerprint=request_fingerprint,
-                provider_attempts=len(self.providers),
-                providers=[provider.name() for provider in self.providers],
-                last_error_type=type(last_err).__name__ if last_err else None,
-                last_error_message=str(last_err) if last_err else None,
-            )
-        _log_run_metric(
+        active_logger.log_chain_failure(providers, last_err)
+        active_logger.log_run_metric(
             status="error",
             provider=None,
-            attempts=len(self.providers),
-            latency_ms=_elapsed_ms(run_started),
+            attempts=len(providers),
+            latency_ms=elapsed_ms(run_started),
             tokens_in=None,
             tokens_out=None,
             cost_usd=0.0,
@@ -254,5 +294,29 @@ class Runner:
         )
         raise last_err if last_err is not None else RuntimeError("No providers succeeded")
 
+    def _invoke_provider(
+        self,
+        provider: ProviderSPI,
+        shadow: ProviderSPI | None,
+        request: ProviderRequest,
+        metrics_path: MetricsPath,
+    ) -> ProviderResponse:
+        metrics_path_str = None if metrics_path is None else str(Path(metrics_path))
+        return run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
 
-__all__ = ["Runner"]
+    def _sleep_on_rate_limit(self, backoff: BackoffPolicy) -> None:
+        if backoff.rate_limit_seconds <= 0:
+            return
+        time.sleep(backoff.rate_limit_seconds)
+
+    def _estimate_cost(self, provider: ProviderSPI, tokens_in: int, tokens_out: int) -> float:
+        estimator = getattr(provider, "estimate_cost", None)
+        if callable(estimator):
+            try:
+                return float(estimator(tokens_in, tokens_out))
+            except Exception:  # pragma: no cover - defensive guard
+                return 0.0
+        return 0.0
+
+
+__all__ = ["BackoffPolicy", "Runner", "RunnerConfig", "EventLogger"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/utils.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/utils.py
@@ -1,6 +1,7 @@
-"""Utility helpers for hashing request payloads."""
+"""Utility helpers for hashing request payloads and timing."""
 
 import hashlib
+import time
 from typing import Any
 
 
@@ -17,3 +18,10 @@ def content_hash(
     if options:
         h.update(repr(sorted(options.items())).encode())
     return h.hexdigest()[:16]
+
+
+def elapsed_ms(start_ts: float, *, end_ts: float | None = None) -> int:
+    """Return elapsed milliseconds between ``start_ts`` and now (clamped to >= 0)."""
+
+    end = end_ts if end_ts is not None else time.time()
+    return max(0, int((end - start_ts) * 1000))


### PR DESCRIPTION
## Summary
- add BackoffPolicy and RunnerConfig dataclasses and refactor Runner to use EventLogger helpers
- share elapsed_ms timing helper across runner and tests
- extend fallback tests to cover configurable backoff and attempt limits

## Testing
- pytest tests/shadow/test_runner_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e007bec88321a8b758decf0b1668