### PR TITLE
Share event logger between runner and shadow metrics

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -184,7 +184,13 @@ class Runner:
         for attempt_index, provider in enumerate(self.providers, start=1):
             attempt_started = time.time()
             try:
-                response = run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
+                response = run_with_shadow(
+                    provider,
+                    shadow,
+                    request,
+                    metrics_path=metrics_path_str,
+                    logger=event_logger,
+                )
             except ProviderSkip as err:
                 last_err = err
                 _record_skip(err, attempt_index, provider)
@@ -447,6 +453,7 @@ class AsyncRunner:
                     shadow_async,
                     request,
                     metrics_path=metrics_path_str,
+                    logger=event_logger,
                 )
             except ProviderSkip as err:
                 last_err = err

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -12,7 +11,6 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
 
-from src.llm_adapter import metrics as metrics_module
 from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.errors import ProviderSkip, RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
@@ -102,24 +100,18 @@ def _run_and_collect(
     prompt: str = "hello",
     expect_exception: type[Exception] | None = None,
 ) -> tuple[ProviderResponse | None, FakeLogger]:
-    runner = Runner(list(providers))
+    logger = FakeLogger()
+    runner = Runner(list(providers), logger=logger)
     request = ProviderRequest(prompt=prompt, model="demo-model")
 
-    logger = FakeLogger()
-    metrics_path = Path(f"/in-memory/{uuid.uuid4().hex}.jsonl")
-    with metrics_module._JSONL_LOGGERS_LOCK:
-        metrics_module._JSONL_LOGGERS[metrics_path] = logger
-    try:
-        if expect_exception is None:
-            response = runner.run(request, shadow_metrics_path=metrics_path)
-            return response, logger
+    metrics_path = f"/in-memory/{uuid.uuid4().hex}.jsonl"
+    if expect_exception is None:
+        response = runner.run(request, shadow_metrics_path=metrics_path)
+        return response, logger
 
-        with pytest.raises(expect_exception):
-            runner.run(request, shadow_metrics_path=metrics_path)
-        return None, logger
-    finally:
-        with metrics_module._JSONL_LOGGERS_LOCK:
-            metrics_module._JSONL_LOGGERS.pop(metrics_path, None)
+    with pytest.raises(expect_exception):
+        runner.run(request, shadow_metrics_path=metrics_path)
+    return None, logger
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- share the runner event logger with shadow execution helpers and fall back to JsonlLogger only when needed
- extend shadow runner tests to inject fake loggers and cover the metrics_path=None disablement scenario
- add async runner coverage that validates logger reuse alongside the JsonlLogger fallback

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
- pytest projects/04-llm-adapter-shadow/tests/test_shadow.py projects/04-llm-adapter-shadow/tests/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f56631408321b6ce45f6010ff6a0