### PR TITLE
Add async runner parallel orchestration support

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import Any
 
 from .errors import (
@@ -279,7 +279,7 @@ class AsyncRunner:
                 provider: ProviderSPI | AsyncProviderSPI,
                 async_provider: AsyncProviderSPI,
                 attempt_index: int,
-            ):
+            ) -> Callable[[], Awaitable[tuple[int, ProviderSPI | AsyncProviderSPI, ProviderResponse]]]:
                 async def _worker() -> tuple[int, ProviderSPI | AsyncProviderSPI, ProviderResponse]:
                     response = await self._invoke_provider_async(
                         provider,
@@ -298,7 +298,9 @@ class AsyncRunner:
 
                 return _worker
 
-            workers = [
+            workers: list[
+                Callable[[], Awaitable[tuple[int, ProviderSPI | AsyncProviderSPI, ProviderResponse]]]
+            ] = [
                 _build_worker(provider, async_provider, index)
                 for index, (provider, async_provider) in enumerate(providers, start=1)
             ]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from .errors import (
     FatalError,
@@ -22,7 +23,7 @@ from .provider_spi import (
     ProviderSPI,
     ensure_async_provider,
 )
-from .runner_config import RunnerConfig
+from .runner_config import RunnerConfig, RunnerMode
 from .runner_shared import (
     MetricsPath,
     error_family,
@@ -31,6 +32,12 @@ from .runner_shared import (
     log_provider_skipped,
     log_run_metric,
     resolve_event_logger,
+)
+from .runner_parallel import (
+    ParallelExecutionError,
+    compute_consensus,
+    run_parallel_all_async,
+    run_parallel_any_async,
 )
 from .shadow import DEFAULT_METRICS_PATH, run_with_shadow_async
 from .utils import content_hash, elapsed_ms
@@ -54,6 +61,130 @@ class AsyncRunner:
         self._logger = logger
         self._config = config or RunnerConfig()
 
+    async def _invoke_provider_async(
+        self,
+        provider: ProviderSPI | AsyncProviderSPI,
+        async_provider: AsyncProviderSPI,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        event_logger: EventLogger | None,
+        request_fingerprint: str,
+        metadata: Mapping[str, Any],
+        shadow: ProviderSPI | AsyncProviderSPI | None,
+        shadow_async: AsyncProviderSPI | None,
+        metrics_path: str | None,
+    ) -> ProviderResponse:
+        attempt_started = time.time()
+        try:
+            response = await run_with_shadow_async(
+                async_provider,
+                shadow_async,
+                request,
+                metrics_path=metrics_path,
+                logger=event_logger,
+            )
+        except RateLimitError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except RetryableError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except SkipError as err:
+            if isinstance(err, ProviderSkip):
+                log_provider_skipped(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=provider,
+                    request=request,
+                    attempt=attempt,
+                    total_providers=total_providers,
+                    error=err,
+                )
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except FatalError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        log_provider_call(
+            event_logger,
+            request_fingerprint=request_fingerprint,
+            provider=provider,
+            request=request,
+            attempt=attempt,
+            total_providers=total_providers,
+            status="ok",
+            latency_ms=response.latency_ms,
+            tokens_in=response.input_tokens,
+            tokens_out=response.output_tokens,
+            error=None,
+            metadata=metadata,
+            shadow_used=shadow is not None,
+            allow_private_model=True,
+        )
+        return response
+
     async def run_async(
         self,
         request: ProviderRequest,
@@ -73,151 +204,192 @@ class AsyncRunner:
         shadow_async = ensure_async_provider(shadow) if shadow is not None else None
 
         max_attempts = self._config.max_attempts
+        providers: Sequence[tuple[ProviderSPI | AsyncProviderSPI, AsyncProviderSPI]]
+        if max_attempts is not None:
+            providers = self.providers[: max(0, max_attempts)]
+        else:
+            providers = self.providers
+        total_providers = len(providers)
+
+        mode = self._config.mode
         attempt_count = 0
-        for loop_index, (provider, async_provider) in enumerate(self.providers, start=1):
-            if max_attempts is not None and loop_index > max_attempts:
-                break
-            attempt_index = loop_index
-            attempt_count = attempt_index
-            attempt_started = time.time()
-            try:
-                response = await run_with_shadow_async(
-                    async_provider,
-                    shadow_async,
-                    request,
-                    metrics_path=metrics_path_str,
-                    logger=event_logger,
-                )
-            except RateLimitError as err:
-                last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                    allow_private_model=True,
-                )
-                sleep_duration = self._config.backoff.rate_limit_sleep_s
-                if sleep_duration > 0:
-                    await asyncio.sleep(sleep_duration)
-            except RetryableError as err:
-                last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                    allow_private_model=True,
-                )
-                if isinstance(err, TimeoutError):
-                    if self._config.backoff.timeout_next_provider:
+
+        if mode is RunnerMode.SEQUENTIAL:
+            for attempt_index, (provider, async_provider) in enumerate(providers, start=1):
+                attempt_count = attempt_index
+                try:
+                    response = await self._invoke_provider_async(
+                        provider,
+                        async_provider,
+                        request,
+                        attempt=attempt_index,
+                        total_providers=total_providers,
+                        event_logger=event_logger,
+                        request_fingerprint=request_fingerprint,
+                        metadata=metadata,
+                        shadow=shadow,
+                        shadow_async=shadow_async,
+                        metrics_path=metrics_path_str,
+                    )
+                except RateLimitError as err:
+                    last_err = err
+                    sleep_duration = self._config.backoff.rate_limit_sleep_s
+                    if sleep_duration > 0:
+                        await asyncio.sleep(sleep_duration)
+                    continue
+                except RetryableError as err:
+                    last_err = err
+                    if isinstance(err, TimeoutError):
+                        if self._config.backoff.timeout_next_provider:
+                            continue
+                        raise
+                    if self._config.backoff.retryable_next_provider:
                         continue
                     raise
-                if self._config.backoff.retryable_next_provider:
+                except SkipError as err:
+                    last_err = err
                     continue
-                raise
-            except SkipError as err:
-                last_err = err
-                if isinstance(err, ProviderSkip):
-                    log_provider_skipped(
+                except FatalError as err:
+                    last_err = err
+                    raise
+                else:
+                    tokens_in = response.input_tokens
+                    tokens_out = response.output_tokens
+                    cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+                    log_run_metric(
                         event_logger,
                         request_fingerprint=request_fingerprint,
-                        provider=provider,
                         request=request,
-                        attempt=attempt_index,
-                        total_providers=len(self.providers),
-                        error=err,
+                        provider=provider,
+                        status="ok",
+                        attempts=attempt_index,
+                        latency_ms=elapsed_ms(run_started),
+                        tokens_in=tokens_in,
+                        tokens_out=tokens_out,
+                        cost_usd=cost_usd,
+                        error=None,
+                        metadata=metadata,
+                        shadow_used=shadow is not None,
                     )
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                    allow_private_model=True,
+                    return response
+        else:
+            attempt_count = total_providers
+
+            def _build_worker(
+                provider: ProviderSPI | AsyncProviderSPI,
+                async_provider: AsyncProviderSPI,
+                attempt_index: int,
+            ):
+                async def _worker() -> tuple[int, ProviderSPI | AsyncProviderSPI, ProviderResponse]:
+                    response = await self._invoke_provider_async(
+                        provider,
+                        async_provider,
+                        request,
+                        attempt=attempt_index,
+                        total_providers=total_providers,
+                        event_logger=event_logger,
+                        request_fingerprint=request_fingerprint,
+                        metadata=metadata,
+                        shadow=shadow,
+                        shadow_async=shadow_async,
+                        metrics_path=metrics_path_str,
+                    )
+                    return attempt_index, provider, response
+
+                return _worker
+
+            workers = [
+                _build_worker(provider, async_provider, index)
+                for index, (provider, async_provider) in enumerate(providers, start=1)
+            ]
+
+            try:
+                if mode is RunnerMode.PARALLEL_ANY:
+                    attempt_index, provider, response = await run_parallel_any_async(
+                        workers,
+                        max_concurrency=self._config.max_concurrency,
+                    )
+                    tokens_in = response.input_tokens
+                    tokens_out = response.output_tokens
+                    cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+                    log_run_metric(
+                        event_logger,
+                        request_fingerprint=request_fingerprint,
+                        request=request,
+                        provider=provider,
+                        status="ok",
+                        attempts=attempt_index,
+                        latency_ms=elapsed_ms(run_started),
+                        tokens_in=tokens_in,
+                        tokens_out=tokens_out,
+                        cost_usd=cost_usd,
+                        error=None,
+                        metadata=metadata,
+                        shadow_used=shadow is not None,
+                    )
+                    return response
+                results = await run_parallel_all_async(
+                    workers,
+                    max_concurrency=self._config.max_concurrency,
                 )
-                continue
-            except FatalError as err:
+            except Exception as err:  # noqa: BLE001
                 last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                    allow_private_model=True,
-                )
-                raise
             else:
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="ok",
-                    latency_ms=response.latency_ms,
-                    tokens_in=response.input_tokens,
-                    tokens_out=response.output_tokens,
-                    error=None,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                    allow_private_model=True,
-                )
-                tokens_in = response.input_tokens
-                tokens_out = response.output_tokens
-                cost_usd = estimate_cost(provider, tokens_in, tokens_out)
-                log_run_metric(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    request=request,
-                    provider=provider,
-                    status="ok",
-                    attempts=attempt_index,
-                    latency_ms=elapsed_ms(run_started),
-                    tokens_in=tokens_in,
-                    tokens_out=tokens_out,
-                    cost_usd=cost_usd,
-                    error=None,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                return response
+                if not results:
+                    last_err = RuntimeError("No providers succeeded")
+                else:
+                    if mode is RunnerMode.CONSENSUS:
+                        try:
+                            consensus = compute_consensus(
+                                [response for _, _, response in results],
+                                config=self._config.consensus,
+                            )
+                        except ParallelExecutionError as err:
+                            last_err = err
+                        else:
+                            for _attempt_index, provider, response in results:
+                                if response is consensus.response:
+                                    tokens_in = response.input_tokens
+                                    tokens_out = response.output_tokens
+                                    cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+                                    log_run_metric(
+                                        event_logger,
+                                        request_fingerprint=request_fingerprint,
+                                        request=request,
+                                        provider=provider,
+                                        status="ok",
+                                        attempts=attempt_count,
+                                        latency_ms=elapsed_ms(run_started),
+                                        tokens_in=tokens_in,
+                                        tokens_out=tokens_out,
+                                        cost_usd=cost_usd,
+                                        error=None,
+                                        metadata=metadata,
+                                        shadow_used=shadow is not None,
+                                    )
+                                    return response
+                            last_err = ParallelExecutionError("consensus resolution failed")
+                    else:
+                        _attempt_index, provider, response = results[0]
+                        tokens_in = response.input_tokens
+                        tokens_out = response.output_tokens
+                        cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+                        log_run_metric(
+                            event_logger,
+                            request_fingerprint=request_fingerprint,
+                            request=request,
+                            provider=provider,
+                            status="ok",
+                            attempts=attempt_count,
+                            latency_ms=elapsed_ms(run_started),
+                            tokens_in=tokens_in,
+                            tokens_out=tokens_out,
+                            cost_usd=cost_usd,
+                            error=None,
+                            metadata=metadata,
+                            shadow_used=shadow is not None,
+                        )
+                        return response
 
         if event_logger is not None:
             event_logger.emit(
@@ -225,7 +397,7 @@ class AsyncRunner:
                 {
                     "request_fingerprint": request_fingerprint,
                     "provider_attempts": attempt_count,
-                    "providers": [provider.name() for provider, _ in self.providers],
+                    "providers": [provider.name() for provider, _ in providers],
                     "last_error_type": type(last_err).__name__ if last_err else None,
                     "last_error_message": str(last_err) if last_err else None,
                     "last_error_family": error_family(last_err),


### PR DESCRIPTION
## Summary
- refactor the async runner to share invocation logging and branch on RunnerMode for parallel_any, parallel_all, and consensus execution
- integrate consensus handling with compute_consensus and ensure cancelled parallel workers are awaited
- add asyncio-based tests covering early winner selection, cancellation cleanup, and consensus quorum failure

## Testing
- not run (tests require pytest)


------
https://chatgpt.com/codex/tasks/task_e_68d8b54a40ac832198565c7e27941845