### PR TITLE
refactor: modernize typing usage in metrics tools

### DIFF
--- a/projects/04-llm-adapter-shadow/tools/consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tools/consume_cases.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from collections.abc import Iterable, Mapping, MutableMapping
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+from typing import Any
 
 
 def _load_json(path: Path) -> Any:
@@ -19,11 +20,11 @@ def _load_json(path: Path) -> Any:
         raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
 
 
-def _load_jsonl(path: Path) -> List[Mapping[str, Any]]:
+def _load_jsonl(path: Path) -> list[Mapping[str, Any]]:
     if not path.exists():
         raise SystemExit(f"attempts file not found: {path}")
 
-    attempts: List[Mapping[str, Any]] = []
+    attempts: list[Mapping[str, Any]] = []
     with path.open("r", encoding="utf-8") as handle:
         for line_no, raw in enumerate(handle, start=1):
             trimmed = raw.strip()
@@ -38,8 +39,8 @@ def _load_jsonl(path: Path) -> List[Mapping[str, Any]]:
     return attempts
 
 
-def _extract_case_ids(cases: Iterable[Mapping[str, Any]]) -> List[str]:
-    ids: List[str] = []
+def _extract_case_ids(cases: Iterable[Mapping[str, Any]]) -> list[str]:
+    ids: list[str] = []
     for entry in cases:
         if isinstance(entry, Mapping):
             value = str(entry.get("id", "")).strip()
@@ -56,7 +57,9 @@ def _attempt_case_id(attempt: Mapping[str, Any]) -> str | None:
     return prefix.strip() or None
 
 
-def _build_metrics(cases: Mapping[str, Any], attempts: List[Mapping[str, Any]]) -> MutableMapping[str, Any]:
+def _build_metrics(
+    cases: Mapping[str, Any], attempts: list[Mapping[str, Any]]
+) -> MutableMapping[str, Any]:
     suite = str(cases.get("suite", "")).strip() if isinstance(cases, Mapping) else ""
     case_entries = cases.get("cases") if isinstance(cases, Mapping) else None
     if not isinstance(case_entries, Iterable):
@@ -64,8 +67,8 @@ def _build_metrics(cases: Mapping[str, Any], attempts: List[Mapping[str, Any]]) 
 
     case_ids = _extract_case_ids(case_entries) if case_entries else []
     statuses: Counter[str] = Counter()
-    seen: Dict[str, Mapping[str, Any]] = {}
-    failed_ids: List[str] = []
+    seen: dict[str, Mapping[str, Any]] = {}
+    failed_ids: list[str] = []
 
     for attempt in attempts:
         status = str(attempt.get("status", "unknown")).lower()

--- a/tools/update_readme_metrics.py
+++ b/tools/update_readme_metrics.py
@@ -7,7 +7,7 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 def parse_args() -> argparse.Namespace:
@@ -18,7 +18,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_payload(path: Path) -> Optional[Dict[str, Any]]:
+def load_payload(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
@@ -27,27 +27,27 @@ def load_payload(path: Path) -> Optional[Dict[str, Any]]:
         return None
 
 
-def format_pass_rate(value: Optional[float]) -> str:
+def format_pass_rate(value: float | None) -> str:
     if value is None:
         return "N/A"
     return f"{value * 100:.2f}%"
 
 
-def format_top_flaky(rows: List[Dict[str, Any]]) -> str:
+def format_top_flaky(rows: list[dict[str, Any]]) -> str:
     if not rows:
         return "データなし"
-    formatted: List[str] = []
+    formatted: list[str] = []
     for row in rows[:3]:
         cid = row.get("canonical_id") or "-"
         score = row.get("score")
-        if isinstance(score, (int, float)):
+        if isinstance(score, int | float):
             formatted.append(f"{len(formatted) + 1}. {cid} (score {score:.2f})")
         else:
             formatted.append(f"{len(formatted) + 1}. {cid}")
     return "<br/>".join(formatted)
 
 
-def format_pass_rate_delta(value: Optional[float]) -> str:
+def format_pass_rate_delta(value: float | None) -> str:
     if value is None:
         return " (基準なし)"
     if abs(value) < 1e-9:
@@ -56,7 +56,7 @@ def format_pass_rate_delta(value: Optional[float]) -> str:
     return f" ({sign}{abs(value) * 100:.2f}pp)"
 
 
-def format_int_delta(value: Optional[int]) -> str:
+def format_int_delta(value: int | None) -> str:
     if value is None:
         return " (基準なし)"
     if value == 0:
@@ -65,7 +65,7 @@ def format_int_delta(value: Optional[int]) -> str:
     return f" ({sign}{abs(value)})"
 
 
-def format_recent_runs(items: List[Dict[str, Any]]) -> List[str]:
+def format_recent_runs(items: list[dict[str, Any]]) -> list[str]:
     if not items:
         return []
     lines = ["直近3回の差分:"]
@@ -82,7 +82,7 @@ def format_recent_runs(items: List[Dict[str, Any]]) -> List[str]:
     return lines
 
 
-def build_table(payload: Optional[Dict[str, Any]], report_url: str) -> List[str]:
+def build_table(payload: dict[str, Any] | None, report_url: str) -> list[str]:
     if payload is None:
         table = [
             "| 指標 | 値 |",
@@ -123,7 +123,7 @@ def build_table(payload: Optional[Dict[str, Any]], report_url: str) -> List[str]
     return table
 
 
-def replace_section(text: str, new_lines: List[str]) -> str:
+def replace_section(text: str, new_lines: list[str]) -> str:
     start_marker = "<!-- qa-metrics:start -->"
     end_marker = "<!-- qa-metrics:end -->"
     if start_marker not in text or end_marker not in text:


### PR DESCRIPTION
## Summary
- switch metrics tooling to use built-in collection generics and collections.abc imports instead of typing aliases
- update helper signatures to use modern union syntax for optional JSON payloads and numeric fields

## Testing
- python tools/update_readme_metrics.py --source tmp_metrics.json --report-url https://example.com --readme tmp_README.md
- python projects/04-llm-adapter-shadow/tools/consume_cases.py --cases tmp_cases.json --attempts tmp_attempts.jsonl --format json --pretty
- ruff check --select UP --fix tools/update_readme_metrics.py projects/04-llm-adapter-shadow/tools/consume_cases.py


------
https://chatgpt.com/codex/tasks/task_e_68d9ef55f5608321a191d3e3873aa97f