### PR TITLE
Refine consensus helpers and tests

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -253,6 +253,48 @@ def _invoke_judge(
     raise TypeError("judge must return str, (choice, score) or mapping of scores")
 
 
+def validate_consensus_schema(
+    responses: Sequence[ProviderResponse], schema: str | None
+) -> tuple[list[tuple[int, ProviderResponse]], dict[int, str], bool]:
+    if not schema:
+        return list(enumerate(responses)), {}, False
+
+    try:
+        schema_spec = json.loads(schema)
+    except json.JSONDecodeError as exc:  # pragma: no cover - config error
+        raise ValueError("invalid consensus schema") from exc
+    if not isinstance(schema_spec, Mapping):
+        raise ValueError("invalid consensus schema")
+
+    valid_entries: list[tuple[int, ProviderResponse]] = []
+    failures: dict[int, str] = {}
+    expected_type = schema_spec.get("type")
+    required_fields = [str(field) for field in schema_spec.get("required", [])]
+
+    for index, response in enumerate(responses):
+        try:
+            parsed = json.loads(response.text)
+        except json.JSONDecodeError as exc:
+            failures[index] = f"invalid json: {exc.msg}"
+            continue
+        if expected_type == "object" and not isinstance(parsed, Mapping):
+            failures[index] = "expected object"
+            continue
+        missing = [field for field in required_fields if field not in parsed]
+        if missing:
+            failures[index] = f"missing keys: {', '.join(missing)}"
+            continue
+        valid_entries.append((index, response))
+
+    return valid_entries, failures, True
+
+
+def invoke_consensus_judge(
+    judge: str, candidates: Sequence[_Candidate]
+) -> tuple[str, float | None]:
+    return _invoke_judge(_load_judge(judge), candidates)
+
+
 def compute_consensus(
     responses: Iterable[ProviderResponse], *, config: ConsensusConfig | None = None
 ) -> ConsensusResult:
@@ -270,34 +312,9 @@ def compute_consensus(
     if tie_breaker is not None and tie_breaker not in {"latency", "cost"}:
         raise ValueError(f"unsupported tie_breaker: {config.tie_breaker!r}")
 
-    schema_spec: dict[str, Any] | None = None
-    if config.schema:
-        try:
-            schema_spec = json.loads(config.schema)
-        except json.JSONDecodeError as exc:  # pragma: no cover - config error
-            raise ValueError("invalid consensus schema") from exc
-
-    valid_entries: list[tuple[int, ProviderResponse]] = []
-    schema_failures: dict[int, str] = {}
-    for index, response in enumerate(collected):
-        if schema_spec is None:
-            valid_entries.append((index, response))
-            continue
-        try:
-            parsed = json.loads(response.text)
-        except json.JSONDecodeError as exc:
-            schema_failures[index] = f"invalid json: {exc.msg}"
-            continue
-        expected_type = schema_spec.get("type")
-        if expected_type == "object" and not isinstance(parsed, Mapping):
-            schema_failures[index] = "expected object"
-            continue
-        required = schema_spec.get("required") or []
-        missing = [field for field in required if field not in parsed]
-        if missing:
-            schema_failures[index] = f"missing keys: {', '.join(map(str, missing))}"
-            continue
-        valid_entries.append((index, response))
+    valid_entries, schema_failures, schema_checked = validate_consensus_schema(
+        collected, config.schema
+    )
 
     if not valid_entries:
         raise ParallelExecutionError("all responses failed schema validation")
@@ -339,25 +356,26 @@ def compute_consensus(
     remaining = pool
     max_rounds = config.max_rounds
 
-    if tie_break_applied and tie_breaker is not None:
+    def _next_round() -> None:
+        nonlocal rounds
         if max_rounds is not None and rounds >= max_rounds:
             raise ParallelExecutionError("consensus max_rounds exhausted")
-        remaining, tie_break_reason = _apply_tie_breaker(tie_breaker, remaining)
         rounds += 1
 
+    if tie_break_applied and tie_breaker is not None:
+        _next_round()
+        remaining, tie_break_reason = _apply_tie_breaker(tie_breaker, remaining)
+
     if len(remaining) > 1 and config.judge:
-        if max_rounds is not None and rounds >= max_rounds:
-            raise ParallelExecutionError("consensus max_rounds exhausted")
+        _next_round()
         judge_name = config.judge
-        judge_callable = _load_judge(judge_name)
-        choice, judge_score = _invoke_judge(judge_callable, remaining)
+        choice, judge_score = invoke_consensus_judge(judge_name, remaining)
         for candidate in remaining:
             if candidate.text == choice:
                 remaining = [candidate]
                 break
         else:  # pragma: no cover - defensive guard
             raise ParallelExecutionError("judge returned unknown choice")
-        rounds += 1
 
     if len(remaining) > 1:
         raise ParallelExecutionError("consensus tie could not be resolved")
@@ -382,7 +400,7 @@ def compute_consensus(
         winner_score=winner_score,
         abstained=len(collected) - len(valid_entries),
         rounds=rounds,
-        schema_checked=schema_spec is not None,
+        schema_checked=schema_checked,
         schema_failures=schema_failures,
         judge_name=judge_name,
         judge_score=judge_score,
@@ -393,6 +411,8 @@ def compute_consensus(
 __all__ = [
     "ParallelExecutionError",
     "ConsensusResult",
+    "invoke_consensus_judge",
+    "validate_consensus_schema",
     "compute_consensus",
     "run_parallel_all_async",
     "run_parallel_all_sync",

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -85,31 +85,49 @@ def test_schema_validation_marks_abstentions() -> None:
     assert result.response.text == '{"value": "ok"}'
     assert result.abstained == 1
     assert result.schema_checked is True
-    assert set(result.schema_failures) == {2}
+    assert result.rounds == 1
+    assert result.schema_failures[2].startswith("invalid json")
 
 
-def test_judge_breaks_tie() -> None:
-    responses = [_response("A", 10), _response("B", 10)]
+def test_judge_provider_handles_runoff_round() -> None:
+    responses = [
+        _response("A", 10),
+        _response("B", 10),
+        _response("A", 20),
+        _response("B", 20),
+    ]
     result = compute_consensus(
         responses,
         config=ConsensusConfig(
             strategy="majority",
+            tie_breaker="latency",
             judge="tests.test_runner_consensus:fake_judge",
-            quorum=1,
-            max_rounds=3,
+            quorum=2,
+            max_rounds=4,
         ),
     )
     assert result.response.text == "B"
     assert result.tie_break_applied is True
+    assert result.tie_break_reason == "latency(min=10)"
     assert result.judge_name == "tests.test_runner_consensus:fake_judge"
     assert result.judge_score == pytest.approx(0.75)
-    assert result.rounds == 2
+    assert result.rounds == 3
 
 
-def test_max_rounds_exhausted_raises() -> None:
-    responses = [_response("A", 10), _response("B", 10)]
+def test_max_rounds_exhausted_before_judge_round() -> None:
+    responses = [
+        _response("A", 10),
+        _response("B", 10),
+        _response("A", 20),
+        _response("B", 20),
+    ]
     with pytest.raises(ParallelExecutionError):
         compute_consensus(
             responses,
-            config=ConsensusConfig(strategy="majority", max_rounds=1),
+            config=ConsensusConfig(
+                strategy="majority",
+                tie_breaker="latency",
+                judge="tests.test_runner_consensus:fake_judge",
+                max_rounds=2,
+            ),
         )


### PR DESCRIPTION
## Summary
- add reusable helpers for schema validation and judge invocation in the consensus runner
- ensure consensus rounds advance sequentially with max_rounds enforcement
- expand consensus tests to cover schema abstentions, judge run-offs, and max round exhaustion

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d8831a4883218bdb2d684a6c8ef9