### PR TITLE
Update GitHub Pages workflow to use jekyll-build-pages action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build with Jekyll
         id: jekyll
-        uses: actions/jekyll-build@v1
+        uses: actions/jekyll-build-pages@v1
         with:
           source: docs
           destination: _site


### PR DESCRIPTION
## Summary
- update the GitHub Pages workflow to use the current `actions/jekyll-build-pages@v1` action

## Testing
- bundle exec jekyll build --source docs --destination _site *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d9eac165d483218794ebfc22b28a47