### PR TITLE
Add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 1'
+
+permissions:
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.6.0
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: |
+            javascript-typescript
+            python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          output: codeql-results
+
+      - name: Upload CodeQL SARIF artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif
+          path: codeql-results/**/*.sarif
+          if-no-files-found: error
+
+      - name: Upload CodeQL failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodeQL-logs
+          path: |
+            ${{ runner.temp }}/codeql
+            ${{ runner.temp }}/codeql_databases
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add a scheduled CodeQL analysis workflow for JavaScript/TypeScript and Python
- configure dependencies, SARIF artifact upload, and failure log archiving

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d97f12f29c8321acb698b34ba93e6a