### PR TITLE
Fix reusable workflow references for adapter tests

### DIFF
--- a/.github/workflows/adapter-tests.yml
+++ b/.github/workflows/adapter-tests.yml
@@ -11,28 +11,6 @@ on:
       - '.github/workflows/adapter-tests.yml'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: projects/04-llm-adapter-shadow/requirements.txt
-
-      - name: Install dependencies
-        working-directory: projects/04-llm-adapter-shadow
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run pytest
-        working-directory: projects/04-llm-adapter-shadow
-        env:
-          PYTHONPATH: src
-        run: pytest -q
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 # .github/workflows/ci.yml
 name: portfolio-ci
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_call:
 
 # 同じブランチで複数実行されたら古い方をキャンセル
 concurrency:


### PR DESCRIPTION
## Summary
- allow the CI workflow to be triggered via `workflow_call`
- reuse the CI workflow from the adapter-tests workflow through a relative path to avoid `refs/pull/*/merge`

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9665ce14483219db45fd9d88f2757