### PR TITLE
Add asyncio execution path to shadow runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -199,7 +199,7 @@ def ensure_async_provider(provider: ProviderSPI | AsyncProviderSPI) -> AsyncProv
         async def _invoke(request: ProviderRequest) -> ProviderResponse:
             result = invoke_async(request)
             if inspect.isawaitable(result):
-                return cast(ProviderResponse, await cast(Awaitable[ProviderResponse], result))
+                return await cast(Awaitable[ProviderResponse], result)
             return cast(ProviderResponse, result)
 
         return _AsyncProviderAdapter(provider, async_invoke=_invoke)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -1,15 +1,22 @@
-"""Provider runner with fallback handling."""
+"""Provider runner with synchronous and asynchronous execution helpers."""
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Sequence
 from pathlib import Path
 
 from .errors import ProviderSkip, RateLimitError, RetriableError, TimeoutError
 from .metrics import log_event
-from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
-from .shadow import DEFAULT_METRICS_PATH, run_with_shadow
+from .provider_spi import (
+    AsyncProviderSPI,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderSPI,
+    ensure_async_provider,
+)
+from .shadow import DEFAULT_METRICS_PATH, run_with_shadow, run_with_shadow_async
 from .utils import content_hash
 
 MetricsPath = str | Path | None
@@ -255,4 +262,255 @@ class Runner:
         raise last_err if last_err is not None else RuntimeError("No providers succeeded")
 
 
