### PR TITLE
Add max score consensus strategy and expose tie-break metadata

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -435,6 +435,7 @@ class AsyncRunner:
                                         "winner_latency_ms": consensus.response.latency_ms,
                                         "tie_break_applied": consensus.tie_break_applied,
                                         "tie_break_reason": consensus.tie_break_reason,
+                                        "tie_breaker_selected": consensus.tie_breaker_selected,
                                         "rounds": consensus.rounds,
                                         "scores": consensus.scores,
                                         "schema_checked": consensus.schema_checked,
@@ -480,6 +481,7 @@ class AsyncRunner:
                                         "winner_score": consensus.winner_score,
                                         "rounds": consensus.rounds,
                                         "tie_break_reason": consensus.tie_break_reason,
+                                        "tie_breaker_selected": consensus.tie_breaker_selected,
                                         "judge": consensus.judge_name,
                                         "judge_score": consensus.judge_score,
                                     }

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -448,6 +448,7 @@ class Runner:
                                 "winner_latency_ms": consensus.response.latency_ms,
                                 "tie_break_applied": consensus.tie_break_applied,
                                 "tie_break_reason": consensus.tie_break_reason,
+                                "tie_breaker_selected": consensus.tie_breaker_selected,
                                 "rounds": consensus.rounds,
                                 "scores": consensus.scores,
                                 "schema_checked": consensus.schema_checked,
@@ -468,6 +469,7 @@ class Runner:
                             "winner_score": consensus.winner_score,
                             "rounds": consensus.rounds,
                             "tie_break_reason": consensus.tie_break_reason,
+                            "tie_breaker_selected": consensus.tie_breaker_selected,
                             "judge": consensus.judge_name,
                             "judge_score": consensus.judge_score,
                         }

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -49,6 +49,7 @@ def test_majority_with_latency_tie_breaker() -> None:
     assert result.votes == 2
     assert result.tie_break_applied is True
     assert result.tie_break_reason.startswith("latency")
+    assert result.tie_breaker_selected == "latency"
     assert result.rounds == 2
 
 
@@ -69,6 +70,28 @@ def test_weighted_strategy_records_scores() -> None:
     assert result.scores["B"] == pytest.approx(0.6)
     assert result.winner_score == pytest.approx(0.6)
     assert result.tie_break_reason == "cost(min)"
+    assert result.tie_breaker_selected == "cost"
+
+
+def test_max_score_strategy_prefers_best_latency() -> None:
+    responses = [
+        _response("A", 18, score=0.6),
+        _response("B", 9, score=0.5),
+        _response("A", 22, score=0.4),
+        _response("B", 7, score=0.6),
+    ]
+    result = compute_consensus(
+        responses,
+        config=ConsensusConfig(strategy="max_score", tie_breaker="latency", quorum=2),
+    )
+    assert result.response.text == "B"
+    assert result.tie_break_applied is True
+    assert result.tie_breaker_selected == "latency"
+    assert result.tie_break_reason.startswith("latency")
+    assert result.scores is not None
+    assert result.scores["A"] == pytest.approx(0.6)
+    assert result.scores["B"] == pytest.approx(0.6)
+    assert result.winner_score == pytest.approx(0.6)
 
 
 def test_schema_validation_marks_abstentions() -> None:
@@ -103,6 +126,7 @@ def test_judge_breaks_tie() -> None:
     assert result.tie_break_applied is True
     assert result.judge_name == "tests.test_runner_consensus:fake_judge"
     assert result.judge_score == pytest.approx(0.75)
+    assert result.tie_breaker_selected is None
     assert result.rounds == 2
 
 


### PR DESCRIPTION
## Summary
- add max_score consensus aggregation and track selected tie-breakers and score maps
- surface the applied tie-breaker name in sync/async runner logging payloads
- extend consensus tests with latency and max_score coverage

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d8825e788321beffde42d0806580