### PR TITLE
chore(ci): remove demo server start from playwright job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,6 @@ jobs:
       - name: Generate E2E tests
         run: npm run e2e:gen
 
-      - name: Start demo server
-        run: |
-          npx -y http-server projects/02-blueprint-to-playwright/demo -p 5173 -c-1 &
-          for i in {1..30}; do
-            if curl -sSf http://localhost:5173 > /dev/null; then
-              echo "Demo server is up";
-              break;
-            fi
-            sleep 1
-          done
-
       - name: Run Playwright
         run: npm test
         env:


### PR DESCRIPTION
## Summary
- remove the demo http-server startup step from the Playwright CI job while keeping the BASE_URL configuration

## Testing
- BASE_URL=http://localhost:5173 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d87efd51b0832194819806e0ffeaaa