### PR TITLE
Refactor adapter config modules

### DIFF
--- a/projects/04-llm-adapter/adapter/core/config.py
+++ b/projects/04-llm-adapter/adapter/core/config.py
@@ -1,301 +1,40 @@
-"""設定ファイルの読み込みロジック。"""
+"""設定ファイル関連の公開 API ファサード。"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from .loader import ConfigError, load_budget_book, load_provider_config, load_provider_configs
+from .models import (
+    BudgetBook,
+    BudgetRule,
+    PricingConfig,
+    ProviderConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from .schema import (
+    PricingConfigModel,
+    ProviderConfigModel,
+    QualityGatesConfigModel,
+    RateLimitConfigModel,
+    RetryConfigModel,
+)
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
-
-try:  # pragma: no cover - 依存がある場合はこちらを利用
-    import yaml  # type: ignore
-except Exception:  # pragma: no cover - フォールバックで処理
-    yaml = None
-
-
-@dataclass
-class RetryConfig:
-    """API 呼び出しの再試行設定。"""
-
-    max: int = 0
-    backoff_s: float = 0.0
-
-
-@dataclass
-class PricingConfig:
-    """1k トークンあたりの料金設定。"""
-
-    prompt_usd: float = 0.0
-    completion_usd: float = 0.0
-    input_per_million: float = 0.0
-    output_per_million: float = 0.0
-
-
-@dataclass
-class RateLimitConfig:
-    """レートリミットのしきい値。"""
-
-    rpm: int = 0
-    tpm: int = 0
-
-
-@dataclass
-class QualityGatesConfig:
-    """決定性ゲートのしきい値。"""
-
-    determinism_diff_rate_max: float = 0.0
-    determinism_len_stdev_max: float = 0.0
-
-
-@dataclass
-class ProviderConfig:
-    """プロバイダ設定。"""
-
-    path: Path
-    schema_version: Optional[int]
-    provider: str
-    endpoint: Optional[str]
-    model: str
-    auth_env: Optional[str]
-    seed: int
-    temperature: float
-    top_p: float
-    max_tokens: int
-    timeout_s: int
-    retries: RetryConfig
-    persist_output: bool
-    pricing: PricingConfig
-    rate_limit: RateLimitConfig
-    quality_gates: QualityGatesConfig
-    raw: Mapping[str, Any]
-
-
-@dataclass
-class BudgetRule:
-    """プロバイダごとの予算ルール。"""
-
-    run_budget_usd: float
-    daily_budget_usd: float
-    stop_on_budget_exceed: bool
-
-
-@dataclass
-class BudgetBook:
-    """予算設定全体。"""
-
-    default: BudgetRule
-    overrides: Mapping[str, BudgetRule]
-
-
-class ConfigError(ValueError):
-    """設定ファイルの検証エラー。"""
-
-
-class RetryConfigModel(BaseModel):
-    """API 呼び出し再試行設定のスキーマ。"""
-
-    model_config = ConfigDict(extra="forbid")
-
-    max: int = 0
-    backoff_s: float = 0.0
-
-
-class PricingConfigModel(BaseModel):
-    """料金設定のスキーマ。"""
-
-    model_config = ConfigDict(extra="forbid")
-
-    prompt_usd: float = 0.0
-    completion_usd: float = 0.0
-    input_per_million: float = 0.0
-    output_per_million: float = 0.0
-
-
-class RateLimitConfigModel(BaseModel):
-    """レートリミット設定のスキーマ。"""
-
-    model_config = ConfigDict(extra="forbid")
-
-    rpm: int = 0
-    tpm: int = 0
-
-
-class QualityGatesConfigModel(BaseModel):
-    """決定性ゲート設定のスキーマ。"""
-
-    model_config = ConfigDict(extra="forbid")
-
-    determinism_diff_rate_max: float = 0.0
-    determinism_len_stdev_max: float = 0.0
-
-
-class ProviderConfigModel(BaseModel):
-    """プロバイダ設定全体のスキーマ。"""
-
-    model_config = ConfigDict(extra="allow")
-
-    schema_version: Optional[int] = None
-    provider: str
-    endpoint: Optional[str] = None
-    model: str
-    auth_env: Optional[str] = None
-    seed: int = 0
-    temperature: float = 0.0
-    top_p: float = 1.0
-    max_tokens: int = 0
-    timeout_s: int = 0
-    retries: RetryConfigModel = Field(default_factory=RetryConfigModel)
-    persist_output: bool = False
-    pricing: PricingConfigModel = Field(default_factory=PricingConfigModel)
-    rate_limit: RateLimitConfigModel = Field(default_factory=RateLimitConfigModel)
-    quality_gates: QualityGatesConfigModel = Field(default_factory=QualityGatesConfigModel)
-
-
-def _format_validation_error(path: Path, exc: ValidationError) -> str:
-    details = []
-    for error in exc.errors():
-        location = ".".join(str(part) for part in error.get("loc", ()) if part is not None)
-        message = error.get("msg", "未知のエラー")
-        if location:
-            details.append(f"{location}: {message}")
-        else:
-            details.append(message)
-    summary = "; ".join(details)
-    return f"設定ファイルの検証に失敗しました ({path}): {summary}"
-
-
-def _load_yaml(path: Union[str, Path]) -> MutableMapping[str, Any]:
-    path = Path(path)
-    text = path.read_text(encoding="utf-8")
-    if yaml is not None:
-        data = yaml.safe_load(text)
-        if not isinstance(data, MutableMapping):
-            raise ValueError(f"YAML の内容が辞書ではありません: {path}")
-        return data
-    return _load_yaml_without_dependency(text, path)
-
-
-def _load_yaml_without_dependency(text: str, path: Path) -> MutableMapping[str, Any]:
-    """PyYAML が無い環境向けの簡易 YAML パーサ。"""
-
-    def convert(value: str) -> Any:
-        value = value.strip()
-        if value == "":
-            return ""
-        lowered = value.lower()
-        if lowered in {"true", "false"}:
-            return lowered == "true"
-        if lowered in {"null", "none"}:
-            return None
-        try:
-            if "." in value:
-                return float(value)
-            return int(value)
-        except ValueError:
-            if (value.startswith('"') and value.endswith('"')) or (
-                value.startswith("'") and value.endswith("'")
-            ):
-                return value[1:-1]
-            return value
-
-    root: MutableMapping[str, Any] = {}
-    stack: List[Tuple[MutableMapping[str, Any], int]] = [(root, 0)]
-    for raw_line in text.splitlines():
-        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
-            continue
-        indent = len(raw_line) - len(raw_line.lstrip(" "))
-        line = raw_line.strip()
-        if ":" not in line:
-            raise ValueError(f"サポート外の YAML 構文です: {path}: {line}")
-        key, value = line.split(":", 1)
-        key = key.strip()
-        value = value.strip()
-        while stack and indent < stack[-1][1]:
-            stack.pop()
-        if not stack:
-            raise ValueError(f"インデントが不正です: {path}: {line}")
-        current = stack[-1][0]
-        if value == "":
-            new_dict: MutableMapping[str, Any] = {}
-            current[key] = new_dict
-            stack.append((new_dict, indent + 2))
-        else:
-            current[key] = convert(value)
-    return root
-
-
-def load_provider_config(path: Union[str, Path]) -> ProviderConfig:
-    """単一のプロバイダ設定を読み込む。"""
-
-    path = Path(path)
-    data = _load_yaml(path)
-    try:
-        model = ProviderConfigModel.model_validate(data)
-    except ValidationError as exc:
-        raise ConfigError(_format_validation_error(path, exc)) from None
-    retries = model.retries
-    pricing = model.pricing
-    rate_limit = model.rate_limit
-    quality = model.quality_gates
-    raw_dump = model.model_dump(mode="python")
-    if model.model_extra:
-        raw_dump.update(model.model_extra)
-    return ProviderConfig(
-        path=path,
-        schema_version=model.schema_version,
-        provider=model.provider,
-        endpoint=model.endpoint,
-        model=model.model,
-        auth_env=model.auth_env,
-        seed=model.seed,
-        temperature=model.temperature,
-        top_p=model.top_p,
-        max_tokens=model.max_tokens,
-        timeout_s=model.timeout_s,
-        retries=RetryConfig(max=retries.max, backoff_s=retries.backoff_s),
-        persist_output=model.persist_output,
-        pricing=PricingConfig(
-            prompt_usd=pricing.prompt_usd,
-            completion_usd=pricing.completion_usd,
-            input_per_million=pricing.input_per_million,
-            output_per_million=pricing.output_per_million,
-        ),
-        rate_limit=RateLimitConfig(rpm=rate_limit.rpm, tpm=rate_limit.tpm),
-        quality_gates=QualityGatesConfig(
-            determinism_diff_rate_max=quality.determinism_diff_rate_max,
-            determinism_len_stdev_max=quality.determinism_len_stdev_max,
-        ),
-        raw=raw_dump,
-    )
-
-
-def load_provider_configs(paths: Iterable[Path]) -> List[ProviderConfig]:
-    """複数のプロバイダ設定を読み込む。"""
-
-    return [load_provider_config(path) for path in paths]
-
-
-def load_budget_book(path: Path) -> BudgetBook:
-    """予算設定を読み込む。"""
-
-    data = _load_yaml(path)
-    default_raw = data.get("default", {})
-    overrides_raw = data.get("overrides", {})
-    default_rule = BudgetRule(
-        run_budget_usd=float(default_raw.get("run_budget_usd", 0.0)),
-        daily_budget_usd=float(default_raw.get("daily_budget_usd", 0.0)),
-        stop_on_budget_exceed=bool(default_raw.get("stop_on_budget_exceed", False)),
-    )
-    overrides: Dict[str, BudgetRule] = {}
-    for provider_name, rule_raw in overrides_raw.items():
-        overrides[provider_name] = BudgetRule(
-            run_budget_usd=float(rule_raw.get("run_budget_usd", default_rule.run_budget_usd)),
-            daily_budget_usd=float(
-                rule_raw.get("daily_budget_usd", default_rule.daily_budget_usd)
-            ),
-            stop_on_budget_exceed=bool(
-                rule_raw.get("stop_on_budget_exceed", default_rule.stop_on_budget_exceed)
-            ),
-        )
-    return BudgetBook(default=default_rule, overrides=overrides)
+__all__ = [
+    "ConfigError",
+    "RetryConfig",
+    "PricingConfig",
+    "RateLimitConfig",
+    "QualityGatesConfig",
+    "ProviderConfig",
+    "BudgetRule",
+    "BudgetBook",
+    "RetryConfigModel",
+    "PricingConfigModel",
+    "RateLimitConfigModel",
+    "QualityGatesConfigModel",
+    "ProviderConfigModel",
+    "load_provider_config",
+    "load_provider_configs",
+    "load_budget_book",
+]

--- a/projects/04-llm-adapter/adapter/core/loader.py
+++ b/projects/04-llm-adapter/adapter/core/loader.py
@@ -1,0 +1,184 @@
+"""設定ファイルの読み込みユーティリティ。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Tuple, Union
+
+from pydantic import ValidationError
+
+from .models import (
+    BudgetBook,
+    BudgetRule,
+    PricingConfig,
+    ProviderConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from .schema import ProviderConfigModel
+
+try:  # pragma: no cover - 依存がある場合はこちらを利用
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - フォールバックで処理
+    yaml = None
+
+__all__ = [
+    "ConfigError",
+    "load_provider_config",
+    "load_provider_configs",
+    "load_budget_book",
+]
+
+
+class ConfigError(ValueError):
+    """設定ファイルの検証エラー。"""
+
+
+def _format_validation_error(path: Path, exc: ValidationError) -> str:
+    details = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error.get("loc", ()) if part is not None)
+        message = error.get("msg", "未知のエラー")
+        if location:
+            details.append(f"{location}: {message}")
+        else:
+            details.append(message)
+    summary = "; ".join(details)
+    return f"設定ファイルの検証に失敗しました ({path}): {summary}"
+
+
+def _load_yaml(path: Union[str, Path]) -> MutableMapping[str, Any]:
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    if yaml is not None:
+        data = yaml.safe_load(text)
+        if not isinstance(data, MutableMapping):
+            raise ValueError(f"YAML の内容が辞書ではありません: {path}")
+        return data
+    return _load_yaml_without_dependency(text, path)
+
+
+def _load_yaml_without_dependency(text: str, path: Path) -> MutableMapping[str, Any]:
+    """PyYAML が無い環境向けの簡易 YAML パーサ。"""
+
+    def convert(value: str) -> Any:
+        value = value.strip()
+        if value == "":
+            return ""
+        lowered = value.lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+        if lowered in {"null", "none"}:
+            return None
+        try:
+            if "." in value:
+                return float(value)
+            return int(value)
+        except ValueError:
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                return value[1:-1]
+            return value
+
+    root: MutableMapping[str, Any] = {}
+    stack: List[Tuple[MutableMapping[str, Any], int]] = [(root, 0)]
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+        if ":" not in line:
+            raise ValueError(f"サポート外の YAML 構文です: {path}: {line}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        while stack and indent < stack[-1][1]:
+            stack.pop()
+        if not stack:
+            raise ValueError(f"インデントが不正です: {path}: {line}")
+        current = stack[-1][0]
+        if value == "":
+            new_dict: MutableMapping[str, Any] = {}
+            current[key] = new_dict
+            stack.append((new_dict, indent + 2))
+        else:
+            current[key] = convert(value)
+    return root
+
+
+def load_provider_config(path: Union[str, Path]) -> ProviderConfig:
+    """単一のプロバイダ設定を読み込む。"""
+
+    path = Path(path)
+    data = _load_yaml(path)
+    try:
+        model = ProviderConfigModel.model_validate(data)
+    except ValidationError as exc:
+        raise ConfigError(_format_validation_error(path, exc)) from None
+    retries = model.retries
+    pricing = model.pricing
+    rate_limit = model.rate_limit
+    quality = model.quality_gates
+    raw_dump = model.model_dump(mode="python")
+    if model.model_extra:
+        raw_dump.update(model.model_extra)
+    return ProviderConfig(
+        path=path,
+        schema_version=model.schema_version,
+        provider=model.provider,
+        endpoint=model.endpoint,
+        model=model.model,
+        auth_env=model.auth_env,
+        seed=model.seed,
+        temperature=model.temperature,
+        top_p=model.top_p,
+        max_tokens=model.max_tokens,
+        timeout_s=model.timeout_s,
+        retries=RetryConfig(max=retries.max, backoff_s=retries.backoff_s),
+        persist_output=model.persist_output,
+        pricing=PricingConfig(
+            prompt_usd=pricing.prompt_usd,
+            completion_usd=pricing.completion_usd,
+            input_per_million=pricing.input_per_million,
+            output_per_million=pricing.output_per_million,
+        ),
+        rate_limit=RateLimitConfig(rpm=rate_limit.rpm, tpm=rate_limit.tpm),
+        quality_gates=QualityGatesConfig(
+            determinism_diff_rate_max=quality.determinism_diff_rate_max,
+            determinism_len_stdev_max=quality.determinism_len_stdev_max,
+        ),
+        raw=raw_dump,
+    )
+
+
+def load_provider_configs(paths: Iterable[Path]) -> List[ProviderConfig]:
+    """複数のプロバイダ設定を読み込む。"""
+
+    return [load_provider_config(path) for path in paths]
+
+
+def load_budget_book(path: Path) -> BudgetBook:
+    """予算設定を読み込む。"""
+
+    data = _load_yaml(path)
+    default_raw = data.get("default", {})
+    overrides_raw = data.get("overrides", {})
+    default_rule = BudgetRule(
+        run_budget_usd=float(default_raw.get("run_budget_usd", 0.0)),
+        daily_budget_usd=float(default_raw.get("daily_budget_usd", 0.0)),
+        stop_on_budget_exceed=bool(default_raw.get("stop_on_budget_exceed", False)),
+    )
+    overrides: Dict[str, BudgetRule] = {}
+    for provider_name, rule_raw in overrides_raw.items():
+        overrides[provider_name] = BudgetRule(
+            run_budget_usd=float(rule_raw.get("run_budget_usd", default_rule.run_budget_usd)),
+            daily_budget_usd=float(
+                rule_raw.get("daily_budget_usd", default_rule.daily_budget_usd)
+            ),
+            stop_on_budget_exceed=bool(
+                rule_raw.get("stop_on_budget_exceed", default_rule.stop_on_budget_exceed)
+            ),
+        )
+    return BudgetBook(default=default_rule, overrides=overrides)

--- a/projects/04-llm-adapter/adapter/core/models.py
+++ b/projects/04-llm-adapter/adapter/core/models.py
@@ -1,0 +1,91 @@
+"""設定モデルの dataclass 定義。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+__all__ = [
+    "RetryConfig",
+    "PricingConfig",
+    "RateLimitConfig",
+    "QualityGatesConfig",
+    "ProviderConfig",
+    "BudgetRule",
+    "BudgetBook",
+]
+
+
+@dataclass
+class RetryConfig:
+    """API 呼び出しの再試行設定。"""
+
+    max: int = 0
+    backoff_s: float = 0.0
+
+
+@dataclass
+class PricingConfig:
+    """1k トークンあたりの料金設定。"""
+
+    prompt_usd: float = 0.0
+    completion_usd: float = 0.0
+    input_per_million: float = 0.0
+    output_per_million: float = 0.0
+
+
+@dataclass
+class RateLimitConfig:
+    """レートリミットのしきい値。"""
+
+    rpm: int = 0
+    tpm: int = 0
+
+
+@dataclass
+class QualityGatesConfig:
+    """決定性ゲートのしきい値。"""
+
+    determinism_diff_rate_max: float = 0.0
+    determinism_len_stdev_max: float = 0.0
+
+
+@dataclass
+class ProviderConfig:
+    """プロバイダ設定。"""
+
+    path: Path
+    schema_version: Optional[int]
+    provider: str
+    endpoint: Optional[str]
+    model: str
+    auth_env: Optional[str]
+    seed: int
+    temperature: float
+    top_p: float
+    max_tokens: int
+    timeout_s: int
+    retries: RetryConfig
+    persist_output: bool
+    pricing: PricingConfig
+    rate_limit: RateLimitConfig
+    quality_gates: QualityGatesConfig
+    raw: Mapping[str, Any]
+
+
+@dataclass
+class BudgetRule:
+    """プロバイダごとの予算ルール。"""
+
+    run_budget_usd: float
+    daily_budget_usd: float
+    stop_on_budget_exceed: bool
+
+
+@dataclass
+class BudgetBook:
+    """予算設定全体。"""
+
+    default: BudgetRule
+    overrides: Mapping[str, BudgetRule]

--- a/projects/04-llm-adapter/adapter/core/schema.py
+++ b/projects/04-llm-adapter/adapter/core/schema.py
@@ -1,0 +1,75 @@
+"""設定ファイル検証用の Pydantic モデル。"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "RetryConfigModel",
+    "PricingConfigModel",
+    "RateLimitConfigModel",
+    "QualityGatesConfigModel",
+    "ProviderConfigModel",
+]
+
+
+class RetryConfigModel(BaseModel):
+    """API 呼び出し再試行設定のスキーマ。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max: int = 0
+    backoff_s: float = 0.0
+
+
+class PricingConfigModel(BaseModel):
+    """料金設定のスキーマ。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_usd: float = 0.0
+    completion_usd: float = 0.0
+    input_per_million: float = 0.0
+    output_per_million: float = 0.0
+
+
+class RateLimitConfigModel(BaseModel):
+    """レートリミット設定のスキーマ。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rpm: int = 0
+    tpm: int = 0
+
+
+class QualityGatesConfigModel(BaseModel):
+    """決定性ゲート設定のスキーマ。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    determinism_diff_rate_max: float = 0.0
+    determinism_len_stdev_max: float = 0.0
+
+
+class ProviderConfigModel(BaseModel):
+    """プロバイダ設定全体のスキーマ。"""
+
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: Optional[int] = None
+    provider: str
+    endpoint: Optional[str] = None
+    model: str
+    auth_env: Optional[str] = None
+    seed: int = 0
+    temperature: float = 0.0
+    top_p: float = 1.0
+    max_tokens: int = 0
+    timeout_s: int = 0
+    retries: RetryConfigModel = Field(default_factory=RetryConfigModel)
+    persist_output: bool = False
+    pricing: PricingConfigModel = Field(default_factory=PricingConfigModel)
+    rate_limit: RateLimitConfigModel = Field(default_factory=RateLimitConfigModel)
+    quality_gates: QualityGatesConfigModel = Field(default_factory=QualityGatesConfigModel)


### PR DESCRIPTION
## Summary
- extract dataclass definitions into adapter.core.models and expose module exports
- move pydantic schemas into adapter.core.schema and loader utilities into adapter.core.loader
- simplify adapter.core.config into a facade that re-exports models, schemas, and loader helpers

## Testing
- python -m mypy --follow-imports=skip projects/04-llm-adapter/adapter/core/config.py
- python -m mypy --follow-imports=skip projects/04-llm-adapter/adapter/core/loader.py projects/04-llm-adapter/adapter/core/models.py projects/04-llm-adapter/adapter/core/schema.py
- pytest projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68d807d882f88321936be95b57550120