### PR TITLE
Adjust workflow doc filters for CI and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ on:
       - 'package-lock.json'
       - 'pyproject.toml'
       - '.github/workflows/**'
-      - '!docs/**'
+      - 'docs/examples/**'
+      - '!docs/**/*.md'
+      - '!docs/**/*.yml'
   pull_request:
     branches: [main]
     paths:
@@ -40,7 +42,9 @@ on:
       - 'package-lock.json'
       - 'pyproject.toml'
       - '.github/workflows/**'
-      - '!docs/**'
+      - 'docs/examples/**'
+      - '!docs/**/*.md'
+      - '!docs/**/*.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,9 @@ on:
       - 'package-lock.json'
       - 'pyproject.toml'
       - '.github/workflows/**'
-      - '!docs/**'
+      - 'docs/examples/**'
+      - '!docs/**/*.md'
+      - '!docs/**/*.yml'
   pull_request:
     branches: [main]
     paths:
@@ -40,7 +42,9 @@ on:
       - 'package-lock.json'
       - 'pyproject.toml'
       - '.github/workflows/**'
-      - '!docs/**'
+      - 'docs/examples/**'
+      - '!docs/**/*.md'
+      - '!docs/**/*.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- ensure CI and Lint workflows still cover docs/examples directories while excluding only markdown and YAML docs files

## Testing
- not run (workflow filter change only)

------
https://chatgpt.com/codex/tasks/task_e_68d9ecb143a08321a14b77488538b03c