### PR TITLE
Ensure reports job downloads artifacts even on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,17 +135,19 @@ jobs:
           node-version: '24'
 
       - name: Download node test artifacts
-        if: ${{ needs['node-tests'].result == 'success' }}
+        if: ${{ always() }}
         uses: actions/download-artifact@v4
         with:
           name: node-test-artifacts
+          if-no-files-found: warn
           path: .
 
       - name: Download Python coverage artifacts
-        if: ${{ needs['python-tests'].result == 'success' }}
+        if: ${{ always() }}
         uses: actions/download-artifact@v4
         with:
           name: python-coverage-artifacts
+          if-no-files-found: warn
           path: .
 
       - name: Build CI reports bundle


### PR DESCRIPTION
## Summary
- ensure the reports job downloads artifacts regardless of upstream job state
- allow the reports build script to proceed even when artifacts are missing by keeping warn-only handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d895147ec48321a9c4882b6165d255