### PR TITLE
Prevent default parallel retries on rate limit

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -340,6 +340,8 @@ class AsyncRunner:
                 worker_index: int, attempt_index: int, error: BaseException
             ) -> tuple[int, float] | None:
                 nonlocal retry_attempts, attempt_count
+                if self._config.max_attempts is None:
+                    return None
                 provider, _ = providers[worker_index]
                 next_attempt_total = total_providers + retry_attempts + 1
                 delay: float | None = None


### PR DESCRIPTION
## Summary
- avoid scheduling additional parallel retries when no max_attempts limit is configured
- add regression coverage ensuring PARALLEL_ANY and PARALLEL_ALL stop after a single rate limit failure

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py projects/04-llm-adapter-shadow/tests/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68d947cc00348321aa725474eaa61f6e