### PR TITLE
Add contents read permission for pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- grant the Pages workflow read access to repository contents so checkout can succeed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9db15e2288321afa770a28a646ab6