### PR TITLE
Refactor flaky analyzer aggregation

### DIFF
--- a/projects/03-ci-flaky/src/analyzer.js
+++ b/projects/03-ci-flaky/src/analyzer.js
@@ -19,6 +19,133 @@ function calculateRecency(perRunStats, runOrderLength, lambda) {
   return denom ? numerator / denom : 0;
 }
 
+class AggregatedEntry {
+  constructor(key) {
+    this.canonical_id = key;
+    this.suite = null;
+    this.class = null;
+    this.name = null;
+    this.params = null;
+    this.attempts = 0;
+    this.passes = 0;
+    this.fails = 0;
+    this.skipped = 0;
+    this.durationTotal = 0;
+    this.failureKinds = new Map();
+    this.failureSignatures = new Map();
+    this.perRun = new Map();
+    this.statuses = [];
+    this.latestFailure = null;
+  }
+
+  addAttempt(attempt, runIndex) {
+    this.suite = attempt.suite;
+    this.class = attempt.class;
+    this.name = attempt.name;
+    if (attempt.params !== undefined && attempt.params !== null) this.params = attempt.params;
+
+    this.statuses.push({
+      runIndex,
+      status: attempt.status,
+      run_id: attempt.run_id,
+      ts: attempt.ts ?? null,
+    });
+
+    if (attempt.status === 'skipped') {
+      this.skipped += 1;
+      return;
+    }
+
+    this.attempts += 1;
+    this.durationTotal += attempt.duration_ms || 0;
+    if (attempt.status === 'pass') this.passes += 1;
+    else if (attempt.status === 'fail' || attempt.status === 'error') this.fails += 1;
+
+    if (attempt.failure_kind) {
+      const next = (this.failureKinds.get(attempt.failure_kind) || 0) + 1;
+      this.failureKinds.set(attempt.failure_kind, next);
+    }
+
+    if (attempt.failure_signature) {
+      const sig = this.failureSignatures.get(attempt.failure_signature) || { count: 0, runs: new Set() };
+      sig.count += 1;
+      if (attempt.run_id) sig.runs.add(attempt.run_id);
+      this.failureSignatures.set(attempt.failure_signature, sig);
+    }
+
+    if (attempt.status === 'fail' || attempt.status === 'error') {
+      const current = this.latestFailure;
+      if (!current || current.runIndex <= runIndex) {
+        this.latestFailure = {
+          runIndex,
+          run_id: attempt.run_id,
+          ts: attempt.ts,
+          message: attempt.failure_message,
+          details: attempt.failure_details,
+          excerpt: attempt.failure_excerpt,
+          failure_kind: attempt.failure_kind,
+          failure_signature: attempt.failure_signature,
+        };
+      }
+    }
+
+    const perRun = this.perRun.get(runIndex) || { attempts: 0, fails: 0, passes: 0 };
+    perRun.attempts += 1;
+    if (attempt.status === 'fail' || attempt.status === 'error') perRun.fails += 1;
+    if (attempt.status === 'pass') perRun.passes += 1;
+    this.perRun.set(runIndex, perRun);
+  }
+
+  toResult(runOrder, weights, baseline, lambda) {
+    const attempts = this.attempts;
+    const fails = this.fails;
+    const passes = this.passes;
+    const pFail = attempts ? fails / attempts : 0;
+    const intermittency = attempts ? (2 * Math.min(passes, fails)) / attempts : 0;
+    const recency = calculateRecency(this.perRun, runOrder.length, lambda);
+    const avgDuration = attempts ? this.durationTotal / attempts : 0;
+    const impact = calculateImpact(avgDuration, baseline);
+    const score = (weights.intermittency ?? 0.5) * intermittency
+      + (weights.p_fail ?? 0.3) * pFail
+      + (weights.recency ?? 0.15) * recency
+      + (weights.impact ?? 0.05) * impact;
+    const failureTop = [...this.failureKinds.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([kind, count]) => `${kind}(${count})`)
+      .join('|');
+    const trend = runOrder.map((_, idx) => {
+      const stats = this.perRun.get(idx);
+      if (!stats || !stats.attempts) return 0;
+      return stats.fails / stats.attempts;
+    });
+
+    return {
+      canonical_id: this.canonical_id,
+      suite: this.suite,
+      class: this.class,
+      name: this.name,
+      params: this.params,
+      attempts,
+      passes,
+      fails,
+      skipped: this.skipped,
+      p_fail: pFail,
+      intermittency,
+      recency,
+      impact,
+      score,
+      avg_duration_ms: Math.round(avgDuration),
+      failure_top_k: failureTop,
+      trend,
+      failure_signatures: this.failureSignatures,
+      failure_kinds: this.failureKinds,
+      statuses: this.statuses,
+      latest_failure: this.latestFailure,
+    };
+  }
+}
+
 export async function loadWindowRuns(storePath, windowSize) {
   const files = listJsonlFiles(storePath);
   if (!files.includes(storePath)) files.push(storePath);
@@ -70,144 +197,29 @@ export function computeAggregates(runs, runOrder, config) {
   const lambda = config.recency_lambda ?? 0.1;
   const baseline = config.impact_baseline_ms ?? 600000;
   const entries = new Map();
-  const failureKindTotals = new Map();
 
   runOrder.forEach((runId, idx) => {
     const run = runs.get(runId);
     if (!run) return;
     for (const attempt of run.attempts) {
       const key = attempt.canonical_id || `${attempt.suite}.${attempt.class}.${attempt.name}`;
-      if (!entries.has(key)) {
-        entries.set(key, {
-          canonical_id: key,
-          suite: attempt.suite,
-          class: attempt.class,
-          name: attempt.name,
-          params: attempt.params ?? null,
-          attempts: 0,
-          passes: 0,
-          fails: 0,
-          skipped: 0,
-          durationTotal: 0,
-          failureKinds: new Map(),
-          failureSignatures: new Map(),
-          perRun: new Map(),
-          statuses: [],
-          latestFailure: null,
-        });
+      let entry = entries.get(key);
+      if (!entry) {
+        entry = new AggregatedEntry(key);
+        entries.set(key, entry);
       }
-      const entry = entries.get(key);
-      entry.suite = attempt.suite;
-      entry.class = attempt.class;
-      entry.name = attempt.name;
-      entry.params = attempt.params ?? entry.params;
-
-      entry.statuses.push({
-        runIndex: idx,
-        status: attempt.status,
-        run_id: attempt.run_id,
-        ts: attempt.ts || null,
-      });
-
-      if (attempt.status === 'skipped') {
-        entry.skipped += 1;
-      } else {
-        entry.attempts += 1;
-        entry.durationTotal += attempt.duration_ms || 0;
-        if (attempt.status === 'pass') entry.passes += 1;
-        else if (attempt.status === 'fail' || attempt.status === 'error') entry.fails += 1;
-      }
-
-      if (attempt.failure_kind) {
-        const current = entry.failureKinds.get(attempt.failure_kind) || 0;
-        entry.failureKinds.set(attempt.failure_kind, current + 1);
-        failureKindTotals.set(
-          attempt.failure_kind,
-          (failureKindTotals.get(attempt.failure_kind) || 0) + 1,
-        );
-      }
-
-      if (attempt.failure_signature) {
-        const sig = entry.failureSignatures.get(attempt.failure_signature) || { count: 0, runs: new Set() };
-        sig.count += 1;
-        if (attempt.run_id) sig.runs.add(attempt.run_id);
-        entry.failureSignatures.set(attempt.failure_signature, sig);
-      }
-
-      if (attempt.status === 'fail' || attempt.status === 'error') {
-        const current = entry.latestFailure;
-        if (!current || current.runIndex <= idx) {
-          entry.latestFailure = {
-            runIndex: idx,
-            run_id: attempt.run_id,
-            ts: attempt.ts,
-            message: attempt.failure_message,
-            details: attempt.failure_details,
-            excerpt: attempt.failure_excerpt,
-            failure_kind: attempt.failure_kind,
-            failure_signature: attempt.failure_signature,
-          };
-        }
-      }
-
-      const perRun = entry.perRun.get(idx) || { attempts: 0, fails: 0, passes: 0 };
-      if (attempt.status !== 'skipped') {
-        perRun.attempts += 1;
-        if (attempt.status === 'fail' || attempt.status === 'error') perRun.fails += 1;
-        if (attempt.status === 'pass') perRun.passes += 1;
-      }
-      entry.perRun.set(idx, perRun);
+      entry.addAttempt(attempt, idx);
     }
   });
 
   const results = [];
+  const failureKindTotals = new Map();
   for (const entry of entries.values()) {
-    const attempts = entry.attempts;
-    const fails = entry.fails;
-    const passes = entry.passes;
-    const pFail = attempts ? fails / attempts : 0;
-    const intermittency = attempts ? (2 * Math.min(passes, fails)) / attempts : 0;
-    const recency = calculateRecency(entry.perRun, runOrder.length, lambda);
-    const avgDuration = attempts ? entry.durationTotal / attempts : 0;
-    const impact = calculateImpact(avgDuration, baseline);
-    const score = (weights.intermittency ?? 0.5) * intermittency
-      + (weights.p_fail ?? 0.3) * pFail
-      + (weights.recency ?? 0.15) * recency
-      + (weights.impact ?? 0.05) * impact;
-    const failureTop = [...entry.failureKinds.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 3)
-      .map(([kind, count]) => `${kind}(${count})`)
-      .join('|');
-    const trend = runOrder.map((_, idx) => {
-      const stats = entry.perRun.get(idx);
-      if (!stats || !stats.attempts) return 0;
-      return stats.fails / stats.attempts;
-    });
-
-    results.push({
-      canonical_id: entry.canonical_id,
-      suite: entry.suite,
-      class: entry.class,
-      name: entry.name,
-      params: entry.params,
-      attempts,
-      passes,
-      fails,
-      skipped: entry.skipped,
-      p_fail: pFail,
-      intermittency,
-      recency,
-      impact,
-      score,
-      avg_duration_ms: Math.round(avgDuration),
-      failure_top_k: failureTop,
-      trend,
-      failure_signatures: entry.failureSignatures,
-      failure_kinds: entry.failureKinds,
-      statuses: entry.statuses,
-      latest_failure: entry.latestFailure,
-    });
+    const result = entry.toResult(runOrder, weights, baseline, lambda);
+    results.push(result);
+    for (const [kind, count] of entry.failureKinds.entries()) {
+      failureKindTotals.set(kind, (failureKindTotals.get(kind) || 0) + count);
+    }
   }
 
   return { results, failureKindTotals };

--- a/tests/analyze-junit-cli.test.mjs
+++ b/tests/analyze-junit-cli.test.mjs
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { computeAggregates } from '../projects/03-ci-flaky/src/analyzer.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
@@ -34,4 +36,83 @@ test('ci analyzer CLI succeeds without external fast-xml-parser dependency', () 
     !/Cannot find package 'fast-xml-parser'/i.test(result.stderr),
     'should not complain about missing fast-xml-parser package',
   );
+});
+
+test('computeAggregates preserves scoring and ranking', () => {
+  const runs = new Map([
+    ['run1', {
+      attempts: [
+        {
+          canonical_id: 'suite.class.test',
+          suite: 'suite',
+          class: 'class',
+          name: 'test',
+          status: 'fail',
+          duration_ms: 1000,
+          failure_kind: 'assert',
+          failure_signature: 'sig1',
+          failure_message: 'boom',
+          failure_details: 'trace',
+          failure_excerpt: 'boom',
+          run_id: 'run1',
+          ts: '2024-01-01T00:00:00Z',
+        },
+      ],
+      meta: {},
+    }],
+    ['run2', {
+      attempts: [
+        {
+          canonical_id: 'suite.class.test',
+          suite: 'suite',
+          class: 'class',
+          name: 'test',
+          status: 'pass',
+          duration_ms: 500,
+          run_id: 'run2',
+          ts: '2024-01-02T00:00:00Z',
+        },
+        {
+          canonical_id: 'suite.class.other',
+          suite: 'suite',
+          class: 'class',
+          name: 'other',
+          status: 'pass',
+          duration_ms: 200,
+          run_id: 'run2',
+          ts: '2024-01-02T00:00:00Z',
+        },
+      ],
+      meta: {},
+    }],
+  ]);
+
+  const config = {
+    weights: { intermittency: 0.5, p_fail: 0.3, recency: 0.15, impact: 0.05 },
+    recency_lambda: 0.1,
+    impact_baseline_ms: 600000,
+  };
+
+  const { results, failureKindTotals } = computeAggregates(runs, ['run1', 'run2'], config);
+  assert.equal(results.length, 2);
+  const [first, second] = [...results].sort((a, b) => b.score - a.score);
+
+  assert.equal(first.canonical_id, 'suite.class.test');
+  assert.equal(first.attempts, 2);
+  assert.equal(first.p_fail, 0.5);
+  assert.equal(first.intermittency, 1);
+  assert.ok(Math.abs(first.recency - 0.47502081252106) < 1e-12);
+  assert.ok(Math.abs(first.score - 0.7461368558976224) < 1e-12);
+  assert.deepEqual(first.trend, [1, 0]);
+  assert.equal(first.latest_failure?.run_id, 'run1');
+  const failureSignature = first.failure_signatures.get('sig1');
+  assert.equal(failureSignature.count, 1);
+  assert.deepEqual([...failureSignature.runs], ['run1']);
+
+  assert.equal(second.canonical_id, 'suite.class.other');
+  assert.equal(second.attempts, 1);
+  assert.ok(second.score < first.score);
+  assert.deepEqual(second.trend, [0, 0]);
+
+  assert.deepEqual([...failureKindTotals.entries()], [['assert', 1]]);
 });


### PR DESCRIPTION
## Summary
- introduce an AggregatedEntry helper that owns attempt aggregation, recency, and failure metadata updates
- refactor computeAggregates to delegate per-attempt updates and result materialization to AggregatedEntry while recomputing failure kind totals after iteration
- extend the analyze-junit CLI test suite with a scoring regression check to ensure rankings remain unchanged

## Testing
- node --test tests/analyze-junit-cli.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d88f70b39083219203481a2c47ca05