### PR TITLE
Limit LLM adapter full suite to main pushes

### DIFF
--- a/.github/workflows/python-llm-adapter-shadow.yml
+++ b/.github/workflows/python-llm-adapter-shadow.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: python-llm-adapter-shadow
@@ -11,6 +12,7 @@ concurrency:
 jobs:
   smoke-parallel:
     name: Smoke (parallel retry scenarios)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +32,7 @@ jobs:
   test:
     name: Full test suite
     needs: smoke-parallel
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _QA / SDET / LLM 成果物をまとめた可視化ポータル_
 - **Website:** <https://ryosuke4219.github.io/portfolio/> — Portfolio Gallery on GitHub Pages
 - **行動規範:** [Contributor Covenant v2.1](CODE_OF_CONDUCT.md)
 - **Docs Deploy:** `.github/workflows/pages.yml` が `docs/` をビルド&公開（追加の Pages ワークフローは不要）
+- **LLM Adapter Shadow CI:** `.github/workflows/python-llm-adapter-shadow.yml` は `main` ブランチへの push でフルスイート、PR ではスモークのみを実行。`workflow_dispatch` で挙動検証可。
 - **Topics:** `qa`, `sdet`, `playwright`, `llm`, `pytest`, `github-actions`, `devcontainers`, `codeql`
 - **Quick Start:** `just setup && just test && just report`
 


### PR DESCRIPTION
## Summary
- ensure the full LLM adapter suite runs only on main push events and keep the smoke job on pull requests
- add workflow_dispatch trigger and document the new execution policy in the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d955e4e1108321b277337fdea4ff0f