### PR TITLE
Add tests for parallel runner behavior and CLI config propagation

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.providers.mock import MockProvider
+from src.llm_adapter.runner_parallel import (
+    ConsensusConfig,
+    ParallelExecutionError,
+    compute_consensus,
+    run_parallel_all_sync,
+    run_parallel_any_sync,
+)
+from src.llm_adapter.shadow import run_with_shadow
+
+
+def test_parallel_primitives(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.llm_adapter.providers.mock.random.random", lambda: 0.0)
+    failing = MockProvider("fail", base_latency_ms=1, error_markers={"[TIMEOUT]"})
+    fast = MockProvider("fast", base_latency_ms=1, error_markers=set())
+    fail_request = ProviderRequest(prompt="[TIMEOUT] hi", model="m1")
+    ok_request = ProviderRequest(prompt="hi", model="m2")
+    winner = run_parallel_any_sync(
+        (
+            lambda: failing.invoke(fail_request),
+            lambda: fast.invoke(ok_request),
+        )
+    )
+    assert winner.text.startswith("echo(fast):")
+    request = ProviderRequest(prompt="hello", model="m")
+    providers = [
+        MockProvider("p1", base_latency_ms=1, error_markers=set()),
+        MockProvider("p2", base_latency_ms=2, error_markers=set()),
+    ]
+    collected = run_parallel_all_sync(tuple(lambda p=p: p.invoke(request) for p in providers))
+    assert [res.text for res in collected] == ["echo(p1): hello", "echo(p2): hello"]
+    responses = [ProviderResponse("A", 0), ProviderResponse("A", 0), ProviderResponse("B", 0)]
+    result = compute_consensus(responses, config=ConsensusConfig(quorum=2))
+    assert result.response.text == "A"
+    assert result.votes == 2
+    with pytest.raises(ParallelExecutionError):
+        compute_consensus(responses, config=ConsensusConfig(quorum=3))
+
+
+def test_parallel_any_with_shadow_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.llm_adapter.providers.mock.random.random", lambda: 0.0)
+    failing = MockProvider("fail", base_latency_ms=1, error_markers={"[TIMEOUT]"})
+    primary = MockProvider("primary", base_latency_ms=1, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=1, error_markers={"[TIMEOUT]"})
+    fail_request = ProviderRequest(prompt="[TIMEOUT] fail", model="m")
+    success_request = ProviderRequest(prompt="[TIMEOUT] ok", model="m")
+    metrics_path = tmp_path / "parallel.jsonl"
+
+    def fail_worker() -> ProviderResponse:
+        return failing.invoke(fail_request)
+
+    def success_worker() -> ProviderResponse:
+        return run_with_shadow(
+            primary,
+            shadow,
+            success_request,
+            metrics_path=metrics_path,
+        )
+
+    response = run_parallel_any_sync((fail_worker, success_worker))
+    assert response.text.startswith("echo(primary):")
+    payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    shadow_event = next(item for item in payloads if item["event"] == "shadow_diff")
+    assert shadow_event["shadow_provider"] == "shadow"
+    assert shadow_event["shadow_ok"] is False
+    assert shadow_event["shadow_error"] == "TimeoutError"

--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from adapter import run_compare as run_compare_module
+from adapter.core import runner_api
+
+
+def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider = tmp_path / "providers.yaml"
+    provider.write_text("{}\n", encoding="utf-8")
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text("{}\n", encoding="utf-8")
+    args = SimpleNamespace(
+        providers=str(provider),
+        prompts=str(prompts),
+        repeat=2,
+        mode="parallel-any",
+        budgets=None,
+        metrics=None,
+        log_level="DEBUG",
+        allow_overrun=True,
+        aggregate=None,
+        quorum=3,
+        tie_breaker=None,
+        schema=None,
+        judge=None,
+        max_concurrency=4,
+        rpm=90,
+    )
+    monkeypatch.setattr(run_compare_module, "_parse_args", lambda: args)
+    captured: dict[str, object] = {}
+
+    def fake_run_compare(provider_paths: list[Path], prompt_path: Path, **kwargs: object) -> int:
+        captured["providers"] = provider_paths
+        captured["prompt"] = prompt_path
+        captured["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(run_compare_module.runner_api, "run_compare", fake_run_compare)
+    assert run_compare_module.main() == 0
+    assert [p.name for p in captured["providers"]] == ["providers.yaml"]
+    assert captured["prompt"].name == "prompts.jsonl"
+    forwarded = captured["kwargs"]
+    assert forwarded["max_concurrency"] == 4
+    assert forwarded["quorum"] == 3
+    assert forwarded["rpm"] == 90
+
+
+def test_run_compare_sanitizes_runner_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider_path = tmp_path / "p.yaml"
+    prompt_path = tmp_path / "prompts.jsonl"
+    provider_path.write_text("{}\n", encoding="utf-8")
+    prompt_path.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(runner_api, "load_provider_configs", lambda paths: ["cfg"])
+    monkeypatch.setattr(runner_api, "load_golden_tasks", lambda path: ["task"])
+    monkeypatch.setattr(runner_api, "load_budget_book", lambda path: "book")
+    monkeypatch.setattr(runner_api, "BudgetManager", lambda book: "budget")
+    captured: dict[str, object] = {}
+
+    class DummyRunner:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def run(self, *, repeat: int, mode: str) -> list[str]:
+            captured["repeat"] = repeat
+            captured["mode"] = mode
+            return []
+
+    monkeypatch.setattr(runner_api, "CompareRunner", lambda *_a, **_k: DummyRunner())
+
+    class DummyConfig:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.mode = kwargs["mode"]
+
+    monkeypatch.setattr(runner_api, "RunnerConfig", DummyConfig)
+    runner_api.run_compare(
+        [provider_path],
+        prompt_path,
+        budgets_path=tmp_path / "budgets.yaml",
+        metrics_path=tmp_path / "metrics.jsonl",
+        repeat=0,
+        mode="parallel-any",
+        quorum=5,
+        max_concurrency=-1,
+        rpm=0,
+    )
+    assert captured["mode"] == "parallel-any"
+    assert captured["quorum"] == 5
+    assert captured["max_concurrency"] is None
+    assert captured["rpm"] is None
+    assert captured["repeat"] == 1


### PR DESCRIPTION
## Summary
- add coverage for parallel orchestrators using mock providers, including shadow metrics and consensus quorum cases
- verify CLI parse args flows propagate concurrency, quorum, and rpm into runner_api configuration with sanitization

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a9cb8d0c8321bd75989dce7e299d