### PR TITLE
refactor: refine adapter error families and logging

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -6,7 +6,13 @@ from typing import Any
 
 import pytest
 
-from src.llm_adapter.errors import AuthError, ProviderSkip, RateLimitError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    ProviderSkip,
+    ProviderSkipReason,
+    RateLimitError,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.gemini import GeminiProvider
 
@@ -139,7 +145,8 @@ def test_gemini_provider_skips_without_api_key(monkeypatch, provider_request_mod
     with pytest.raises(ProviderSkip) as excinfo:
         provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
-    assert excinfo.value.reason == "missing_gemini_api_key"
+    assert excinfo.value.reason == ProviderSkipReason.MISSING_GEMINI_API_KEY
+    assert isinstance(excinfo.value.reason, ProviderSkipReason)
 
 
 def test_gemini_provider_translates_rate_limit(provider_request_model):

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
@@ -188,6 +188,9 @@ def test_runner_fallback_paths(
     skip_events = [rec for rec in records if rec["event"] == "provider_skipped"]
     assert len(skip_events) == expected_skip_events
 
+    for event in skip_events:
+        assert event.get("error_family") == "skip"
+
     if expected_run_status == "ok":
         assert response is not None
     else:
@@ -218,6 +221,7 @@ def test_rate_limit_triggers_backoff_and_logs(
     )
     assert first_call["status"] == "error"
     assert first_call["error_type"] == "RateLimitError"
+    assert first_call["error_family"] == "rate_limit"
 
 
 def test_timeout_switches_to_next_provider(tmp_path: Path) -> None:
@@ -234,6 +238,7 @@ def test_timeout_switches_to_next_provider(tmp_path: Path) -> None:
     )
     assert timeout_event["status"] == "error"
     assert timeout_event["error_type"] == "TimeoutError"
+    assert timeout_event["error_family"] == "retryable"
 
     success_event = next(
         rec
@@ -241,6 +246,7 @@ def test_timeout_switches_to_next_provider(tmp_path: Path) -> None:
         if rec["event"] == "provider_call" and rec["provider"] == "success"
     )
     assert success_event["status"] == "ok"
+    assert success_event.get("error_family") is None
 
 
 def test_run_metric_contains_tokens_and_cost(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- introduce RetryableError, SkipError, and FatalError bases in the adapter error hierarchy while keeping existing subclasses backwards compatible
- model ProviderSkip reasons with ProviderSkipReason and normalize logging to include error_family metadata
- adjust runner sync/async flows and tests to cover the new error families and structured skip reasons

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ec196bc4832180341c4d39ff045c