### PR TITLE
feat: share runner event logger with shadow execution

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -184,7 +184,13 @@ class Runner:
         for attempt_index, provider in enumerate(self.providers, start=1):
             attempt_started = time.time()
             try:
-                response = run_with_shadow(provider, shadow, request, metrics_path=metrics_path_str)
+                response = run_with_shadow(
+                    provider,
+                    shadow,
+                    request,
+                    metrics_path=metrics_path_str,
+                    logger=event_logger,
+                )
             except ProviderSkip as err:
                 last_err = err
                 _record_skip(err, attempt_index, provider)
@@ -447,6 +453,7 @@ class AsyncRunner:
                     shadow_async,
                     request,
                     metrics_path=metrics_path_str,
+                    logger=event_logger,
                 )
             except ProviderSkip as err:
                 last_err = err


### PR DESCRIPTION
## Summary
- allow run_with_shadow helpers to accept an injected EventLogger and fall back to JsonlLogger only when required
- update Runner to pass its logger through to shadow execution and expand tests for logger injection vs. metrics_path=None scenarios

## Testing
- pytest projects/04-llm-adapter-shadow/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f56921ec83218cdf947c255df093