### PR TITLE
Add retry controls to parallel all runners

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -13,7 +13,6 @@ from concurrent.futures import (
     FIRST_COMPLETED,
     Future,
     ThreadPoolExecutor,
-    as_completed,
     wait,
 )
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary
- add optional retry controls to the parallel-all runners for sync and async execution
- implement attempt accounting and retry hook handling while preserving cancellation semantics

## Testing
- `pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py -k parallel_all`


------
https://chatgpt.com/codex/tasks/task_e_68d91642bd288321a08fc15204e0d14e