### PR TITLE
feat: extend consensus resolution policies

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -26,7 +26,7 @@ from .provider_spi import (
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import (
     ParallelExecutionError,
-    compute_consensus,
+    resolve_consensus,
     run_parallel_all_async,
     run_parallel_any_async,
 )
@@ -343,7 +343,7 @@ class AsyncRunner:
                 else:
                     if mode is RunnerMode.CONSENSUS:
                         try:
-                            consensus = compute_consensus(
+                            consensus = resolve_consensus(
                                 [response for _, _, response in results],
                                 config=self._config.consensus,
                             )

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections import Counter
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+import json
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from concurrent.futures import (
     FIRST_COMPLETED,
     ThreadPoolExecutor,
@@ -140,38 +140,118 @@ async def run_parallel_all_async(
         raise
     return responses
 
-
 @dataclass(slots=True)
 class ConsensusResult:
     response: ProviderResponse
     votes: int
+    score: float
+    reason: str
 
+
+def _extract_weight(response: ProviderResponse) -> float:
+    raw = response.raw
+    if isinstance(raw, Mapping):
+        weight = raw.get("weight")
+        if isinstance(weight, (int, float)):
+            return float(weight)
+    return 1.0
 
 def compute_consensus(
     responses: Iterable[ProviderResponse], *, config: ConsensusConfig | None = None
 ) -> ConsensusResult:
-    """Return the majority response according to ``config``."""
-
     collected = list(responses)
     if not collected:
         raise ValueError("responses must not be empty")
-    if config is None:
-        config = ConsensusConfig()
-    quorum = config.quorum or len(collected)
-    counter = Counter(response.text.strip() for response in collected)
-    top_text, votes = counter.most_common(1)[0]
-    if votes < quorum:
-        raise ParallelExecutionError("consensus quorum not reached")
+    cfg = config or ConsensusConfig()
+    groups: dict[str, list[ProviderResponse]] = {}
     for response in collected:
-        if response.text.strip() == top_text:
-            return ConsensusResult(response=response, votes=votes)
-    raise RuntimeError("consensus resolution failed")
+        groups.setdefault(response.text.strip(), []).append(response)
+    if cfg.strategy == "majority":
+        score_fn = lambda group: float(len(group))
+    elif cfg.strategy == "weighted":
+        score_fn = lambda group: float(sum(_extract_weight(resp) for resp in group))
+    else:
+        raise ValueError(f"unsupported consensus strategy: {cfg.strategy}")
+    scores = {text: score_fn(group) for text, group in groups.items()}
+    top_score = max(scores.values())
+    tied_texts = [text for text, score in scores.items() if score == top_score]
+    quorum = cfg.quorum or len(collected)
+    if max(len(groups[text]) for text in tied_texts) < quorum:
+        raise ParallelExecutionError("consensus quorum not reached")
+    if len(tied_texts) == 1:
+        text = tied_texts[0]
+        return ConsensusResult(groups[text][0], len(groups[text]), top_score, f"strategy={cfg.strategy}")
+    if cfg.tie_breaker == "latency":
+        metric = lambda resp: resp.latency_ms
+    elif cfg.tie_breaker == "cost":
+        metric = lambda resp: resp.token_usage.total
+    elif cfg.tie_breaker is None:
+        raise ParallelExecutionError("consensus tie unresolved")
+    else:
+        raise ValueError(f"unsupported tie breaker: {cfg.tie_breaker}")
+    text = min(tied_texts, key=lambda t: min(metric(resp) for resp in groups[t]))
+    winner = min(groups[text], key=metric)
+    return ConsensusResult(winner, len(groups[text]), top_score, f"strategy={cfg.strategy},tie_breaker={cfg.tie_breaker}")
+
+def _build_schema_validator(schema: str) -> Callable[[ProviderResponse], bool]:
+    data = json.loads(schema)
+    required = data.get("required", []) if isinstance(data, dict) else []
+    expect_object = isinstance(data, dict) and data.get("type") == "object"
+
+    def _validate(response: ProviderResponse) -> bool:
+        try:
+            payload = json.loads(response.text)
+        except json.JSONDecodeError:
+            return False
+        if expect_object and not isinstance(payload, dict):
+            return False
+        return all(field in payload for field in required)
+
+    return _validate
+
+def resolve_consensus(
+    responses: Sequence[ProviderResponse],
+    *,
+    config: ConsensusConfig | None = None,
+    judge: Callable[[Sequence[ProviderResponse]], ProviderResponse | None] | None = None,
+) -> ConsensusResult:
+    cfg = config or ConsensusConfig()
+    remaining = list(responses)
+    validator = _build_schema_validator(cfg.schema) if cfg.schema else None
+    rounds = cfg.max_rounds or 1
+    last_error: ParallelExecutionError | None = None
+    for _ in range(rounds):
+        if validator is not None:
+            remaining = [response for response in remaining if validator(response)]
+        if not remaining:
+            raise ParallelExecutionError("no responses after validation")
+        try:
+            return compute_consensus(remaining, config=cfg)
+        except ParallelExecutionError as exc:
+            last_error = exc
+            if cfg.judge is None:
+                continue
+            if judge is None:
+                raise ValueError("judge callable required when judge is configured")
+            judged = judge(remaining)
+            if judged is None:
+                continue
+            return ConsensusResult(
+                response=judged,
+                votes=0,
+                score=0.0,
+                reason=f"judge={cfg.judge}",
+            )
+    if last_error is not None:
+        raise last_error
+    raise ParallelExecutionError("consensus resolution failed")
 
 
 __all__ = [
     "ParallelExecutionError",
     "ConsensusResult",
     "compute_consensus",
+    "resolve_consensus",
     "run_parallel_all_async",
     "run_parallel_all_sync",
     "run_parallel_any_async",

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -19,7 +19,7 @@ from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import (
     ParallelExecutionError,
-    compute_consensus,
+    resolve_consensus,
     run_parallel_all_sync,
     run_parallel_any_sync,
 )
@@ -375,7 +375,7 @@ class Runner:
                 ]
                 if len(provider_responses) != len(responses):
                     raise ParallelExecutionError("all workers failed")
-                consensus = compute_consensus(
+                consensus = resolve_consensus(
                     provider_responses, config=self._config.consensus
                 )
                 return consensus.response

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,0 +1,64 @@
+import json
+from collections.abc import Sequence
+import pytest
+
+from src.llm_adapter.provider_spi import ProviderResponse, TokenUsage
+from src.llm_adapter.runner_config import ConsensusConfig
+from src.llm_adapter.runner_parallel import ParallelExecutionError, compute_consensus, resolve_consensus
+
+
+def _resp(
+    text: str,
+    *,
+    latency: int = 10,
+    tokens: tuple[int, int] = (1, 1),
+    raw: dict | None = None,
+) -> ProviderResponse:
+    return ProviderResponse(text=text, latency_ms=latency, token_usage=TokenUsage(prompt=tokens[0], completion=tokens[1]), raw=raw)
+
+
+def test_compute_consensus_variants() -> None:
+    cases = [
+        (
+            ConsensusConfig(strategy="majority", tie_breaker="latency", quorum=2),
+            [_resp("A", latency=20), _resp("B", latency=15), _resp("A", latency=40), _resp("B", latency=10)],
+            "B",
+            "latency",
+        ),
+        (
+            ConsensusConfig(strategy="majority", tie_breaker="cost", quorum=2),
+            [_resp("A", tokens=(10, 5)), _resp("B", tokens=(1, 1)), _resp("A", tokens=(1, 1)), _resp("B", tokens=(20, 20))],
+            "A",
+            "cost",
+        ),
+        (
+            ConsensusConfig(strategy="weighted", quorum=1),
+            [_resp("A", raw={"weight": 1.0}), _resp("B", raw={"weight": 4.0}), _resp("A", raw={"weight": 2.0})],
+            "B",
+            "strategy=weighted",
+        ),
+    ]
+    for config, responses, expected, reason_hint in cases:
+        result = compute_consensus(responses, config=config)
+        assert result.response.text == expected
+        assert reason_hint in result.reason
+        if config.strategy == "weighted":
+            assert result.score == pytest.approx(4.0)
+
+
+def test_resolve_consensus_schema_and_judge() -> None:
+    schema = json.dumps({"type": "object", "required": ["answer"]})
+    responses = [_resp(json.dumps({"answer": "A"})), _resp("not json"), _resp(json.dumps({"answer": "B"}))]
+    config = ConsensusConfig(strategy="majority", schema=schema, judge="mock", max_rounds=2)
+
+    def _judge(candidates: Sequence[ProviderResponse]) -> ProviderResponse | None:
+        return next((resp for resp in candidates if "B" in resp.text), None)
+
+    result = resolve_consensus(responses, config=config, judge=_judge)
+    assert json.loads(result.response.text)["answer"] == "B"
+    assert result.reason == "judge=mock"
+
+
+def test_resolve_consensus_unresolved_tie() -> None:
+    with pytest.raises(ParallelExecutionError):
+        resolve_consensus([_resp("A"), _resp("B")], config=ConsensusConfig(strategy="majority"))


### PR DESCRIPTION
## Summary
- extend consensus scoring to support weighted strategy, tie-breakers, and explicit reasoning
- add resolve_consensus helper honoring schema validation, judge callbacks, and max rounds in runner paths
- cover consensus flows with new dedicated tests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c344d080832190583e106a65336e