### PR TITLE
Fix parse command directory handling for CI flaky store

### DIFF
--- a/projects/03-ci-flaky/src/commands/parse.js
+++ b/projects/03-ci-flaky/src/commands/parse.js
@@ -178,7 +178,7 @@ export async function runParse(args) {
     source: attempt.source,
   }));
 
-  ensureDir(resolvedConfig.paths.store);
+  ensureDir(path.dirname(resolvedConfig.paths.store));
   appendAttempts(resolvedConfig.paths.store, enrichedAttempts);
 
   const failCount = enrichedAttempts.filter((a) => a.status === 'fail' || a.status === 'error').length;


### PR DESCRIPTION
## Summary
- ensure the parse command only creates the store directory, not the JSONL file path

## Testing
- node projects/03-ci-flaky/scripts/flaky.mjs parse --input /tmp/sample-junit.xml --run-id test_run

------
https://chatgpt.com/codex/tasks/task_e_68d9ed0890988321bf693357a8e65d01