### PR TITLE
Skip async sleep when probe delay is non-positive

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -60,10 +60,14 @@ class _AsyncProbeProvider:
 
     async def invoke_async(self, request: ProviderRequest) -> ProviderResponse:
         try:
-            await asyncio.sleep(self._delay)
+            if self._delay <= 0:
+                latency_ms = 0
+            else:
+                await asyncio.sleep(self._delay)
+                latency_ms = int(self._delay * 1000)
             return ProviderResponse(
                 text=f"{self._text}:{request.prompt}",
-                latency_ms=int(self._delay * 1000),
+                latency_ms=latency_ms,
                 token_usage=TokenUsage(prompt=1, completion=1),
                 model=request.model,
             )


### PR DESCRIPTION
## Summary
- skip scheduling asyncio.sleep in `_AsyncProbeProvider.invoke_async` when the configured delay is non-positive so the helper reports zero latency without awaiting

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_retry_behaviour *(fails: test path not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d92390566883219a723196fddaf221