### PR TITLE
Split sync runner tests into dedicated module

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import pytest
+
+from src.llm_adapter.errors import ProviderSkip
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from src.llm_adapter.runner import Runner
+from src.llm_adapter.runner_config import RunnerConfig
+
+
+class FakeLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: Mapping[str, Any]) -> None:
+        self.events.append((event_type, dict(record)))
+
+    def of_type(self, event_type: str) -> list[dict[str, Any]]:
+        return [record for logged_event, record in self.events if logged_event == event_type]
+
+
+class _ErrorProvider(ProviderSPI):
+    def __init__(self, name: str, exc: Exception) -> None:
+        self._name = name
+        self._exc = exc
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        raise self._exc
+
+
+class _SuccessProvider(ProviderSPI):
+    def __init__(
+        self,
+        name: str,
+        *,
+        tokens_in: int = 12,
+        tokens_out: int = 8,
+        latency_ms: int = 5,
+        cost_usd: float = 0.123,
+    ) -> None:
+        self._name = name
+        self._tokens_in = tokens_in
+        self._tokens_out = tokens_out
+        self._latency = latency_ms
+        self._cost = cost_usd
+        self.cost_calls: list[tuple[int, int]] = []
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        return ProviderResponse(
+            text=f"{self._name}:ok",
+            latency_ms=self._latency,
+            tokens_in=self._tokens_in,
+            tokens_out=self._tokens_out,
+            model=request.model,
+        )
+
+    def estimate_cost(self, tokens_in: int, tokens_out: int) -> float:
+        self.cost_calls.append((tokens_in, tokens_out))
+        return self._cost
+
+
+class _SkipProvider(ProviderSPI):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return {"chat"}
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        raise ProviderSkip(f"{self._name} unavailable")
+
+
+def _run_and_collect(
+    providers: Iterable[ProviderSPI],
+    *,
+    prompt: str = "hello",
+    expect_exception: type[Exception] | None = None,
+    config: RunnerConfig | None = None,
+) -> tuple[ProviderResponse | None, FakeLogger]:
+    logger = FakeLogger()
+    runner = Runner(list(providers), logger=logger, config=config)
+    request = ProviderRequest(prompt=prompt, model="demo-model")
+
+    if expect_exception is None:
+        response = runner.run(request, shadow_metrics_path="unused-metrics.jsonl")
+        return response, logger
+
+    with pytest.raises(expect_exception):
+        runner.run(request, shadow_metrics_path="unused-metrics.jsonl")
+    return None, logger
+
+
+__all__ = [
+    "FakeLogger",
+    "_ErrorProvider",
+    "_SuccessProvider",
+    "_SkipProvider",
+    "_run_and_collect",
+]

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_fallback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
@@ -21,287 +21,13 @@ from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, Prov
 from src.llm_adapter.runner import AsyncRunner, Runner
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig
 
