### PR TITLE
feat(adapter): extend compare CLI modes and config

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -4,14 +4,41 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterable, List, Literal, Sequence
+from dataclasses import dataclass
+from typing import Iterable, List, Literal, Sequence, cast
 
 from .budgets import BudgetManager
 from .config import load_budget_book, load_provider_configs
 from .datasets import load_golden_tasks
 from .runners import CompareRunner
 
-Mode = Literal["parallel", "serial"]
+Mode = Literal["sequential", "parallel-any", "parallel-all", "consensus"]
+
+_MODE_CHOICES: tuple[Mode, ...] = (
+    "sequential",
+    "parallel-any",
+    "parallel-all",
+    "consensus",
+)
+
+_MODE_ALIASES: dict[str, Mode] = {
+    "parallel": "parallel-any",
+    "serial": "sequential",
+}
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    """ランナーの制御パラメータ."""
+
+    mode: Mode
+    aggregate: str | None = None
+    quorum: int | None = None
+    tie_breaker: str | None = None
+    schema: Path | None = None
+    judge: str | None = None
+    max_concurrency: int | None = None
+    rpm: int | None = None
 
 
 def default_budgets_path() -> Path:
@@ -22,6 +49,35 @@ def default_metrics_path() -> Path:
     return Path(__file__).resolve().parent.parent.parent / "data" / "runs-metrics.jsonl"
 
 
+def _normalize_mode(value: Mode | str) -> Mode:
+    candidate: str
+    if isinstance(value, str):
+        candidate = _MODE_ALIASES.get(value, value)
+    else:
+        candidate = value
+    if candidate not in _MODE_CHOICES:
+        raise ValueError(f"unknown mode: {value}")
+    return cast(Mode, candidate)
+
+
+def _sanitize_positive_int(value: int | None) -> int | None:
+    if value is None:
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
+def _resolve_optional_path(value: Path | str | None) -> Path | None:
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return value
+    if not value:
+        return None
+    return Path(value).expanduser().resolve()
+
+
 def run_compare(
     provider_paths: Sequence[Path],
     prompt_path: Path,
@@ -29,11 +85,31 @@ def run_compare(
     budgets_path: Path,
     metrics_path: Path,
     repeat: int = 1,
-    mode: Mode = "parallel",
+    mode: Mode | str = "sequential",
     allow_overrun: bool = False,
     log_level: str = "INFO",
+    aggregate: str | None = None,
+    quorum: int | None = None,
+    tie_breaker: str | None = None,
+    schema: Path | str | None = None,
+    judge: str | None = None,
+    max_concurrency: int | None = None,
+    rpm: int | None = None,
+    runner_config: RunnerConfig | None = None,
 ) -> int:
     logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
+
+    resolved_mode = _normalize_mode(mode)
+    config = runner_config or RunnerConfig(
+        mode=resolved_mode,
+        aggregate=aggregate,
+        quorum=_sanitize_positive_int(quorum),
+        tie_breaker=tie_breaker,
+        schema=_resolve_optional_path(schema),
+        judge=judge,
+        max_concurrency=_sanitize_positive_int(max_concurrency),
+        rpm=_sanitize_positive_int(rpm),
+    )
 
     provider_configs = load_provider_configs(list(provider_paths))
     tasks = load_golden_tasks(prompt_path)
@@ -47,7 +123,7 @@ def run_compare(
         metrics_path,
         allow_overrun=allow_overrun,
     )
-    results = runner.run(repeat=max(repeat, 1), mode=mode)
+    results = runner.run(repeat=max(repeat, 1), mode=config.mode)
     logging.getLogger(__name__).info("%d 件の試行を記録しました", len(results))
     return 0
 
@@ -69,7 +145,7 @@ def run_batch(provider_specs: Iterable[str], prompts_path: str) -> int:
         budgets_path=default_budgets_path(),
         metrics_path=default_metrics_path(),
         repeat=1,
-        mode="parallel",
+        mode="parallel-any",
         allow_overrun=False,
         log_level="INFO",
     )
@@ -77,6 +153,7 @@ def run_batch(provider_specs: Iterable[str], prompts_path: str) -> int:
 
 __all__ = [
     "Mode",
+    "RunnerConfig",
     "default_budgets_path",
     "default_metrics_path",
     "run_batch",


### PR DESCRIPTION
## Summary
- add new comparison modes and consensus-related options to adapter/run_compare.py
- extend runner_api with RunnerConfig to normalize modes and carry CLI config
- document the new CLI usage patterns in the core README

## Testing
- pytest projects/04-llm-adapter/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d8a01a06008321a8992688d7e58f4d