### PR TITLE
Support parallel runner modes in sync runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -333,7 +333,7 @@ class Runner:
                 )
                 fatal = self._extract_fatal_error(results)
                 if fatal is not None:
-                    raise fatal
+                    raise fatal from None
                 if winner.response is None:
                     raise ParallelExecutionError("all workers failed")
                 return winner.response
@@ -344,7 +344,7 @@ class Runner:
                 )
                 fatal = self._extract_fatal_error(results)
                 if fatal is not None:
-                    raise fatal
+                    raise fatal from None
                 for response in responses:
                     if response.response is None:
                         raise ParallelExecutionError("all workers failed")
@@ -356,7 +356,7 @@ class Runner:
                 )
                 fatal = self._extract_fatal_error(results)
                 if fatal is not None:
-                    raise fatal
+                    raise fatal from None
                 provider_responses = [
                     res.response
                     for res in responses
@@ -371,7 +371,7 @@ class Runner:
         except ParallelExecutionError as exc:
             fatal = self._extract_fatal_error(results)
             if fatal is not None:
-                raise fatal
+                raise fatal from None
             raise exc
         finally:
             self._log_parallel_results(

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from .errors import (
     FatalError,
@@ -15,7 +16,13 @@ from .errors import (
 )
 from .observability import EventLogger
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
-from .runner_config import RunnerConfig
+from .runner_config import RunnerConfig, RunnerMode
+from .runner_parallel import (
+    ParallelExecutionError,
+    compute_consensus,
+    run_parallel_all_sync,
+    run_parallel_any_sync,
+)
 from .runner_shared import (
     MetricsPath,
     error_family,
@@ -27,6 +34,18 @@ from .runner_shared import (
 )
 from .shadow import DEFAULT_METRICS_PATH, run_with_shadow
 from .utils import content_hash, elapsed_ms
+
+
+@dataclass(slots=True)
+class ProviderInvocationResult:
+    provider: ProviderSPI
+    attempt: int
+    total_providers: int
+    response: ProviderResponse | None
+    error: Exception | None
+    latency_ms: float
+    tokens_in: int | None
+    tokens_out: int | None
 
 
 class Runner:
@@ -45,6 +64,125 @@ class Runner:
         self._logger = logger
         self._config = config or RunnerConfig()
 
+    def _invoke_provider_sync(
+        self,
+        provider: ProviderSPI,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        event_logger: EventLogger | None,
+        request_fingerprint: str,
+        metadata: dict[str, object],
+        shadow: ProviderSPI | None,
+        metrics_path: MetricsPath,
+    ) -> ProviderInvocationResult:
+        attempt_started = time.time()
+        response: ProviderResponse | None = None
+        error: Exception | None = None
+        latency_ms: float
+        tokens_in: int | None = None
+        tokens_out: int | None = None
+        try:
+            response = run_with_shadow(
+                provider,
+                shadow,
+                request,
+                metrics_path=metrics_path,
+                logger=event_logger,
+            )
+        except Exception as exc:  # noqa: BLE001
+            error = exc
+            latency_ms = elapsed_ms(attempt_started)
+            if isinstance(exc, ProviderSkip):
+                log_provider_skipped(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=provider,
+                    request=request,
+                    attempt=attempt,
+                    total_providers=total_providers,
+                    error=exc,
+                )
+        else:
+            latency_ms = response.latency_ms
+            usage = response.token_usage
+            tokens_in = usage.prompt
+            tokens_out = usage.completion
+        status = "ok" if error is None else "error"
+        log_provider_call(
+            event_logger,
+            request_fingerprint=request_fingerprint,
+            provider=provider,
+            request=request,
+            attempt=attempt,
+            total_providers=total_providers,
+            status=status,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            error=error,
+            metadata=metadata,
+            shadow_used=shadow is not None,
+        )
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=response,
+            error=error,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+
+    def _log_parallel_results(
+        self,
+        results: Sequence[ProviderInvocationResult | None],
+        *,
+        event_logger: EventLogger | None,
+        request: ProviderRequest,
+        request_fingerprint: str,
+        metadata: dict[str, object],
+        run_started: float,
+        shadow_used: bool,
+    ) -> None:
+        for result in results:
+            if result is None:
+                continue
+            status = "ok" if result.response is not None else "error"
+            tokens_in = result.tokens_in if status == "ok" else None
+            tokens_out = result.tokens_out if status == "ok" else None
+            cost_usd = 0.0
+            if status == "ok":
+                cost_usd = estimate_cost(result.provider, tokens_in, tokens_out)
+            log_run_metric(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                request=request,
+                provider=result.provider,
+                status=status,
+                attempts=result.attempt,
+                latency_ms=elapsed_ms(run_started),
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=cost_usd,
+                error=None if status == "ok" else result.error,
+                metadata=metadata,
+                shadow_used=shadow_used,
+            )
+
+    def _extract_fatal_error(
+        self, results: Sequence[ProviderInvocationResult | None]
+    ) -> FatalError | None:
+        for result in results:
+            if result is None:
+                continue
+            error = result.error
+            if isinstance(error, FatalError):
+                return error
+        return None
+
     def run(
         self,
         request: ProviderRequest,
@@ -57,182 +195,196 @@ class Runner:
         event_logger, metrics_path_str = resolve_event_logger(
             self._logger, shadow_metrics_path
         )
-        metadata = request.metadata or {}
+        metadata = dict(request.metadata or {})
         run_started = time.time()
         request_fingerprint = content_hash(
             "runner", request.prompt_text, request.options, request.max_tokens
         )
+        shadow_used = shadow is not None
+        mode = self._config.mode
 
-        max_attempts = self._config.max_attempts
-        attempt_count = 0
-        for loop_index, provider in enumerate(self.providers, start=1):
-            if max_attempts is not None and loop_index > max_attempts:
-                break
-            attempt_index = loop_index
-            attempt_count = attempt_index
-            attempt_started = time.time()
-            try:
-                response = run_with_shadow(
+        if mode is RunnerMode.SEQUENTIAL:
+            max_attempts = self._config.max_attempts
+            attempt_count = 0
+            for loop_index, provider in enumerate(self.providers, start=1):
+                if max_attempts is not None and loop_index > max_attempts:
+                    break
+                attempt_index = loop_index
+                attempt_count = attempt_index
+                result = self._invoke_provider_sync(
                     provider,
-                    shadow,
                     request,
+                    attempt=attempt_index,
+                    total_providers=len(self.providers),
+                    event_logger=event_logger,
+                    request_fingerprint=request_fingerprint,
+                    metadata=metadata,
+                    shadow=shadow,
                     metrics_path=metrics_path_str,
-                    logger=event_logger,
                 )
-            except RateLimitError as err:
-                last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                sleep_duration = self._config.backoff.rate_limit_sleep_s
-                if sleep_duration > 0:
-                    time.sleep(sleep_duration)
-            except RetryableError as err:
-                last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                if isinstance(err, TimeoutError):
-                    if self._config.backoff.timeout_next_provider:
-                        continue
-                    raise
-                if self._config.backoff.retryable_next_provider:
-                    continue
-                raise
-            except SkipError as err:
-                last_err = err
-                if isinstance(err, ProviderSkip):
-                    log_provider_skipped(
+                if result.response is not None:
+                    tokens_in = result.tokens_in
+                    tokens_out = result.tokens_out
+                    cost_usd = estimate_cost(
+                        provider,
+                        tokens_in,
+                        tokens_out,
+                    )
+                    log_run_metric(
                         event_logger,
                         request_fingerprint=request_fingerprint,
-                        provider=provider,
                         request=request,
-                        attempt=attempt_index,
-                        total_providers=len(self.providers),
-                        error=err,
+                        provider=provider,
+                        status="ok",
+                        attempts=attempt_index,
+                        latency_ms=elapsed_ms(run_started),
+                        tokens_in=tokens_in,
+                        tokens_out=tokens_out,
+                        cost_usd=cost_usd,
+                        error=None,
+                        metadata=metadata,
+                        shadow_used=shadow_used,
                     )
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                continue
-            except FatalError as err:
-                last_err = err
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="error",
-                    latency_ms=elapsed_ms(attempt_started),
-                    tokens_in=None,
-                    tokens_out=None,
-                    error=err,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                raise
-            else:
-                log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=provider,
-                    request=request,
-                    attempt=attempt_index,
-                    total_providers=len(self.providers),
-                    status="ok",
-                    latency_ms=response.latency_ms,
-                    tokens_in=response.input_tokens,
-                    tokens_out=response.output_tokens,
-                    error=None,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                tokens_in = response.input_tokens
-                tokens_out = response.output_tokens
-                cost_usd = estimate_cost(provider, tokens_in, tokens_out)
-                log_run_metric(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    request=request,
-                    provider=provider,
-                    status="ok",
-                    attempts=attempt_index,
-                    latency_ms=elapsed_ms(run_started),
-                    tokens_in=tokens_in,
-                    tokens_out=tokens_out,
-                    cost_usd=cost_usd,
-                    error=None,
-                    metadata=metadata,
-                    shadow_used=shadow is not None,
-                )
-                return response
+                    return result.response
+                error = result.error
+                last_err = error
+                if error is None:
+                    continue
+                if isinstance(error, FatalError):
+                    raise error
+                if isinstance(error, RateLimitError):
+                    sleep_duration = self._config.backoff.rate_limit_sleep_s
+                    if sleep_duration > 0:
+                        time.sleep(sleep_duration)
+                    continue
+                if isinstance(error, RetryableError):
+                    if isinstance(error, TimeoutError):
+                        if not self._config.backoff.timeout_next_provider:
+                            raise error
+                        continue
+                    if self._config.backoff.retryable_next_provider:
+                        continue
+                    raise error
+                if isinstance(error, SkipError):
+                    continue
+                raise error
 
-        if event_logger is not None:
-            event_logger.emit(
-                "provider_chain_failed",
-                {
-                    "request_fingerprint": request_fingerprint,
-                    "provider_attempts": attempt_count,
-                    "providers": [provider.name() for provider in self.providers],
-                    "last_error_type": type(last_err).__name__ if last_err else None,
-                    "last_error_message": str(last_err) if last_err else None,
-                    "last_error_family": error_family(last_err),
-                },
+            if event_logger is not None:
+                event_logger.emit(
+                    "provider_chain_failed",
+                    {
+                        "request_fingerprint": request_fingerprint,
+                        "provider_attempts": attempt_count,
+                        "providers": [provider.name() for provider in self.providers],
+                        "last_error_type": type(last_err).__name__ if last_err else None,
+                        "last_error_message": str(last_err) if last_err else None,
+                        "last_error_family": error_family(last_err),
+                    },
+                )
+            log_run_metric(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                request=request,
+                provider=None,
+                status="error",
+                attempts=attempt_count,
+                latency_ms=elapsed_ms(run_started),
+                tokens_in=None,
+                tokens_out=None,
+                cost_usd=0.0,
+                error=last_err,
+                metadata=metadata,
+                shadow_used=shadow_used,
             )
-        log_run_metric(
-            event_logger,
-            request_fingerprint=request_fingerprint,
-            request=request,
-            provider=None,
-            status="error",
-            attempts=attempt_count,
-            latency_ms=elapsed_ms(run_started),
-            tokens_in=None,
-            tokens_out=None,
-            cost_usd=0.0,
-            error=last_err,
-            metadata=metadata,
-            shadow_used=shadow is not None,
-        )
-        raise last_err if last_err is not None else RuntimeError("No providers succeeded")
+            raise last_err if last_err is not None else RuntimeError(
+                "No providers succeeded"
+            )
+
+        total_providers = len(self.providers)
+        results: list[ProviderInvocationResult | None] = [None] * total_providers
+
+        def make_worker(index: int, provider: ProviderSPI):
+            def worker() -> ProviderInvocationResult:
+                result = self._invoke_provider_sync(
+                    provider,
+                    request,
+                    attempt=index,
+                    total_providers=total_providers,
+                    event_logger=event_logger,
+                    request_fingerprint=request_fingerprint,
+                    metadata=metadata,
+                    shadow=shadow,
+                    metrics_path=metrics_path_str,
+                )
+                results[index - 1] = result
+                return result
+
+            return worker
+
+        workers = [
+            make_worker(index, provider)
+            for index, provider in enumerate(self.providers, start=1)
+        ]
+
+        try:
+            if mode is RunnerMode.PARALLEL_ANY:
+                winner = run_parallel_any_sync(
+                    workers, max_concurrency=self._config.max_concurrency
+                )
+                fatal = self._extract_fatal_error(results)
+                if fatal is not None:
+                    raise fatal
+                if winner.response is None:
+                    raise ParallelExecutionError("all workers failed")
+                return winner.response
+
+            if mode is RunnerMode.PARALLEL_ALL:
+                responses = run_parallel_all_sync(
+                    workers, max_concurrency=self._config.max_concurrency
+                )
+                fatal = self._extract_fatal_error(results)
+                if fatal is not None:
+                    raise fatal
+                for response in responses:
+                    if response.response is None:
+                        raise ParallelExecutionError("all workers failed")
+                return responses[0].response
+
+            if mode is RunnerMode.CONSENSUS:
+                responses = run_parallel_all_sync(
+                    workers, max_concurrency=self._config.max_concurrency
+                )
+                fatal = self._extract_fatal_error(results)
+                if fatal is not None:
+                    raise fatal
+                provider_responses = [
+                    res.response
+                    for res in responses
+                    if res.response is not None
+                ]
+                if len(provider_responses) != len(responses):
+                    raise ParallelExecutionError("all workers failed")
+                consensus = compute_consensus(
+                    provider_responses, config=self._config.consensus
+                )
+                return consensus.response
+        except ParallelExecutionError as exc:
+            fatal = self._extract_fatal_error(results)
+            if fatal is not None:
+                raise fatal
+            raise exc
+        finally:
+            self._log_parallel_results(
+                results,
+                event_logger=event_logger,
+                request=request,
+                request_fingerprint=request_fingerprint,
+                metadata=metadata,
+                run_started=run_started,
+                shadow_used=shadow_used,
+            )
+
+        raise RuntimeError(f"Unsupported runner mode: {mode}")
 
 
 __all__ = ["Runner"]

--- a/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+import pytest
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
+from src.llm_adapter.runner_parallel import ParallelExecutionError
+from src.llm_adapter.runner_sync import Runner
+
+
+class _MockProvider:
+    def __init__(self, name: str, behavior: Callable[[ProviderRequest], ProviderResponse]):
+        self._name = name
+        self._behavior = behavior
+        self.calls = 0
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        self.calls += 1
+        return self._behavior(request)
+
+
+def _response(text: str) -> ProviderResponse:
+    return ProviderResponse(text=text, latency_ms=10, tokens_in=5, tokens_out=3)
+
+
+def test_runner_parallel_any_cancels_pending_workers() -> None:
+    request = ProviderRequest(model="gpt-test", prompt="hi")
+
+    fast = _MockProvider("fast", lambda _: _response("fast"))
+
+    def _slow(_: ProviderRequest) -> ProviderResponse:
+        time.sleep(0.05)
+        return _response("slow")
+
+    slow = _MockProvider("slow", _slow)
+
+    def _never(_: ProviderRequest) -> ProviderResponse:
+        raise AssertionError("should not be called")
+
+    blocked = _MockProvider("blocked", _never)
+
+    runner = Runner(
+        [fast, slow, blocked],
+        config=RunnerConfig(mode=RunnerMode.PARALLEL_ANY, max_concurrency=1),
+    )
+
+    started = time.time()
+    result = runner.run(request)
+    elapsed = time.time() - started
+
+    assert result.text == "fast"
+    assert fast.calls == 1
+    assert elapsed < 0.04
+    # third provider should never run due to early cancellation
+    assert blocked.calls == 0
+
+
+def test_runner_parallel_all_collects_all_results() -> None:
+    request = ProviderRequest(model="gpt-test", prompt="hi")
+
+    provider_a = _MockProvider("a", lambda _: _response("A"))
+    provider_b = _MockProvider("b", lambda _: _response("B"))
+
+    runner = Runner(
+        [provider_a, provider_b],
+        config=RunnerConfig(mode=RunnerMode.PARALLEL_ALL, max_concurrency=2),
+    )
+
+    result = runner.run(request)
+
+    assert result.text == "A"
+    assert provider_a.calls == 1
+    assert provider_b.calls == 1
+
+
+def test_runner_consensus_majority_selection() -> None:
+    request = ProviderRequest(model="gpt-test", prompt="hi")
+
+    agree1 = _MockProvider("agree-1", lambda _: _response("agree"))
+    agree2 = _MockProvider("agree-2", lambda _: _response("agree"))
+    disagree = _MockProvider("disagree", lambda _: _response("disagree"))
+
+    runner = Runner(
+        [agree1, agree2, disagree],
+        config=RunnerConfig(
+            mode=RunnerMode.CONSENSUS,
+            max_concurrency=3,
+            consensus=ConsensusConfig(quorum=2),
+        ),
+    )
+
+    result = runner.run(request)
+
+    assert result.text == "agree"
+
+
+def test_runner_consensus_quorum_failure() -> None:
+    request = ProviderRequest(model="gpt-test", prompt="hi")
+
+    agree = _MockProvider("agree", lambda _: _response("agree"))
+    disagree = _MockProvider("disagree", lambda _: _response("disagree"))
+    abstain = _MockProvider("abstain", lambda _: _response("abstain"))
+
+    runner = Runner(
+        [agree, disagree, abstain],
+        config=RunnerConfig(
+            mode=RunnerMode.CONSENSUS,
+            max_concurrency=2,
+            consensus=ConsensusConfig(quorum=3),
+        ),
+    )
+
+    with pytest.raises(ParallelExecutionError):
+        runner.run(request)


### PR DESCRIPTION
## Summary
- extract a reusable provider invocation helper for the synchronous runner
- route Runner.run through sequential or parallel execution strategies and log parallel metrics
- add tests covering sequential mode switching including parallel_any, parallel_all, and consensus behaviour

## Testing
- pytest tests/test_runner_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b5317b1883219ccbff7f366d89b5