### PR TITLE
Add SkipReason enum for provider skip events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -15,6 +15,7 @@ from ..errors import (
     ProviderSkip,
     RateLimitError,
     RetriableError,
+    SkipReason,
     TimeoutError,
 )
 from ..provider_spi import ProviderRequest, ProviderResponse
@@ -205,11 +206,17 @@ class GeminiProvider(BaseProvider):
 
         api_key = os.getenv("GEMINI_API_KEY")
         if api_key is None:
-            raise ProviderSkip("gemini: GEMINI_API_KEY not set", reason="missing_gemini_api_key")
+            raise ProviderSkip(
+                "gemini: GEMINI_API_KEY not set",
+                reason=SkipReason.MISSING_GEMINI_API_KEY,
+            )
 
         api_key_value = api_key.strip()
         if not api_key_value:
-            raise ProviderSkip("gemini: GEMINI_API_KEY not set", reason="missing_gemini_api_key")
+            raise ProviderSkip(
+                "gemini: GEMINI_API_KEY not set",
+                reason=SkipReason.MISSING_GEMINI_API_KEY,
+            )
 
         module = cast(Any, self._client_module)
         client = cast(GeminiClientProtocol, module.Client(api_key=api_key_value))

--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -6,7 +6,13 @@ from typing import Any
 
 import pytest
 
-from src.llm_adapter.errors import AuthError, ProviderSkip, RateLimitError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    ProviderSkip,
+    RateLimitError,
+    SkipReason,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.gemini import GeminiProvider
 
@@ -139,7 +145,7 @@ def test_gemini_provider_skips_without_api_key(monkeypatch, provider_request_mod
     with pytest.raises(ProviderSkip) as excinfo:
         provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
 
-    assert excinfo.value.reason == "missing_gemini_api_key"
+    assert excinfo.value.reason == SkipReason.MISSING_GEMINI_API_KEY
 
 
 def test_gemini_provider_translates_rate_limit(provider_request_model):


### PR DESCRIPTION
## Summary
- introduce a SkipReason enum and normalize ProviderSkip reasons
- ensure runner metrics serialize enum-backed skip reasons and update Gemini provider usage
- cover the new behavior in the fallback and Gemini provider tests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f175f4bc832189443edd29190b5e