### PR TITLE
Expose parallel-all runner results

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from .runner_async import AsyncRunner
 from .runner_config import BackoffPolicy, RunnerConfig
+from .runner_parallel import ParallelAllResult
 from .runner_sync import Runner
 
-__all__ = ["BackoffPolicy", "RunnerConfig", "Runner", "AsyncRunner"]
+__all__ = [
+    "BackoffPolicy",
+    "RunnerConfig",
+    "Runner",
+    "AsyncRunner",
+    "ParallelAllResult",
+]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -25,6 +25,7 @@ from .provider_spi import (
 )
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import (
+    ParallelAllResult,
     ParallelExecutionError,
     compute_consensus,
     run_parallel_all_async,
@@ -223,7 +224,7 @@ class AsyncRunner:
         request: ProviderRequest,
         shadow: ProviderSPI | AsyncProviderSPI | None = None,
         shadow_metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
-    ) -> ProviderResponse:
+    ) -> ProviderResponse | ParallelAllResult[WorkerResult, ProviderResponse]:
         last_err: Exception | None = None
         event_logger, metrics_path_str = resolve_event_logger(
             self._logger, shadow_metrics_path
@@ -522,7 +523,10 @@ class AsyncRunner:
                             metadata=metadata,
                             shadow_used=shadow is not None,
                         )
-                        return response
+                        return ParallelAllResult(
+                            results,
+                            lambda entry: entry[2],
+                        )
 
         if mode is RunnerMode.CONSENSUS:
             for _, _, _, metrics in results:

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -15,7 +15,7 @@ from concurrent.futures import (
     wait,
 )
 from dataclasses import dataclass, field
-from typing import Any, TypeVar, cast
+from typing import Any, Callable as TypingCallable, Generic, Iterator, TypeVar, cast
 
 from .provider_spi import ProviderResponse
 from .runner_config import ConsensusConfig
@@ -29,6 +29,53 @@ AsyncWorker = Callable[[], Awaitable[T]]
 
 class ParallelExecutionError(RuntimeError):
     """Raised when all parallel workers fail to produce a response."""
+
+
+S = TypeVar("S")
+
+
+@dataclass(slots=True)
+class ParallelAllResult(Generic[T, S]):
+    """Container capturing every result from ``run_parallel_all_*`` helpers."""
+
+    items: Sequence[T]
+    _extract: TypingCallable[[T], S]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise ValueError("ParallelAllResult requires at least one item")
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self.items)
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, index: int) -> T:
+        return self.items[index]
+
+    @property
+    def invocations(self) -> Sequence[T]:
+        return self.items
+
+    @property
+    def responses(self) -> list[S]:
+        return [self._extract(item) for item in self.items]
+
+    @property
+    def primary_invocation(self) -> T:
+        return self.items[0]
+
+    @property
+    def primary_response(self) -> S:
+        return self._extract(self.primary_invocation)
+
+    def __getattr__(self, name: str) -> Any:
+        primary = self.primary_response
+        if hasattr(primary, name):
+            return getattr(primary, name)
+        msg = f"{type(self).__name__} has no attribute {name!r}"
+        raise AttributeError(msg)
 
 
 def _normalize_concurrency(total: int, limit: int | None) -> int:


### PR DESCRIPTION
## Summary
- add a `ParallelAllResult` container that preserves all outputs from `run_parallel_all_*` helpers while proxying the primary response for compatibility
- update both sync and async runners to return the container in `PARALLEL_ALL` mode and export it via the public API
- extend parallel runner tests to confirm full response access and legacy attribute forwarding

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py


------
https://chatgpt.com/codex/tasks/task_e_68d8f5d922d88321a1bedd3707c1b342