### PR TITLE
Update pytest command to enforce asyncio strict mode

### DIFF
--- a/.github/workflows/python-llm-adapter-shadow.yml
+++ b/.github/workflows/python-llm-adapter-shadow.yml
@@ -21,4 +21,4 @@ jobs:
           pip install -r projects/04-llm-adapter-shadow/requirements.txt
       - name: Run tests
         run: |
-          pytest -q projects/04-llm-adapter-shadow/tests
+          pytest -q --asyncio-mode=strict projects/04-llm-adapter-shadow/tests

--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=8.2.0
 pytest-cov>=5.0.0
+pytest-asyncio>=0.23.6
 google-genai>=0.3
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- ensure the workflow runs pytest with --asyncio-mode=strict for the LLM adapter shadow project
- add pytest-asyncio to the project requirements to support the strict asyncio pytest option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95156500c83219da8c61a917fd649