### PR TITLE
Extract runner test helpers

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import pytest
+
+from src.llm_adapter.errors import ProviderSkip
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from src.llm_adapter.runner import Runner
+from src.llm_adapter.runner_config import RunnerConfig
+
+
+class FakeLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: Mapping[str, Any]) -> None:
+        self.events.append((event_type, dict(record)))
+
+    def of_type(self, event_type: str) -> list[dict[str, Any]]:
+        return [record for logged_event, record in self.events if logged_event == event_type]
+
+
+class _ErrorProvider(ProviderSPI):
+    def __init__(self, name: str, exc: Exception) -> None:
+        self._name = name
+        self._exc = exc
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:  # pragma: no cover - raises
+        raise self._exc
+
+
+class _SuccessProvider(ProviderSPI):
+    def __init__(
+        self,
+        name: str,
+        *,
+        tokens_in: int = 12,
+        tokens_out: int = 8,
+        latency_ms: int = 5,
+        cost_usd: float = 0.123,
+    ) -> None:
+        self._name = name
+        self._tokens_in = tokens_in
+        self._tokens_out = tokens_out
+        self._latency = latency_ms
+        self._cost = cost_usd
+        self.cost_calls: list[tuple[int, int]] = []
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        return ProviderResponse(
+            text=f"{self._name}:ok",
+            latency_ms=self._latency,
+            tokens_in=self._tokens_in,
+            tokens_out=self._tokens_out,
+            model=request.model,
+        )
+
+    def estimate_cost(self, tokens_in: int, tokens_out: int) -> float:
+        self.cost_calls.append((tokens_in, tokens_out))
+        return self._cost
+
+
+class _SkipProvider(ProviderSPI):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:  # pragma: no cover - raises
+        raise ProviderSkip(f"{self._name} unavailable")
+
+
+def _run_and_collect(
+    providers: Iterable[ProviderSPI],
+    *,
+    prompt: str = "hello",
+    expect_exception: type[Exception] | None = None,
+    config: RunnerConfig | None = None,
+) -> tuple[ProviderResponse | None, FakeLogger]:
+    logger = FakeLogger()
+    runner = Runner(list(providers), logger=logger, config=config)
+    request = ProviderRequest(prompt=prompt, model="demo-model")
+
+    if expect_exception is None:
+        response = runner.run(request, shadow_metrics_path=None)
+        return response, logger
+
+    with pytest.raises(expect_exception):
+        runner.run(request, shadow_metrics_path=None)
+    return None, logger


### PR DESCRIPTION
## Summary
- move runner test helpers into a dedicated module for reuse
- update fallback runner tests to import helpers from the shared module

## Testing
- pytest tests/shadow/test_runner_fallback.py::test_run_metric_contains_tokens_and_cost -q *(fails: missing hypothesis dependency in the offline environment)*
- pytest -k test_run_metric_contains_tokens_and_cost tests/shadow/test_runner_fallback.py *(skipped: hypothesis not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68d80ec85dd88321928d33f06c2be801