### PR TITLE
test: isolate provider request normalization property

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pytest
+
+pytest.importorskip("hypothesis")
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+
+from src.llm_adapter.provider_spi import (
+    ProviderRequest,
+    _extract_prompt_from_messages,
+    _normalize_message,
+)
+
+
+def _message_entries() -> SearchStrategy[Mapping[str, Any]]:
+    text_strategy = st.text()
+    sequence_strategy = st.lists(text_strategy, max_size=3).map(tuple)
+    content_strategy = st.one_of(
+        st.none(),
+        text_strategy,
+        sequence_strategy,
+        st.integers(),
+    )
+    role_strategy = st.one_of(st.none(), text_strategy)
+    extra_strategy = st.dictionaries(
+        st.text(min_size=1),
+        st.one_of(text_strategy, st.integers()),
+        max_size=1,
+    )
+    return st.builds(
+        lambda role, content, extra: {"role": role, "content": content, **extra},
+        role_strategy,
+        content_strategy,
+        extra_strategy,
+    )
+
+
+@given(
+    prompt=st.one_of(st.none(), st.text()),
+    messages=st.lists(_message_entries(), max_size=4),
+)
+def test_provider_request_normalization_boundaries(
+    prompt: str | None, messages: Sequence[Mapping[str, Any]]
+) -> None:
+    prompt_value = "" if prompt is None else prompt
+    request = ProviderRequest(prompt=prompt_value, messages=messages, model="demo-model")
+
+    expected_prompt = prompt_value.strip()
+    normalized_messages: list[Mapping[str, Any]] = []
+    for entry in messages:
+        if isinstance(entry, Mapping):
+            normalized = _normalize_message(entry)
+            if normalized:
+                normalized_messages.append(normalized)
+
+    if not normalized_messages and expected_prompt:
+        normalized_messages.append({"role": "user", "content": expected_prompt})
+
+    if not expected_prompt and normalized_messages:
+        expected_prompt = _extract_prompt_from_messages(normalized_messages)
+
+    assert request.chat_messages == normalized_messages
+    assert request.prompt_text == expected_prompt
+
+    for message in request.chat_messages:
+        role = message["role"]
+        assert isinstance(role, str)
+        assert role.strip() == role
+        assert role
+
+        content = message["content"]
+        if isinstance(content, str):
+            assert content.strip() == content
+            assert content
+        elif isinstance(content, Sequence) and not isinstance(content, bytes | bytearray | str):
+            assert content
+            for part in content:
+                assert isinstance(part, str)
+                assert part.strip() == part
+                assert part
+        else:
+            assert content is not None

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
@@ -4,12 +4,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 import pytest
-
-pytest.importorskip("hypothesis")
-from hypothesis import given
-from hypothesis import strategies as st
-from hypothesis.strategies import SearchStrategy
-from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.errors import (
     AuthError,
     ProviderSkip,
@@ -365,73 +359,3 @@ def test_run_metric_contains_tokens_and_cost() -> None:
     assert run_event["tokens_out"] == 9
     assert run_event["cost_usd"] == pytest.approx(0.456)
     assert succeeding.cost_calls == [(21, 9)]
-
-
-def _message_entries() -> SearchStrategy[Mapping[str, Any]]:
-    text_strategy = st.text()
-    sequence_strategy = st.lists(text_strategy, max_size=3).map(tuple)
-    content_strategy = st.one_of(
-        st.none(),
-        text_strategy,
-        sequence_strategy,
-        st.integers(),
-    )
-    role_strategy = st.one_of(st.none(), text_strategy)
-    extra_strategy = st.dictionaries(
-        st.text(min_size=1),
-        st.one_of(text_strategy, st.integers()),
-        max_size=1,
-    )
-    return st.builds(
-        lambda role, content, extra: {"role": role, "content": content, **extra},
-        role_strategy,
-        content_strategy,
-        extra_strategy,
-    )
-
-
-@given(
-    prompt=st.one_of(st.none(), st.text()),
-    messages=st.lists(_message_entries(), max_size=4),
-)
-def test_provider_request_normalization_boundaries(
-    prompt: str | None, messages: Sequence[Mapping[str, Any]]
-) -> None:
-    prompt_value = "" if prompt is None else prompt
-    request = ProviderRequest(prompt=prompt_value, messages=messages, model="demo-model")
-
-    expected_prompt = prompt_value.strip()
-    normalized_messages: list[Mapping[str, Any]] = []
-    for entry in messages:
-        if isinstance(entry, Mapping):
-            normalized = provider_spi_module._normalize_message(entry)
-            if normalized:
-                normalized_messages.append(normalized)
-
-    if not normalized_messages and expected_prompt:
-        normalized_messages.append({"role": "user", "content": expected_prompt})
-
-    if not expected_prompt and normalized_messages:
-        expected_prompt = provider_spi_module._extract_prompt_from_messages(normalized_messages)
-
-    assert request.chat_messages == normalized_messages
-    assert request.prompt_text == expected_prompt
-
-    for message in request.chat_messages:
-        role = message["role"]
-        assert isinstance(role, str)
-        assert role.strip() == role
-        assert role
-
-        content = message["content"]
-        if isinstance(content, str):
-            assert content.strip() == content
-            assert content
-        elif isinstance(content, Sequence) and not isinstance(content, bytes | bytearray | str):
-            assert content
-            for part in content:
-                assert isinstance(part, str)
-                assert part.strip() == part
-                assert part
-        else:
-            assert content is not None


### PR DESCRIPTION
## Summary
- move the provider request normalization property-based test into its own module
- adjust the fallback runner tests to drop unused hypothesis imports

## Testing
- pytest tests/shadow/test_provider_request_normalization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d80ecaf6b48321bd24b7469f1c62ee