### PR TITLE
Fix python CI workflow environment and runner API compatibility

### DIFF
--- a/.github/workflows/python-pytest.yml
+++ b/.github/workflows/python-pytest.yml
@@ -7,6 +7,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      PYTHONPATH: ${{ format('{0}/projects/04-llm-adapter-shadow', github.workspace) }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- ensure the python pytest reusable workflow sets PYTHONPATH so the shadow adapter package is importable
- expose `CompareRunner` from `runner_api` and allow tests to monkeypatch `runner.run` without requiring a config argument

## Testing
- PYTHONPATH=$PWD/projects/04-llm-adapter-shadow pytest projects/04-llm-adapter/tests/test_cli_runner_config.py projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68d96f6804e08321908ea185defdb907