### PR TITLE
Add Gemfile for GitHub Pages docs build

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-theme-cayman'
+gem 'jekyll-seo-tag'
+gem 'jekyll-sitemap'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  github-pages
+  jekyll-seo-tag
+  jekyll-sitemap
+  jekyll-theme-cayman
+
+BUNDLED WITH
+   2.6.7


### PR DESCRIPTION
## Summary
- add a Gemfile under docs to pull in GitHub Pages and related Jekyll plugins
- check in the corresponding lockfile with the linux platform recorded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e236b5d48321aac958370266b97c