### PR TITLE
Add contents read permission to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
     - cron: '30 1 * * 1'
 
 permissions:
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- allow the CodeQL workflow to read repository contents so checkout@v4 can run

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9db1541b08321acdbc921a5563169