-__all__ = ["Runner"]
+class AsyncRunner:
+    """Async counterpart of :class:`Runner` providing ``asyncio`` bridges."""
+
+    def __init__(self, providers: Sequence[ProviderSPI | AsyncProviderSPI]):
+        if not providers:
+            raise ValueError("AsyncRunner requires at least one provider")
+        self.providers: list[tuple[ProviderSPI | AsyncProviderSPI, AsyncProviderSPI]] = [
+            (provider, ensure_async_provider(provider)) for provider in providers
+        ]
+
+    async def run_async(
+        self,
+        request: ProviderRequest,
+        shadow: ProviderSPI | AsyncProviderSPI | None = None,
+        shadow_metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+    ) -> ProviderResponse:
+        last_err: Exception | None = None
+        metrics_path_str = None if shadow_metrics_path is None else str(Path(shadow_metrics_path))
+        metadata = request.metadata or {}
+        run_started = time.time()
+        request_fingerprint = content_hash(
+            "runner", request.prompt_text, request.options, request.max_tokens
+        )
+
+        shadow_async = ensure_async_provider(shadow) if shadow is not None else None
+
+        def _record_skip(
+            err: ProviderSkip, attempt: int, provider: ProviderSPI | AsyncProviderSPI
+        ) -> None:
+            if not metrics_path_str:
+                return
+            log_event(
+                "provider_skipped",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                request_hash=content_hash(
+                    provider.name(),
+                    request.prompt_text,
+                    request.options,
+                    request.max_tokens,
+                ),
+                provider=provider.name(),
+                attempt=attempt,
+                total_providers=len(self.providers),
+                reason=err.reason if hasattr(err, "reason") else None,
+                error_message=str(err),
+            )
+
+        def _provider_model(provider: ProviderSPI | AsyncProviderSPI) -> str | None:
+            for attr in ("model", "_model"):
+                value = getattr(provider, attr, None)
+                if isinstance(value, str) and value:
+                    return value
+            return None
+
+        def _elapsed_ms(start_ts: float) -> int:
+            return max(0, int((time.time() - start_ts) * 1000))
+
+        def _log_provider_call(
+            provider: ProviderSPI | AsyncProviderSPI,
+            attempt: int,
+            *,
+            status: str,
+            latency_ms: int | None,
+            tokens_in: int | None,
+            tokens_out: int | None,
+            error: Exception | None = None,
+        ) -> None:
+            if not metrics_path_str:
+                return
+
+            error_type = type(error).__name__ if error is not None else None
+            error_message = str(error) if error is not None else None
+
+            log_event(
+                "provider_call",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                request_hash=content_hash(
+                    provider.name(),
+                    request.prompt_text,
+                    request.options,
+                    request.max_tokens,
+                ),
+                provider=provider.name(),
+                model=_provider_model(provider),
+                attempt=attempt,
+                total_providers=len(self.providers),
+                status=status,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                error_type=error_type,
+                error_message=error_message,
+                shadow_used=shadow is not None,
+                trace_id=metadata.get("trace_id"),
+                project_id=metadata.get("project_id"),
+            )
+
+        def _estimate_cost(
+            provider: ProviderSPI | AsyncProviderSPI, tokens_in: int, tokens_out: int
+        ) -> float:
+            estimator = getattr(provider, "estimate_cost", None)
+            if callable(estimator):
+                try:
+                    return float(estimator(tokens_in, tokens_out))
+                except Exception:  # pragma: no cover - defensive guard
+                    return 0.0
+            return 0.0
+
+        def _log_run_metric(
+            *,
+            status: str,
+            provider: ProviderSPI | AsyncProviderSPI | None,
+            attempts: int,
+            latency_ms: int,
+            tokens_in: int | None,
+            tokens_out: int | None,
+            cost_usd: float,
+            error: Exception | None,
+        ) -> None:
+            if not metrics_path_str:
+                return
+
+            error_type = type(error).__name__ if error else None
+            error_message = str(error) if error else None
+            provider_name = provider.name() if provider is not None else None
+            request_hash = (
+                content_hash(
+                    provider_name,
+                    request.prompt_text,
+                    request.options,
+                    request.max_tokens,
+                )
+                if provider_name
+                else None
+            )
+
+            log_event(
+                "run_metric",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                request_hash=request_hash,
+                provider=provider_name,
+                status=status,
+                attempts=attempts,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=float(cost_usd),
+                error_type=error_type,
+                error_message=error_message,
+                shadow_used=shadow is not None,
+                trace_id=metadata.get("trace_id"),
+                project_id=metadata.get("project_id"),
+            )
+
+        for attempt_index, (provider, async_provider) in enumerate(self.providers, start=1):
+            attempt_started = time.time()
+            try:
+                response = await run_with_shadow_async(
+                    async_provider,
+                    shadow_async,
+                    request,
+                    metrics_path=metrics_path_str,
+                )
+            except ProviderSkip as err:
+                last_err = err
+                _record_skip(err, attempt_index, provider)
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
+                continue
+            except RateLimitError as err:
+                last_err = err
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
+                await asyncio.sleep(0.05)
+            except (TimeoutError, RetriableError) as err:
+                last_err = err
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="error",
+                    latency_ms=_elapsed_ms(attempt_started),
+                    tokens_in=None,
+                    tokens_out=None,
+                    error=err,
+                )
+                continue
+            else:
+                _log_provider_call(
+                    provider,
+                    attempt_index,
+                    status="ok",
+                    latency_ms=response.latency_ms,
+                    tokens_in=response.input_tokens,
+                    tokens_out=response.output_tokens,
+                    error=None,
+                )
+                tokens_in = response.input_tokens
+                tokens_out = response.output_tokens
+                cost_usd = _estimate_cost(provider, tokens_in, tokens_out)
+                _log_run_metric(
+                    status="ok",
+                    provider=provider,
+                    attempts=attempt_index,
+                    latency_ms=_elapsed_ms(run_started),
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    cost_usd=cost_usd,
+                    error=None,
+                )
+                return response
+
+        if metrics_path_str:
+            log_event(
+                "provider_chain_failed",
+                metrics_path_str,
+                request_fingerprint=request_fingerprint,
+                provider_attempts=len(self.providers),
+                providers=[provider.name() for provider, _ in self.providers],
+                last_error_type=type(last_err).__name__ if last_err else None,
+                last_error_message=str(last_err) if last_err else None,
+            )
+        _log_run_metric(
+            status="error",
+            provider=None,
+            attempts=len(self.providers),
+            latency_ms=_elapsed_ms(run_started),
+            tokens_in=None,
+            tokens_out=None,
+            cost_usd=0.0,
+            error=last_err,
+        )
+        raise last_err if last_err is not None else RuntimeError("No providers succeeded")
+
+
+__all__ = ["Runner", "AsyncRunner"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import threading
 import time
 from pathlib import Path
 from typing import Any
-
-import asyncio
-import contextlib
 
 from .metrics import log_event
 from .provider_spi import (

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -7,8 +7,17 @@ import time
 from pathlib import Path
 from typing import Any
 
+import asyncio
+import contextlib
+
 from .metrics import log_event
-from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from .provider_spi import (
+    AsyncProviderSPI,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderSPI,
+    ensure_async_provider,
+)
 from .utils import content_hash
 
 MetricsPath = str | Path | None
@@ -138,4 +147,116 @@ def run_with_shadow(
     return primary_res
 
 
-__all__ = ["run_with_shadow", "DEFAULT_METRICS_PATH"]
+async def run_with_shadow_async(
+    primary: ProviderSPI | AsyncProviderSPI,
+    shadow: ProviderSPI | AsyncProviderSPI | None,
+    req: ProviderRequest,
+    metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+) -> ProviderResponse:
+    primary_async = ensure_async_provider(primary)
+    shadow_async = ensure_async_provider(shadow) if shadow is not None else None
+
+    shadow_task: asyncio.Task[dict[str, Any]] | None = None
+    shadow_payload: dict[str, Any] | None = None
+    shadow_name: str | None = None
+    shadow_started: float | None = None
+    metrics_path_str = _to_path_str(metrics_path)
+
+    if shadow_async is not None:
+        shadow_name = shadow_async.name()
+        shadow_started = time.time()
+
+        async def _shadow_worker() -> dict[str, Any]:
+            ts0 = time.time()
+            try:
+                response = await shadow_async.invoke_async(req)
+            except Exception as exc:  # pragma: no cover - logged below
+                payload = {
+                    "ok": False,
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                    "provider": shadow_name,
+                }
+            else:
+                payload = {
+                    "ok": True,
+                    "provider": shadow_name,
+                    "latency_ms": response.latency_ms,
+                    "text_len": len(response.text),
+                    "token_usage_total": _tokens_total(response),
+                }
+            payload["duration_ms"] = int((time.time() - ts0) * 1000)
+            return payload
+
+        shadow_task = asyncio.create_task(_shadow_worker())
+
+    try:
+        primary_res = await primary_async.invoke_async(req)
+    except Exception:
+        if shadow_task is not None:
+            shadow_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await shadow_task
+        raise
+
+    if shadow_task is not None:
+        try:
+            shadow_payload = await asyncio.wait_for(shadow_task, timeout=10)
+        except asyncio.TimeoutError:
+            shadow_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await shadow_task
+            duration_ms = 0
+            if shadow_started is not None:
+                duration_ms = int((time.time() - shadow_started) * 1000)
+            shadow_payload = {
+                "provider": shadow_name,
+                "ok": False,
+                "error": "ShadowTimeout",
+                "duration_ms": duration_ms,
+            }
+        except asyncio.CancelledError:  # pragma: no cover - defensive
+            shadow_payload = {"provider": shadow_name, "ok": False}
+
+        if shadow_payload is None:
+            shadow_payload = {"provider": shadow_name, "ok": False}
+
+        if metrics_path_str:
+            primary_text_len = len(primary_res.text)
+            request_fingerprint = content_hash(
+                "runner", req.prompt_text, req.options, req.max_tokens
+            )
+            record: dict[str, Any] = {
+                "request_hash": content_hash(
+                    primary_async.name(), req.prompt_text, req.options, req.max_tokens
+                ),
+                "request_fingerprint": request_fingerprint,
+                "primary_provider": primary_async.name(),
+                "primary_latency_ms": primary_res.latency_ms,
+                "primary_text_len": primary_text_len,
+                "primary_token_usage_total": _tokens_total(primary_res),
+                "shadow_provider": shadow_payload.get("provider", shadow_name),
+                "shadow_ok": shadow_payload.get("ok"),
+                "shadow_latency_ms": shadow_payload.get("latency_ms"),
+                "shadow_duration_ms": shadow_payload.get("duration_ms"),
+                "shadow_error": shadow_payload.get("error"),
+            }
+
+            if shadow_payload.get("latency_ms") is not None:
+                record["latency_gap_ms"] = shadow_payload["latency_ms"] - primary_res.latency_ms
+
+            if shadow_payload.get("text_len") is not None:
+                record["shadow_text_len"] = shadow_payload["text_len"]
+
+            if shadow_payload.get("token_usage_total") is not None:
+                record["shadow_token_usage_total"] = shadow_payload["token_usage_total"]
+
+            if shadow_payload.get("message"):
+                record["shadow_error_message"] = shadow_payload["message"]
+
+            log_event("shadow_diff", metrics_path_str, **record)
+
+    return primary_res
+
+
+__all__ = ["run_with_shadow", "run_with_shadow_async", "DEFAULT_METRICS_PATH"]

--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.providers.mock import MockProvider
+from src.llm_adapter.runner import AsyncRunner, Runner
+
+
+def test_async_runner_matches_sync(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    sync_runner = Runner([primary])
+    async_runner = AsyncRunner([primary])
+
+    sync_request = ProviderRequest(prompt="hello", metadata={"trace_id": "t1"}, model="primary-model")
+    async_request = ProviderRequest(prompt="hello", metadata={"trace_id": "t1"}, model="primary-model")
+
+    sync_metrics = tmp_path / "sync-metrics.jsonl"
+    async_metrics = tmp_path / "async-metrics.jsonl"
+
+    sync_response = sync_runner.run(sync_request, shadow_metrics_path=sync_metrics)
+    async_response = asyncio.run(
+        async_runner.run_async(async_request, shadow_metrics_path=async_metrics)
+    )
+
+    assert async_response.text == sync_response.text
+    assert async_response.model == sync_response.model
+    assert async_metrics.exists()
+
+
+def test_async_shadow_exec_records_metrics(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
+    runner = AsyncRunner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    metadata = {"trace_id": "trace-async", "project_id": "proj-async"}
+    request = ProviderRequest(prompt="hello", metadata=metadata, model="primary-model")
+
+    response = asyncio.run(
+        runner.run_async(
+            request,
+            shadow=shadow,
+            shadow_metrics_path=metrics_path,
+        )
+    )
+
+    assert response.text.startswith("echo(primary):")
+    assert metrics_path.exists()
+
+    payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
+    call_event = next(item for item in payloads if item["event"] == "provider_call")
+
+    assert diff_event["primary_provider"] == "primary"
+    assert diff_event["shadow_provider"] == "shadow"
+    assert diff_event["shadow_ok"] is True
+    token_usage = response.token_usage
+    assert token_usage is not None
+    assert diff_event["primary_token_usage_total"] == token_usage.total
+    expected_tokens = max(1, len("hello") // 4) + 16
+    assert diff_event["shadow_token_usage_total"] == expected_tokens
+    assert diff_event["shadow_text_len"] == len("echo(shadow): hello")
+    assert diff_event["request_fingerprint"]
+    assert call_event["provider"] == "primary"
+    assert call_event["shadow_used"] is True
+    assert call_event["status"] == "ok"
+    assert call_event["latency_ms"] == response.latency_ms
+    assert call_event["tokens_in"] == token_usage.prompt
+    assert call_event["tokens_out"] == token_usage.completion
+    assert call_event["trace_id"] == metadata["trace_id"]
+    assert call_event["project_id"] == metadata["project_id"]
+
+
+def test_async_shadow_error_records_metrics(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    runner = AsyncRunner([primary])
+
+    metrics_path = tmp_path / "metrics-error.jsonl"
+
+    asyncio.run(
+        runner.run_async(
+            ProviderRequest(prompt="[TIMEOUT] hello", model="primary-model"),
+            shadow=shadow,
+            shadow_metrics_path=metrics_path,
+        )
+    )
+
+    payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
+
+    assert diff_event["shadow_ok"] is False
+    assert diff_event["shadow_error"] == "TimeoutError"
+    assert diff_event["shadow_error_message"] == "simulated timeout"
+    assert diff_event["shadow_duration_ms"] >= 0


### PR DESCRIPTION
## Summary
- introduce AsyncProviderSPI plus helper to wrap synchronous providers for asyncio
- add AsyncRunner with async run support and async-aware shadow execution bridge
- provide async shadow helper and pytest coverage ensuring metrics parity with sync path

## Testing
- pytest projects/04-llm-adapter-shadow/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7e003e5508321a87ce20badabc078