### PR TITLE
Add token bucket rate limiting to runners

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -206,7 +206,7 @@ def _extract_score(response: ProviderResponse) -> float:
     raw = response.raw
     if isinstance(raw, Mapping):
         value = raw.get("score")
-        if isinstance(value, (int, float)):
+        if isinstance(value, int | float):
             return float(value)
     return 0.0
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Awaitable
+from typing import TYPE_CHECKING, Any
 
 from .errors import FatalError, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger


### PR DESCRIPTION
## Summary
- add a shared token bucket that enforces rpm limits using a monotonic clock
- integrate the limiter into sync and async runners before provider invocation
- cover rpm throttling in the sync and async runner test suites

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_modes.py projects/04-llm-adapter-shadow/tests/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d88361388321b9bb3ac41d8e2596