### PR TITLE
Refine runner backoff configuration layout

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -1,0 +1,18 @@
+"""Configuration objects for runner backoff behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class BackoffPolicy:
+    rate_limit_sleep_s: float = 0.05
+    timeout_next_provider: bool = True
+    retryable_next_provider: bool = True
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    backoff: BackoffPolicy = field(default_factory=BackoffPolicy)
+    max_attempts: int | None = None


### PR DESCRIPTION
## Summary
- extract BackoffPolicy and RunnerConfig into a dedicated runner_config module while preserving Runner imports
- update runner fallback tests to import the new module and wrap parametrized provider lists for line-length compliance
- adjust content normalization checks to use modern isinstance unions and keep hypothesis import ordering lint-clean

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner.py projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f82f3fe48321bd2112f86e5aae27