### PR TITLE
Refine runner error handling and metrics logging

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -2,8 +2,8 @@
 
 Runner retry policy:
 - ``RateLimitError`` → waits 0.05 seconds before continuing with the next provider.
-- ``TimeoutError`` / ``RetriableError`` → immediately try the next provider with no delay.
-- ``ProviderSkip`` → simply recorded as a skip event; control moves on without retrying.
+- ``TimeoutError`` / ``RetryableError`` → immediately try the next provider with no delay.
+- ``SkipError`` → simply recorded as a skip event; control moves on without retrying.
 """
 
 from __future__ import annotations
@@ -13,31 +13,36 @@ class AdapterError(Exception):
     """Base class for errors originating from providers or the adapter."""
 
 
-class TimeoutError(AdapterError):
+class RetryableError(AdapterError):
+    """Base class for recoverable issues that should fall back to other providers."""
+
+
+class RetriableError(RetryableError):
+    """Backward-compatible alias for :class:`RetryableError`."""
+
+
+class TimeoutError(RetryableError):
     """Raised when a provider does not respond within the expected window (instant fallback)."""
 
 
-class RateLimitError(AdapterError):
-    """Raised when a provider rejects the request due to rate limiting (0.05 s backoff)."""
+class RateLimitError(RetryableError):
+    """Raised when a provider rejects the request due to rate limiting (backoff required)."""
 
 
 class AuthError(AdapterError):
     """Raised when credentials are missing or invalid for the provider."""
 
 
-class RetriableError(AdapterError):
-    """Raised for transient issues where retrying with another provider may help.
-
-    Runner instantly falls back to the next provider when this error is encountered.
-    """
-
-
 class FatalError(AdapterError):
     """Raised for unrecoverable issues that should halt the runner."""
 
 
-class ProviderSkip(AdapterError):
+class SkipError(AdapterError):
     """Raised when a provider should be skipped without counting as a failure (logged only)."""
+
+
+class ProviderSkip(SkipError):
+    """Backward-compatible alias for :class:`SkipError`."""
 
     def __init__(self, message: str, *, reason: str | None = None) -> None:
         super().__init__(message)
@@ -50,11 +55,13 @@ class ConfigError(AdapterError):
 
 __all__ = [
     "AdapterError",
+    "RetryableError",
     "TimeoutError",
     "RateLimitError",
     "AuthError",
     "RetriableError",
     "FatalError",
+    "SkipError",
     "ProviderSkip",
     "ConfigError",
 ]


### PR DESCRIPTION
## Summary
- introduce RetryableError/SkipError aliases to clarify adapter error families
- add RunnerConfig and rework runner loops to classify retryable, skip, and fatal outcomes with error_family logging
- preserve rate limit backoff semantics while feeding metrics with new error family context

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py projects/04-llm-adapter-shadow/tests/test_err_cases.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f173fc18832193f91ae89156837e