-
-class FakeLogger:
-    def __init__(self) -> None:
-        self.events: list[tuple[str, dict[str, Any]]] = []
-
-    def emit(self, event_type: str, record: Mapping[str, Any]) -> None:
-        self.events.append((event_type, dict(record)))
-
-    def of_type(self, event_type: str) -> list[dict[str, Any]]:
-        return [record for logged_event, record in self.events if logged_event == event_type]
-
-
-class _ErrorProvider(ProviderSPI):
-    def __init__(self, name: str, exc: Exception) -> None:
-        self._name = name
-        self._exc = exc
-
-    def name(self) -> str:
-        return self._name
-
-    def capabilities(self) -> set[str]:
-        return {"chat"}
-
-    def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        raise self._exc
-
-
-class _SuccessProvider(ProviderSPI):
-    def __init__(
-        self,
-        name: str,
-        *,
-        tokens_in: int = 12,
-        tokens_out: int = 8,
-        latency_ms: int = 5,
-        cost_usd: float = 0.123,
-    ) -> None:
-        self._name = name
-        self._tokens_in = tokens_in
-        self._tokens_out = tokens_out
-        self._latency = latency_ms
-        self._cost = cost_usd
-        self.cost_calls: list[tuple[int, int]] = []
-
-    def name(self) -> str:
-        return self._name
-
-    def capabilities(self) -> set[str]:
-        return {"chat"}
-
-    def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        return ProviderResponse(
-            text=f"{self._name}:ok",
-            latency_ms=self._latency,
-            tokens_in=self._tokens_in,
-            tokens_out=self._tokens_out,
-            model=request.model,
-        )
-
-    def estimate_cost(self, tokens_in: int, tokens_out: int) -> float:
-        self.cost_calls.append((tokens_in, tokens_out))
-        return self._cost
-
-
-class _SkipProvider(ProviderSPI):
-    def __init__(self, name: str) -> None:
-        self._name = name
-
-    def name(self) -> str:
-        return self._name
-
-    def capabilities(self) -> set[str]:
-        return {"chat"}
-
-    def invoke(self, request: ProviderRequest) -> ProviderResponse:
-        raise ProviderSkip(f"{self._name} unavailable")
-
-
-def _run_and_collect(
-    providers: Iterable[ProviderSPI],
-    *,
-    prompt: str = "hello",
-    expect_exception: type[Exception] | None = None,
-    config: RunnerConfig | None = None,
-) -> tuple[ProviderResponse | None, FakeLogger]:
-    logger = FakeLogger()
-    runner = Runner(list(providers), logger=logger, config=config)
-    request = ProviderRequest(prompt=prompt, model="demo-model")
-
-    if expect_exception is None:
-        response = runner.run(request, shadow_metrics_path=None)
-        return response, logger
-
-    with pytest.raises(expect_exception):
-        runner.run(request, shadow_metrics_path=None)
-    return None, logger
-
-
-@pytest.mark.parametrize(
-    (
-        "providers",
-        "expected_statuses",
-        "expected_run_status",
-        "expected_provider",
-        "expected_attempts",
-        "expected_skip_events",
-        "expect_exception",
-    ),
-    [
-        pytest.param(
-            [_SuccessProvider("primary")],
-            ["ok"],
-            "ok",
-            "primary",
-            1,
-            0,
-            None,
-            id="first-success",
-        ),
-        pytest.param(
-            [
-                _ErrorProvider("fail-first", RetriableError("transient")),
-                _SuccessProvider("fallback"),
-            ],
-            ["error", "ok"],
-            "ok",
-            "fallback",
-            2,
-            0,
-            None,
-            id="fallback-success",
-        ),
-        pytest.param(
-            [
-                _ErrorProvider("slow", TimeoutError("too slow")),
-                _ErrorProvider("slower", TimeoutError("still slow")),
-            ],
-            ["error", "error"],
-            "error",
-            None,
-            2,
-            0,
-            TimeoutError,
-            id="all-fail",
-        ),
-        pytest.param(
-            [_SkipProvider("skipped"), _SuccessProvider("active")],
-            ["error", "ok"],
-            "ok",
-            "active",
-            2,
-            1,
-            None,
-            id="skip-then-success",
-        ),
-    ],
+from tests.shadow._runner_test_helpers import (
+    FakeLogger,
+    _ErrorProvider,
+    _SkipProvider,
+    _SuccessProvider,
+    _run_and_collect,
 )
-def test_runner_fallback_paths(
-    providers: list[ProviderSPI],
-    expected_statuses: list[str],
-    expected_run_status: str,
-    expected_provider: str | None,
-    expected_attempts: int,
-    expected_skip_events: int,
-    expect_exception: type[Exception] | None,
-) -> None:
-    response, logger = _run_and_collect(
-        providers,
-        expect_exception=expect_exception,
-    )
-
-    provider_events = logger.of_type("provider_call")
-    assert len(provider_events) == len(expected_statuses)
-    assert [event["status"] for event in provider_events] == expected_statuses
-
-    run_event = logger.of_type("run_metric")[0]
-    assert run_event["status"] == expected_run_status
-    assert run_event.get("provider") == expected_provider
-    assert run_event["attempts"] == expected_attempts
-
-    skip_events = logger.of_type("provider_skipped")
-    assert len(skip_events) == expected_skip_events
-
-    if expected_run_status == "ok":
-        assert response is not None
-    else:
-        assert response is None
-
-
-def test_rate_limit_triggers_backoff_and_logs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    rate_limited = _ErrorProvider("rate-limit", RateLimitError("slow down"))
-    succeeding = _SuccessProvider("success")
-
-    sleep_calls: list[float] = []
-
-    def _fake_sleep(duration: float) -> None:
-        sleep_calls.append(duration)
-
-    monkeypatch.setattr("src.llm_adapter.runner.time.sleep", _fake_sleep)
-
-    _, logger = _run_and_collect(
-        [rate_limited, succeeding],
-        config=RunnerConfig(backoff=BackoffPolicy(rate_limit_sleep_s=0.123)),
-    )
-
-    assert sleep_calls == [0.123]
-    first_call = next(
-        record
-        for record in logger.of_type("provider_call")
-        if record["provider"] == "rate-limit"
-    )
-    assert first_call["status"] == "error"
-    assert first_call["error_type"] == "RateLimitError"
-    assert first_call["error_family"] == "rate_limit"
-
-
-def test_timeout_switches_to_next_provider() -> None:
-    timeouting = _ErrorProvider("slow", TimeoutError("too slow"))
-    succeeding = _SuccessProvider("success")
-
-    _, logger = _run_and_collect([timeouting, succeeding])
-
-    timeout_event = next(
-        record
-        for record in logger.of_type("provider_call")
-        if record["provider"] == "slow"
-    )
-    assert timeout_event["status"] == "error"
-    assert timeout_event["error_type"] == "TimeoutError"
-    assert timeout_event["error_family"] == "retryable"
-
-    success_event = next(
-        record
-        for record in logger.of_type("provider_call")
-        if record["provider"] == "success"
-    )
-    assert success_event["status"] == "ok"
-
-
-def test_provider_skip_logs_error_family() -> None:
-    response, logger = _run_and_collect([_SkipProvider("skipped"), _SuccessProvider("active")])
-
-    assert response is not None
-    skip_event = next(
-        record for record in logger.of_type("provider_call") if record["provider"] == "skipped"
-    )
-    assert skip_event["status"] == "error"
-    assert skip_event["error_type"] == "ProviderSkip"
-    assert skip_event["error_family"] == "skip"
-
-
-def test_fatal_error_logs_error_family() -> None:
-    _, logger = _run_and_collect(
-        [_ErrorProvider("fatal", AuthError("invalid"))],
-        expect_exception=AuthError,
-    )
-
-    fatal_event = logger.of_type("provider_call")[0]
-    assert fatal_event["status"] == "error"
-    assert fatal_event["error_type"] == "AuthError"
-    assert fatal_event["error_family"] == "fatal"
-
-
-def test_provider_chain_failed_records_last_error_family() -> None:
-    _, logger = _run_and_collect(
-        [
-            _ErrorProvider("first", TimeoutError("slow")),
-            _ErrorProvider("second", RetriableError("oops")),
-        ],
-        expect_exception=RetriableError,
-    )
-
-    chain_event = logger.of_type("provider_chain_failed")[0]
-    assert chain_event["last_error_type"] == "RetriableError"
-    assert chain_event["last_error_family"] == "retryable"
-
-    run_event = logger.of_type("run_metric")[0]
-    assert run_event["status"] == "error"
-    assert run_event["error_family"] == "retryable"
 
 
 @pytest.mark.asyncio
@@ -316,7 +42,7 @@ async def test_async_rate_limit_triggers_backoff_and_logs(
     async def _fake_sleep(duration: float) -> None:
         sleep_calls.append(duration)
 
-    monkeypatch.setattr("src.llm_adapter.runner.asyncio.sleep", _fake_sleep)
+    monkeypatch.setattr("src.llm_adapter.runner_async.asyncio.sleep", _fake_sleep)
 
     logger = FakeLogger()
     runner = AsyncRunner(
@@ -354,18 +80,6 @@ async def test_async_retryable_error_logs_family() -> None:
 
     chain_event = logger.of_type("provider_chain_failed")[0]
     assert chain_event["last_error_family"] == "retryable"
-
-def test_run_metric_contains_tokens_and_cost() -> None:
-    succeeding = _SuccessProvider("success", tokens_in=21, tokens_out=9, cost_usd=0.456)
-
-    _, logger = _run_and_collect([succeeding])
-
-    run_event = logger.of_type("run_metric")[0]
-    assert run_event["tokens_in"] == 21
-    assert run_event["tokens_out"] == 9
-    assert run_event["cost_usd"] == pytest.approx(0.456)
-    assert succeeding.cost_calls == [(21, 9)]
-
 
 def _message_entries() -> SearchStrategy[Mapping[str, Any]]:
     text_strategy = st.text()

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import pytest
+
+from src.llm_adapter.errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from src.llm_adapter.provider_spi import ProviderSPI
+from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig
+
+from tests.shadow._runner_test_helpers import (
+    _ErrorProvider,
+    _SkipProvider,
+    _SuccessProvider,
+    _run_and_collect,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "providers",
+        "expected_statuses",
+        "expected_run_status",
+        "expected_provider",
+        "expected_attempts",
+        "expected_skip_events",
+        "expect_exception",
+    ),
+    [
+        pytest.param(
+            [_SuccessProvider("primary")],
+            ["ok"],
+            "ok",
+            "primary",
+            1,
+            0,
+            None,
+            id="first-success",
+        ),
+        pytest.param(
+            [
+                _ErrorProvider("fail-first", RetriableError("transient")),
+                _SuccessProvider("fallback"),
+            ],
+            ["error", "ok"],
+            "ok",
+            "fallback",
+            2,
+            0,
+            None,
+            id="fallback-success",
+        ),
+        pytest.param(
+            [
+                _ErrorProvider("slow", TimeoutError("too slow")),
+                _ErrorProvider("slower", TimeoutError("still slow")),
+            ],
+            ["error", "error"],
+            "error",
+            None,
+            2,
+            0,
+            TimeoutError,
+            id="all-fail",
+        ),
+        pytest.param(
+            [_SkipProvider("skipped"), _SuccessProvider("active")],
+            ["error", "ok"],
+            "ok",
+            "active",
+            2,
+            1,
+            None,
+            id="skip-then-success",
+        ),
+    ],
+)
+def test_runner_fallback_paths(
+    providers: list[ProviderSPI],
+    expected_statuses: list[str],
+    expected_run_status: str,
+    expected_provider: str | None,
+    expected_attempts: int,
+    expected_skip_events: int,
+    expect_exception: type[Exception] | None,
+) -> None:
+    response, logger = _run_and_collect(
+        providers,
+        expect_exception=expect_exception,
+    )
+
+    provider_events = logger.of_type("provider_call")
+    assert len(provider_events) == len(expected_statuses)
+    assert [event["status"] for event in provider_events] == expected_statuses
+
+    run_event = logger.of_type("run_metric")[0]
+    assert run_event["status"] == expected_run_status
+    assert run_event.get("provider") == expected_provider
+    assert run_event["attempts"] == expected_attempts
+
+    skip_events = logger.of_type("provider_skipped")
+    assert len(skip_events) == expected_skip_events
+
+    if expected_run_status == "ok":
+        assert response is not None
+    else:
+        assert response is None
+
+
+def test_rate_limit_triggers_backoff_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rate_limited = _ErrorProvider("rate-limit", RateLimitError("slow down"))
+    succeeding = _SuccessProvider("success")
+
+    sleep_calls: list[float] = []
+
+    def _fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr("src.llm_adapter.runner_sync.time.sleep", _fake_sleep)
+
+    _, logger = _run_and_collect(
+        [rate_limited, succeeding],
+        config=RunnerConfig(backoff=BackoffPolicy(rate_limit_sleep_s=0.123)),
+    )
+
+    assert sleep_calls == [0.123]
+    first_call = next(
+        record
+        for record in logger.of_type("provider_call")
+        if record["provider"] == "rate-limit"
+    )
+    assert first_call["status"] == "error"
+    assert first_call["error_type"] == "RateLimitError"
+    assert first_call["error_family"] == "rate_limit"
+
+
+def test_timeout_switches_to_next_provider() -> None:
+    timeouting = _ErrorProvider("slow", TimeoutError("too slow"))
+    succeeding = _SuccessProvider("success")
+
+    _, logger = _run_and_collect([timeouting, succeeding])
+
+    timeout_event = next(
+        record
+        for record in logger.of_type("provider_call")
+        if record["provider"] == "slow"
+    )
+    assert timeout_event["status"] == "error"
+    assert timeout_event["error_type"] == "TimeoutError"
+    assert timeout_event["error_family"] == "retryable"
+
+    success_event = next(
+        record
+        for record in logger.of_type("provider_call")
+        if record["provider"] == "success"
+    )
+    assert success_event["status"] == "ok"
+
+
+def test_provider_skip_logs_error_family() -> None:
+    response, logger = _run_and_collect([_SkipProvider("skipped"), _SuccessProvider("active")])
+
+    assert response is not None
+    skip_event = next(
+        record for record in logger.of_type("provider_call") if record["provider"] == "skipped"
+    )
+    assert skip_event["status"] == "error"
+    assert skip_event["error_type"] == "ProviderSkip"
+    assert skip_event["error_family"] == "skip"
+
+
+def test_fatal_error_logs_error_family() -> None:
+    _, logger = _run_and_collect(
+        [_ErrorProvider("fatal", AuthError("invalid"))],
+        expect_exception=AuthError,
+    )
+
+    fatal_event = logger.of_type("provider_call")[0]
+    assert fatal_event["status"] == "error"
+    assert fatal_event["error_type"] == "AuthError"
+    assert fatal_event["error_family"] == "fatal"
+
+
+def test_provider_chain_failed_records_last_error_family() -> None:
+    _, logger = _run_and_collect(
+        [
+            _ErrorProvider("first", TimeoutError("slow")),
+            _ErrorProvider("second", RetriableError("oops")),
+        ],
+        expect_exception=RetriableError,
+    )
+
+    chain_event = logger.of_type("provider_chain_failed")[0]
+    assert chain_event["last_error_type"] == "RetriableError"
+    assert chain_event["last_error_family"] == "retryable"
+
+    run_event = logger.of_type("run_metric")[0]
+    assert run_event["status"] == "error"
+    assert run_event["error_family"] == "retryable"
+
+
+def test_run_metric_contains_tokens_and_cost() -> None:
+    succeeding = _SuccessProvider("success", tokens_in=21, tokens_out=9, cost_usd=0.456)
+
+    _, logger = _run_and_collect([succeeding])
+
+    run_event = logger.of_type("run_metric")[0]
+    assert run_event["tokens_in"] == 21
+    assert run_event["tokens_out"] == 9
+    assert run_event["cost_usd"] == pytest.approx(0.456)
+    assert succeeding.cost_calls == [(21, 9)]


### PR DESCRIPTION
## Summary
- move synchronous runner fallback coverage into a dedicated tests/shadow/test_runner_sync.py module
- extract reusable runner test helpers for both sync and fallback suites and update existing fallback tests to use them

## Testing
- pytest tests/shadow/test_runner_sync.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d80ec9ab508321bb146b2f4ac080c8