### PR TITLE
Handle consensus failures without aborting

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,12 +1,24 @@
+from typing import Any, Mapping
+
 import pytest
 
-from src.llm_adapter.provider_spi import ProviderResponse, TokenUsage
-from src.llm_adapter.runner_config import ConsensusConfig
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
+from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
+    ConsensusFailure,
     ConsensusResult,
     ParallelExecutionError,
     compute_consensus,
 )
+from src.llm_adapter.runner_sync import Runner
+
+
+class _CapturingLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: Mapping[str, Any]) -> None:
+        self.events.append((event_type, dict(record)))
 
 
 def _response(
@@ -154,3 +166,88 @@ def test_max_rounds_exhausted_before_judge_round() -> None:
                 max_rounds=2,
             ),
         )
+
+
+def test_compute_consensus_records_failures() -> None:
+    responses = [_response("A", 10), _response("A", 11)]
+    failures = [
+        ConsensusFailure(
+            provider="fail",
+            attempt=1,
+            error_type="RuntimeError",
+            error_message="boom",
+        )
+    ]
+    result = compute_consensus(
+        responses,
+        config=ConsensusConfig(quorum=2),
+        failures=failures,
+    )
+    assert result.response.text == "A"
+    assert result.failures == tuple(failures)
+
+
+def test_runner_consensus_logs_partial_failures() -> None:
+    class _StaticProvider:
+        def __init__(self, name: str, text: str, latency_ms: int) -> None:
+            self._name = name
+            self._text = text
+            self._latency = latency_ms
+
+        def name(self) -> str:
+            return self._name
+
+        def capabilities(self) -> set[str]:
+            return set()
+
+        def invoke(self, request: ProviderRequest) -> ProviderResponse:
+            return ProviderResponse(
+                text=self._text,
+                latency_ms=self._latency,
+                token_usage=TokenUsage(prompt=1, completion=1),
+                model=request.model,
+                finish_reason="stop",
+            )
+
+    class _FailingProvider:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def name(self) -> str:
+            return self._name
+
+        def capabilities(self) -> set[str]:
+            return set()
+
+        def invoke(self, request: ProviderRequest) -> ProviderResponse:
+            raise RuntimeError("boom")
+
+    providers = [
+        _StaticProvider("p1", "agree", latency_ms=5),
+        _FailingProvider("fail"),
+        _StaticProvider("p2", "agree", latency_ms=7),
+    ]
+    logger = _CapturingLogger()
+    runner = Runner(
+        providers,
+        logger=logger,
+        config=RunnerConfig(
+            mode=RunnerMode.CONSENSUS,
+            max_concurrency=3,
+            consensus=ConsensusConfig(quorum=2),
+        ),
+    )
+
+    request = ProviderRequest(prompt="hello", model="m-consensus")
+    response = runner.run(request)
+
+    assert response.text == "agree"
+
+    consensus_event = next(
+        record for record in logger.events if record[0] == "consensus_vote"
+    )[1]
+    assert consensus_event["failures_total"] == 1
+    failure_entry = consensus_event["failures"][0]
+    assert failure_entry["provider"] == "fail"
+    assert failure_entry["error_type"] == "RuntimeError"
+


### PR DESCRIPTION
## Summary
- preserve failed invocations during consensus runs and expose them through a new `ConsensusFailure` record on `ConsensusResult`
- update sync and async runners to tolerate partial provider failures while logging failure details into consensus metrics
- extend consensus tests to cover quorum success with failures and ensure failure metadata is captured

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fbc8191083218887527de16b43e2