### PR TITLE
Handle failed parallel workers before returning

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -364,6 +364,13 @@ class Runner:
                     capture_shadow_metrics=capture_shadow,
                 )
                 results[index - 1] = result
+                if result.response is None:
+                    error = result.error
+                    if error is not None:
+                        raise error
+                    error = ParallelExecutionError("provider returned no response")
+                    result.error = error
+                    raise error
                 return result
 
             return worker


### PR DESCRIPTION
## Summary
- raise provider errors from Runner parallel workers so ParallelAny can reschedule remaining futures
- cover fast-failure scenario with a regression test to ensure slow successes are returned

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fbc23ad88321a705fecf2f0de3d2