### PR TITLE
refactor: restructure adapter error hierarchy

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -8,53 +8,90 @@ Runner retry policy:
 
 from __future__ import annotations
 
+from enum import Enum
+
 
 class AdapterError(Exception):
     """Base class for errors originating from providers or the adapter."""
 
 
-class TimeoutError(AdapterError):
+class RetryableError(AdapterError):
+    """Base class for errors where retrying the next provider is recommended."""
+
+
+class SkipError(AdapterError):
+    """Base class for events where the provider should be skipped without retry."""
+
+
+class FatalError(AdapterError):
+    """Base class for unrecoverable issues that should halt the runner."""
+
+
+class TimeoutError(RetryableError):
     """Raised when a provider does not respond within the expected window (instant fallback)."""
 
 
-class RateLimitError(AdapterError):
+class RateLimitError(RetryableError):
     """Raised when a provider rejects the request due to rate limiting (0.05 s backoff)."""
 
 
-class AuthError(AdapterError):
+class AuthError(FatalError):
     """Raised when credentials are missing or invalid for the provider."""
 
 
-class RetriableError(AdapterError):
+class RetriableError(RetryableError):
     """Raised for transient issues where retrying with another provider may help.
 
     Runner instantly falls back to the next provider when this error is encountered.
     """
 
 
-class FatalError(AdapterError):
-    """Raised for unrecoverable issues that should halt the runner."""
+class SkipReason(str, Enum):
+    """Structured reasons explaining why a provider was skipped."""
+
+    UNKNOWN = "unknown"
+    MISSING_GEMINI_API_KEY = "missing_gemini_api_key"
 
 
-class ProviderSkip(AdapterError):
+class ProviderSkip(SkipError):
     """Raised when a provider should be skipped without counting as a failure (logged only)."""
 
-    def __init__(self, message: str, *, reason: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: SkipReason | str | None = None,
+    ) -> None:
         super().__init__(message)
-        self.reason = reason
+        self._message = message
+        if reason is None:
+            self.reason: SkipReason | None = None
+        elif isinstance(reason, SkipReason):
+            self.reason = reason
+        else:
+            try:
+                self.reason = SkipReason(reason)
+            except ValueError:
+                self.reason = SkipReason.UNKNOWN
+
+    def __str__(self) -> str:
+        return self._message
 
 
-class ConfigError(AdapterError):
+class ConfigError(FatalError):
     """Raised when a provider is misconfigured."""
 
 
 __all__ = [
     "AdapterError",
+    "RetriableError",
+    "RetryableError",
     "TimeoutError",
     "RateLimitError",
     "AuthError",
-    "RetriableError",
+    "SkipError",
     "FatalError",
     "ProviderSkip",
+    "SkipReason",
     "ConfigError",
 ]

--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -6,7 +6,13 @@ from typing import Any
 
 import pytest
 
-from src.llm_adapter.errors import AuthError, ProviderSkip, RateLimitError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    ProviderSkip,
+    RateLimitError,
+    SkipReason,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.gemini import GeminiProvider
 
@@ -139,7 +145,7 @@ def test_gemini_provider_skips_without_api_key(monkeypatch, provider_request_mod
     with pytest.raises(ProviderSkip) as excinfo:
         provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
-    assert excinfo.value.reason == "missing_gemini_api_key"
+    assert excinfo.value.reason is SkipReason.MISSING_GEMINI_API_KEY
 
 
 def test_gemini_provider_translates_rate_limit(provider_request_model):


### PR DESCRIPTION
## Summary
- add retryable, skip, and fatal adapter error base classes and expose them via __all__
- introduce SkipReason enum and update ProviderSkip to carry enum reasons while keeping compatibility
- adjust gemini provider test to assert the enum-based skip reason

## Testing
- pytest projects/04-llm-adapter-shadow -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f171c8208321b5ad4760c2f7f779