### PR TITLE
Add configurable consensus orchestration features

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -432,6 +432,12 @@ class AsyncRunner:
                                         "winner_latency_ms": consensus.response.latency_ms,
                                         "tie_break_applied": consensus.tie_break_applied,
                                         "tie_break_reason": consensus.tie_break_reason,
+                                        "rounds": consensus.rounds,
+                                        "scores": consensus.scores,
+                                        "schema_checked": consensus.schema_checked,
+                                        "schema_failures": consensus.schema_failures,
+                                        "judge": consensus.judge_name,
+                                        "judge_score": consensus.judge_score,
                                         "votes": dict(consensus.tally),
                                         "candidate_summaries": candidate_summaries,
                                     },
@@ -467,6 +473,11 @@ class AsyncRunner:
                                         "votes_for": consensus.votes,
                                         "votes_total": consensus.total_voters,
                                         "tie_break_applied": consensus.tie_break_applied,
+                                        "winner_score": consensus.winner_score,
+                                        "rounds": consensus.rounds,
+                                        "tie_break_reason": consensus.tie_break_reason,
+                                        "judge": consensus.judge_name,
+                                        "judge_score": consensus.judge_score,
                                     }
                                 }
                                 if not shadow_payload.get("shadow_ok", True):

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -9,6 +9,7 @@ import math
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from concurrent.futures import (
     FIRST_COMPLETED,
+    Future,
     ThreadPoolExecutor,
     as_completed,
     wait,
@@ -46,7 +47,19 @@ def run_parallel_any_sync(
     max_workers = _normalize_concurrency(len(workers), max_concurrency)
     errors: list[BaseException] = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_map = {executor.submit(worker): idx for idx, worker in enumerate(workers)}
+        worker_iter = iter(enumerate(workers))
+        future_map: dict[Future[T], int] = {}
+
+        def _submit_next() -> None:
+            try:
+                idx, worker = next(worker_iter)
+            except StopIteration:
+                return
+            future_map[executor.submit(worker)] = idx
+
+        for _ in range(max_workers):
+            _submit_next()
+
         while future_map:
             done, _ = wait(future_map, return_when=FIRST_COMPLETED)
             for future in done:
@@ -55,8 +68,9 @@ def run_parallel_any_sync(
                     result = future.result()
                 except BaseException as exc:  # noqa: BLE001
                     errors.append(exc)
+                    _submit_next()
                     continue
-                for pending in future_map:
+                for pending in list(future_map):
                     pending.cancel()
                 return result
     raise ParallelExecutionError("all workers failed") from errors[-1] if errors else None

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -435,23 +435,29 @@ class Runner:
                         "consensus_vote",
                         {
                             "request_fingerprint": request_fingerprint,
-                            "strategy": consensus.strategy,
-                            "tie_breaker": consensus.tie_breaker,
-                            "min_votes": consensus.min_votes,
-                            "score_threshold": consensus.score_threshold,
-                            "voters_total": consensus.total_voters,
-                            "votes_for": consensus.votes,
-                            "votes_against": votes_against,
-                            "abstained": consensus.abstained,
-                            "winner_provider": winner_invocation.provider.name(),
-                            "winner_score": consensus.winner_score,
-                            "winner_latency_ms": consensus.response.latency_ms,
-                            "tie_break_applied": consensus.tie_break_applied,
-                            "tie_break_reason": consensus.tie_break_reason,
-                            "votes": dict(consensus.tally),
-                            "candidate_summaries": candidate_summaries,
-                        },
-                    )
+                                "strategy": consensus.strategy,
+                                "tie_breaker": consensus.tie_breaker,
+                                "min_votes": consensus.min_votes,
+                                "score_threshold": consensus.score_threshold,
+                                "voters_total": consensus.total_voters,
+                                "votes_for": consensus.votes,
+                                "votes_against": votes_against,
+                                "abstained": consensus.abstained,
+                                "winner_provider": winner_invocation.provider.name(),
+                                "winner_score": consensus.winner_score,
+                                "winner_latency_ms": consensus.response.latency_ms,
+                                "tie_break_applied": consensus.tie_break_applied,
+                                "tie_break_reason": consensus.tie_break_reason,
+                                "rounds": consensus.rounds,
+                                "scores": consensus.scores,
+                                "schema_checked": consensus.schema_checked,
+                                "schema_failures": consensus.schema_failures,
+                                "judge": consensus.judge_name,
+                                "judge_score": consensus.judge_score,
+                                "votes": dict(consensus.tally),
+                                "candidate_summaries": candidate_summaries,
+                            },
+                        )
                 if winner_invocation.shadow_metrics is not None:
                     shadow_payload = winner_invocation.shadow_metrics.payload
                     extra: dict[str, object] = {
@@ -459,6 +465,11 @@ class Runner:
                             "votes_for": consensus.votes,
                             "votes_total": consensus.total_voters,
                             "tie_break_applied": consensus.tie_break_applied,
+                            "winner_score": consensus.winner_score,
+                            "rounds": consensus.rounds,
+                            "tie_break_reason": consensus.tie_break_reason,
+                            "judge": consensus.judge_name,
+                            "judge_score": consensus.judge_score,
                         }
                     }
                     if not shadow_payload.get("shadow_ok", True):


### PR DESCRIPTION
## Summary
- add dedicated consensus runner tests that cover strategy selection, tie-breakers, schema validation, judge resolution, and max-round failures
- extend `compute_consensus` to support weighted scoring, schema filtering, judge delegates, and richer result metadata
- propagate the new consensus metrics through synchronous and asynchronous runner events and shadow delta payloads

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py projects/04-llm-adapter-shadow/tests/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d0c582148321af81d294fc596c63