### PR TITLE
Adjust async retry test attempts

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -524,6 +524,8 @@ def test_async_parallel_retry_behaviour(monkeypatch: pytest.MonkeyPatch) -> None
         config=RunnerConfig(
             mode=RunnerMode.PARALLEL_ANY,
             backoff=BackoffPolicy(rate_limit_sleep_s=0.25, timeout_next_provider=False),
+            # 既定ではリトライしないためテストで旧来どおり 3 回試行させる
+            max_attempts=4,
         ),
     )
 


### PR DESCRIPTION
## Summary
- configure the async parallel retry behaviour test to use four allowed attempts so the flaky probe still runs three times
- document in the test that retries are enabled explicitly for this scenario

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py -k test_async_parallel_retry_behaviour

------
https://chatgpt.com/codex/tasks/task_e_68d953791cec8321965526fdcc0d0560