### PR TITLE
Add token usage property and deprecation notice

### DIFF
--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -99,7 +99,9 @@ projects/04-llm-adapter-shadow/
 
    - `GEMINI_API_KEY` が未設定／空文字なら Gemini は `ProviderSkip` として自動スキップし、`provider_skipped` イベントを記録します。他プロバイダが成功すればチェーン全体は継続します。
    - PowerShell では bash 由来の構文（ヒアドキュメントなど）が動かないため、`python -c "..."` などで置き換えてください。
-   - `runs-metrics.jsonl` にイベントが追加されない場合は書き込み権限と直前の `provider_chain_failed` ログを確認してください。
+- `runs-metrics.jsonl` にイベントが追加されない場合は書き込み権限と直前の `provider_chain_failed` ログを確認してください。
+
+> ℹ️ `ProviderResponse.token_usage`（`prompt` / `completion` / `total`）を正式APIとし、旧来の `input_tokens` / `output_tokens` は段階的に非推奨化しています。既存呼び出しは動作を維持しますが、必要に応じて `llm_adapter.provider_spi.SUPPRESS_TOKEN_USAGE_DEPRECATION = True` で警告を抑止できます。
 
 ### Provider configuration
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -161,9 +161,10 @@ class AsyncProviderSPI(Protocol):
     async def invoke_async(self, request: ProviderRequest) -> ProviderResponse: ...
 
 
-ProviderResponse.token_usage = property(
-    ProviderResponse._get_token_usage,
-    ProviderResponse._set_token_usage,
+setattr(
+    ProviderResponse,
+    "token_usage",
+    property(ProviderResponse._get_token_usage, ProviderResponse._set_token_usage),
 )
 
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -132,12 +132,10 @@ class ProviderResponse:
             )
         return self.tokens_out or 0
 
-    @property
-    def token_usage(self) -> TokenUsage:
+    def _get_token_usage(self) -> TokenUsage:
         return self._token_usage
 
-    @token_usage.setter
-    def token_usage(self, value: TokenUsage | None) -> None:
+    def _set_token_usage(self, value: TokenUsage | None) -> None:
         if value is None:
             value = TokenUsage(
                 prompt=int(self.tokens_in or 0),
@@ -161,6 +159,12 @@ class AsyncProviderSPI(Protocol):
     def name(self) -> str: ...
     def capabilities(self) -> set[str]: ...
     async def invoke_async(self, request: ProviderRequest) -> ProviderResponse: ...
+
+
+ProviderResponse.token_usage = property(
+    ProviderResponse._get_token_usage,
+    ProviderResponse._set_token_usage,
+)
 
 
 class _AsyncProviderAdapter(AsyncProviderSPI):


### PR DESCRIPTION
## Summary
- expose ProviderResponse.token_usage as the canonical token accounting accessor
- emit deprecation warnings for the legacy input_tokens and output_tokens helpers with an opt-out flag
- document the migration guidance in the project README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a019c52c83219b67399004f67b98