### PR TITLE
refactor: modernize metrics typing

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/cli.py
+++ b/projects/04-llm-adapter/tools/report/metrics/cli.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
 
 from .data import (
     build_comparison_table,
@@ -22,9 +22,9 @@ from .weekly_summary import update_weekly_summary
 
 def generate_report(
     metrics_path: Path,
-    golden_dir: Optional[Path],
+    golden_dir: Path | None,
     out_path: Path,
-    weekly_summary_path: Optional[Path] = None,
+    weekly_summary_path: Path | None = None,
 ) -> None:
     metrics = load_metrics(metrics_path)
     overview = compute_overview(metrics)
@@ -50,7 +50,7 @@ def generate_report(
         update_weekly_summary(weekly_summary_path, failure_total, failure_summary)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="JSONL メトリクスから HTML を生成")
     parser.add_argument("--metrics", required=True, help="runs-metrics.jsonl のパス")
     parser.add_argument("--golden", default=None, help="ゴールデンディレクトリ")

--- a/projects/04-llm-adapter/tools/report/metrics/weekly_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/weekly_summary.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import List, Mapping, Sequence
 
 
 def update_weekly_summary(
@@ -13,8 +13,8 @@ def update_weekly_summary(
     failure_summary: Sequence[Mapping[str, object]],
 ) -> None:
     weekly_path.parent.mkdir(parents=True, exist_ok=True)
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    lines: List[str] = [f"## {today} 時点の失敗サマリ", ""]
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    lines: list[str] = [f"## {today} 時点の失敗サマリ", ""]
     if failure_total > 0 and failure_summary:
         lines.append(f"- 失敗総数: {failure_total}")
         lines.append("")
@@ -30,7 +30,7 @@ def update_weekly_summary(
         existing_text = weekly_path.read_text(encoding="utf-8").strip()
     else:
         existing_text = ""
-    existing_entries: List[str] = []
+    existing_entries: list[str] = []
     if existing_text:
         if existing_text.startswith(header):
             body = existing_text[len(header) :].strip()


### PR DESCRIPTION
## Summary
- replace deprecated typing.List usage in weekly summary helper with built-in generics and UTC handling
- switch CLI helpers to modern typing syntax and Sequence argv handling while keeping behavior unchanged
- run ruff with unused-parameter fixes to ensure typing modernizations comply with lint rules

## Testing
- ruff check --select UP --fix projects/04-llm-adapter/tools/report/metrics/weekly_summary.py projects/04-llm-adapter/tools/report/metrics/cli.py
- PYTHONPATH=projects/04-llm-adapter python -m tools.report.metrics.cli --help >/tmp/cli_help.txt


------
https://chatgpt.com/codex/tasks/task_e_68d9ef5125708321877b5a9562f0804c