### PR TITLE
Add aliases for legacy message utility names

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -8,9 +8,12 @@ from typing import Any, Protocol, cast
 
 from .utils import (
     ensure_str_list,
-    extract_prompt_from_messages,
-    normalize_message,
+    extract_prompt_from_messages as _extract_prompt_from_messages,
+    normalize_message as _normalize_message,
 )
+
+normalize_message = _normalize_message
+extract_prompt_from_messages = _extract_prompt_from_messages
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- alias the internal normalize_message and extract_prompt_from_messages imports to support legacy underscore-prefixed usage
- keep the public names available by re-exporting the aliased functions

## Testing
- pytest -q projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68d80079754c8321957dab052c94b45c