### PR TITLE
Add rpm token bucket enforcement

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -2,16 +2,116 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from threading import Lock
+from typing import TYPE_CHECKING, Any, Callable
 
 from .errors import FatalError, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger
+from .runner_config import RunnerConfig
 from .utils import content_hash
 
 if TYPE_CHECKING:
     from .provider_spi import AsyncProviderSPI, ProviderRequest, ProviderSPI
+
+
+class TokenPermit:
+    """Handle returned by :class:`TokenBucket` acquisitions."""
+
+    __slots__ = ("_committed",)
+
+    def __init__(self) -> None:
+        self._committed = False
+
+    def commit(self) -> None:
+        """Finalize the permit (idempotent)."""
+
+        if self._committed:
+            return
+        self._committed = True
+
+
+class TokenBucket:
+    """Simple token bucket enforcing request-per-minute constraints."""
+
+    __slots__ = (
+        "_capacity",
+        "_tokens",
+        "_refill_rate",
+        "_last_refill",
+        "_clock",
+        "_lock",
+    )
+
+    def __init__(
+        self,
+        rpm: int,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if rpm <= 0:
+            raise ValueError("rpm must be positive")
+        self._refill_rate = float(rpm) / 60.0
+        self._capacity = max(1.0, self._refill_rate)
+        self._tokens = self._capacity
+        self._clock = clock or time.monotonic
+        self._last_refill = self._clock()
+        self._lock = Lock()
+
+    def _refill(self, now: float) -> None:
+        if self._tokens >= self._capacity:
+            self._last_refill = now
+            return
+        elapsed = max(0.0, now - self._last_refill)
+        if elapsed <= 0.0:
+            return
+        self._tokens = min(
+            self._capacity,
+            self._tokens + elapsed * self._refill_rate,
+        )
+        self._last_refill = now
+
+    def _reserve(self) -> float:
+        with self._lock:
+            now = self._clock()
+            self._refill(now)
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return 0.0
+            deficit = 1.0 - self._tokens
+            wait_time = deficit / self._refill_rate
+        return max(wait_time, 0.0)
+
+    def acquire(self) -> TokenPermit:
+        """Block until a token can be consumed and return a permit."""
+
+        while True:
+            wait_time = self._reserve()
+            if wait_time <= 0.0:
+                break
+            time.sleep(wait_time)
+        return TokenPermit()
+
+    async def acquire_async(self) -> TokenPermit:
+        """Async variant of :meth:`acquire`."""
+
+        while True:
+            wait_time = self._reserve()
+            if wait_time <= 0.0:
+                break
+            await asyncio.sleep(wait_time)
+        return TokenPermit()
+
+
+def token_bucket_from_config(config: RunnerConfig) -> TokenBucket | None:
+    """Build a token bucket from ``config`` if an RPM limit is set."""
+
+    if config.rpm is None:
+        return None
+    return TokenBucket(config.rpm)
 
 MetricsPath = str | Path | None
 


### PR DESCRIPTION
## Summary
- add a token-bucket helper that enforces RunnerConfig.rpm and expose acquisition handles to callers
- gate sync and async provider invocations on the rpm bucket to avoid overruns even on errors
- add synchronous and asynchronous regression tests that assert the observed call cadence under rpm constraints

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_modes.py::test_runner_respects_rpm_spacing projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_runner_respects_rpm_spacing

------
https://chatgpt.com/codex/tasks/task_e_68d8d0c724a4832186ef7679fdc74646