### PR TITLE
Update adapter metrics typing to modern generics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/budgets.py
+++ b/projects/04-llm-adapter/adapter/core/budgets.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import Dict
-
 from .config import BudgetBook, BudgetRule
 
 
@@ -21,7 +19,7 @@ class BudgetManager:
 
     def __init__(self, book: BudgetBook) -> None:
         self.book = book
-        self._states: Dict[str, BudgetState] = {}
+        self._states: dict[str, BudgetState] = {}
         self._today = date.today()
 
     def _rule_for(self, provider_name: str) -> BudgetRule:


### PR DESCRIPTION
## Summary
- replace legacy typing imports with built-in generics across metrics and budgets helpers
- update dataclass fields and helper annotations to use PEP 604 unions and align `asdict` typing
- rely on `datetime.UTC` for timestamp generation consistency

## Testing
- ruff check --select UP --fix projects/04-llm-adapter/adapter/core/metrics.py projects/04-llm-adapter/adapter/core/budgets.py
- pytest *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68d9ef4d57cc8321b0539a7e2a02de23