### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,69 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      JEKYLL_ENV: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        id: jekyll
+        uses: actions/jekyll-build@v1
+        with:
+          source: docs
+          destination: _site
+        continue-on-error: true
+
+      - name: Upload artifact
+        if: steps.jekyll.outcome == 'success'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Collect trace logs
+        if: steps.jekyll.outcome == 'failure'
+        run: |
+          bundle exec jekyll build --source docs --destination _site --trace > jekyll-trace.log 2>&1 || true
+          echo '### Jekyll build trace' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat jekyll-trace.log >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        env:
+          JEKYLL_ENV: production
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
+      - name: Deployment summary
+        run: |
+          echo '## Deployment' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '[View deployed site](${{ steps.deploy.outputs.page_url }})' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that builds the docs site and deploys via GitHub Pages
- capture Jekyll trace output in the job summary when the build fails and surface the deployed URL on success

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d97f1128fc8321995e695fe793eb28