### PR TITLE
Update pytest workflow to cover adapter and shadow packages

### DIFF
--- a/.github/workflows/python-pytest.yml
+++ b/.github/workflows/python-pytest.yml
@@ -17,20 +17,25 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
+          cache-dependency-path: |
+            projects/04-llm-adapter/requirements.txt
+            projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r projects/04-llm-adapter/requirements.txt
           pip install -r projects/04-llm-adapter-shadow/requirements.txt
 
       - name: Run pytest with coverage HTML
         run: |
           pytest \
+            --cov=projects/04-llm-adapter \
             --cov=projects/04-llm-adapter-shadow \
             --cov-report=xml:projects/04-llm-adapter-shadow/coverage.xml \
             --cov-report=html:projects/04-llm-adapter-shadow/htmlcov \
             --cov-report=term-missing \
+            projects/04-llm-adapter/tests \
             projects/04-llm-adapter-shadow/tests
 
       - name: Upload Python coverage artifacts


### PR DESCRIPTION
## Summary
- cache and install dependencies for both adapter and shadow requirement sets
- run pytest against both adapter and shadow test suites with combined coverage collection

## Testing
- not run (environment has restricted network access for Python dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d95b7558848321a9c6fc6bfa78fba2