### PR TITLE
refactor: introduce event logger abstraction

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
@@ -2,39 +2,19 @@
 
 from __future__ import annotations
 
-import json
-import time
-from pathlib import Path
-from threading import Lock
 from typing import Any, Union
+
+from .observability import DEFAULT_LOGGER, EventLogger
 
 PathLike = Union[str, "Path"]
 
-
-_LOG_LOCK = Lock()
-
-
-def _ensure_dir(path: Path) -> None:
-    """Create the parent directory for ``path`` if it is missing."""
-
-    parent = path.parent
-    if parent != Path(""):
-        parent.mkdir(parents=True, exist_ok=True)
+_DEFAULT_LOGGER: EventLogger = DEFAULT_LOGGER
 
 
 def log_event(event_type: str, path: PathLike, **fields: Any) -> None:
-    """Append a structured metrics record to ``path``.
+    """Append a structured metrics record to ``path`` using the default logger."""
 
-    The file is encoded as UTF-8 JSONL so that it can easily be tailed or
-    ingested by lightweight tooling.
-    """
+    _DEFAULT_LOGGER.emit(event_type, path, **fields)
 
-    target = Path(path)
-    _ensure_dir(target)
 
-    record = {"ts": int(time.time() * 1000), "event": event_type}
-    record.update(fields)
-
-    with _LOG_LOCK:
-        with target.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+__all__ = ["log_event"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/observability.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/observability.py
@@ -1,0 +1,86 @@
+"""Event logging primitives for metrics emission."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from threading import Lock
+from typing import Any, Iterable, Protocol, Sequence, TextIO
+
+PathLike = str | Path
+
+
+def _ensure_dir(path: Path) -> None:
+    parent = path.parent
+    if parent != Path(""):
+        parent.mkdir(parents=True, exist_ok=True)
+
+
+class EventLogger(Protocol):
+    """Protocol for structured event sinks."""
+
+    def emit(self, event_type: str, path: PathLike, **fields: Any) -> None:
+        """Persist a structured event."""
+        ...
+
+
+class JsonlLogger:
+    """Append structured events to a JSONL file."""
+
+    _LOCK = Lock()
+
+    def emit(self, event_type: str, path: PathLike, **fields: Any) -> None:
+        target = Path(path)
+        _ensure_dir(target)
+
+        record = dict(fields)
+        record.setdefault("ts", int(time.time() * 1000))
+        record["event"] = event_type
+
+        with self._LOCK:
+            with target.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+class StdLogger:
+    """Write structured events to a text stream as JSONL."""
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self._stream: TextIO = stream if stream is not None else sys.stdout
+
+    def emit(self, event_type: str, path: PathLike, **fields: Any) -> None:  # pragma: no cover - passthrough
+        record = dict(fields)
+        record.setdefault("ts", int(time.time() * 1000))
+        record["event"] = event_type
+        self._stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+        self._stream.flush()
+
+
+class CompositeLogger:
+    """Broadcast events to multiple loggers."""
+
+    def __init__(self, loggers: Sequence[EventLogger] | Iterable[EventLogger]) -> None:
+        self._loggers: tuple[EventLogger, ...] = tuple(loggers)
+
+    def emit(self, event_type: str, path: PathLike, **fields: Any) -> None:
+        if not self._loggers:
+            return
+
+        payload = dict(fields)
+        payload.setdefault("ts", int(time.time() * 1000))
+        for logger in self._loggers:
+            logger.emit(event_type, path, **payload)
+
+
+DEFAULT_LOGGER = JsonlLogger()
+
+
+__all__ = [
+    "CompositeLogger",
+    "DEFAULT_LOGGER",
+    "EventLogger",
+    "JsonlLogger",
+    "StdLogger",
+]


### PR DESCRIPTION
## Summary
- add an observability module with composable event loggers and a shared JSONL implementation
- update runner and shadow execution to use pluggable event loggers while preserving existing payloads
- switch metrics-related tests to rely on an in-memory fake logger instead of filesystem checks

## Testing
- pytest projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68d7e0096fc48321b6defaf314c2b866