### PR TITLE
Restrict CI and lint workflows to source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,40 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - 'projects/**'
+      - 'tools/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pyproject.toml'
+      - '.github/workflows/**'
+      - '!docs/**'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - 'projects/**'
+      - 'tools/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pyproject.toml'
+      - '.github/workflows/**'
+      - '!docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,40 @@ name: Lint
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - 'projects/**'
+      - 'tools/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pyproject.toml'
+      - '.github/workflows/**'
+      - '!docs/**'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.jsx'
+      - 'projects/**'
+      - 'tools/**'
+      - 'packages/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pyproject.toml'
+      - '.github/workflows/**'
+      - '!docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- limit CI and lint workflows to run only when source, configuration, or workflow files change
- keep manual dispatch available so maintainers can bypass the path filters when needed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9e5182a108321b521fb142c13b16c