### PR TITLE
Refactor CompareRunner orchestration

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -123,7 +123,7 @@ def run_compare(
         metrics_path,
         allow_overrun=allow_overrun,
     )
-    results = runner.run(repeat=max(repeat, 1), mode=config.mode)
+    results = runner.run(repeat=max(repeat, 1), config=config)
     logging.getLogger(__name__).info("%d 件の試行を記録しました", len(results))
     return 0
 


### PR DESCRIPTION
## Summary
- refactor `CompareRunner.run` to dispatch by `RunnerConfig.mode` and add threaded implementations for parallel-any/all and consensus runs that respect `max_concurrency`
- introduce aggregation bookkeeping plus schema validation and RPM throttling around `_run_single`
- wire `run_compare` to pass the full `RunnerConfig` into `CompareRunner`

## Testing
- pytest projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d8abd4b4308321af7dd09419148248