### PR TITLE
docs: clarify token usage guidance

### DIFF
--- a/projects/04-llm-adapter-shadow/README.md
+++ b/projects/04-llm-adapter-shadow/README.md
@@ -116,6 +116,8 @@ projects/04-llm-adapter-shadow/
 
 プロバイダ文字列は最初のコロンのみを区切り文字として扱うため、`ollama:gemma3n:e2b` のようにモデルIDにコロンを含めても問題ありません。`mock:foo` を指定するとモックプロバイダで簡易動作確認が可能です。
 
+> ⚠️ `ProviderResponse.token_usage` が正式名称です。旧 `response.input_tokens` / `response.output_tokens` は互換プロパティとして残っていますが将来削除予定で、`DeprecationWarning` が出た場合は `response.token_usage.prompt` / `response.token_usage.completion`（合計値は `response.token_usage.total`）へ読み替えてください。メトリクスJSONの `*_token_usage_total` もこの値を参照します。
+
 #### よく使う環境変数例
 
 ```bash


### PR DESCRIPTION
## Summary
- document that ProviderResponse.token_usage is the canonical property
- note the pending deprecation of input_tokens/output_tokens and how to migrate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a2b5ac848321ab4650024b146552