### PR TITLE
Fix Bundler Gemfile reference for Pages trace logs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,7 @@ jobs:
           exit 1
         env:
           JEKYLL_ENV: production
+          BUNDLE_GEMFILE: docs/Gemfile
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- configure the Collect trace logs step to point Bundler at docs/Gemfile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ecb4005083218eaba8497cba8e05