### PR TITLE
Add CI workflow for Node and Python suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.6.0
+      - run: npm ci
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r projects/04-llm-adapter-shadow/requirements.txt
+      - name: Run Node test suites
+        run: |
+          set -euxo pipefail
+          npm run spec:validate
+          npm run e2e:gen
+          bash scripts/run-node-suite.sh
+          npm run ci:analyze
+          npm run ci:issue
+          PYTHON=python3 node --test tests/e2e-shadow.test.mjs
+      - name: Run Python tests
+        run: |
+          set -euxo pipefail
+          pytest -q projects/04-llm-adapter-shadow/tests
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-artifacts
+          path: |
+            junit-results.xml
+            projects/03-ci-flaky/out
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add CI workflow that installs Node and Python dependencies
- run Node validation, generation, and analysis commands before executing Python tests
- upload junit results and flaky project outputs as build artifacts

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68d97f0e2fec83219ef64cf021c1b8f7