### PR TITLE
Enable workflow_dispatch for LLM adapter shadow smoke job

### DIFF
--- a/.github/workflows/python-llm-adapter-shadow.yml
+++ b/.github/workflows/python-llm-adapter-shadow.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   smoke-parallel:
     name: Smoke (parallel retry scenarios)
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- allow the smoke job to run for workflow_dispatch triggers alongside push and PR events
- confirmed via a workflow_dispatch dry run script that both jobs execute sequentially under the manual trigger

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68d958c5d73c8321a33da6b7c286529f