### PR TITLE
Add deprecation warnings for ProviderResponse token aliases

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Protocol, cast
@@ -110,10 +111,22 @@ class ProviderResponse:
 
     @property
     def input_tokens(self) -> int:
+        warnings.warn(
+            "ProviderResponse.input_tokens is deprecated and will be removed in a future release. "
+            "Use ProviderResponse.token_usage.prompt when logging token counts.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.tokens_in or 0
 
     @property
     def output_tokens(self) -> int:
+        warnings.warn(
+            "ProviderResponse.output_tokens is deprecated and will be removed in a future release. "
+            "Use ProviderResponse.token_usage.completion when logging token counts.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.tokens_out or 0
 
 

--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -11,3 +12,19 @@ if str(PROJECT_ROOT) not in sys.path:
 @pytest.fixture(autouse=True)
 def _fast_mock_provider_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("src.llm_adapter.providers.mock.time.sleep", lambda *args, **kwargs: None)
+
+
+@pytest.fixture(autouse=True)
+def _suppress_provider_response_alias_deprecations() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"ProviderResponse\.input_tokens is deprecated and will be removed",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"ProviderResponse\.output_tokens is deprecated and will be removed",
+            category=DeprecationWarning,
+        )
+        yield


### PR DESCRIPTION
## Summary
- emit DeprecationWarning when ProviderResponse.input_tokens/output_tokens are accessed and point callers to token_usage
- suppress the new deprecation warnings in the shadow test suite with an autouse fixture

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a5378cfc8321aac044176a9cfa3f