### PR TITLE
Add smoke parallel job to llm adapter shadow workflow

### DIFF
--- a/.github/workflows/python-llm-adapter-shadow.yml
+++ b/.github/workflows/python-llm-adapter-shadow.yml
@@ -5,8 +5,31 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: python-llm-adapter-shadow
+
 jobs:
+  smoke-parallel:
+    name: Smoke (parallel retry scenarios)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r projects/04-llm-adapter-shadow/requirements.txt
+      - name: Run smoke tests
+        run: |
+          pytest -q projects/04-llm-adapter-shadow/tests/test_runner_async.py -k "parallel_retry_behaviour or parallel_all_rate_limit_does_not_retry" --maxfail=1
+
   test:
+    name: Full test suite
+    needs: smoke-parallel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a smoke job that exercises the parallel retry scenarios for the LLM adapter shadow suite
- ensure the full suite waits for the smoke job and share concurrency to avoid parallel execution

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d95152d8988321970819a7a457e658