### PR TITLE
refactor: modernize prompt CLI type hints

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/prompt_io.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_io.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .utils import LOGGER, _msg, _sanitize_message
 
@@ -11,8 +12,8 @@ if TYPE_CHECKING:
     from .prompt_runner import PromptResult
 
 
-def read_jsonl_prompts(path: Path, lang: str) -> List[str]:
-    prompts: List[str] = []
+def read_jsonl_prompts(path: Path, lang: str) -> list[str]:
+    prompts: list[str] = []
     try:
         with path.open("r", encoding="utf-8") as fp:
             for line_no, raw_line in enumerate(fp, start=1):
@@ -42,8 +43,8 @@ def read_jsonl_prompts(path: Path, lang: str) -> List[str]:
     return prompts
 
 
-def collect_prompts(args: argparse.Namespace, parser: argparse.ArgumentParser, lang: str) -> List[str]:
-    prompts: List[str] = []
+def collect_prompts(args: argparse.Namespace, parser: argparse.ArgumentParser, lang: str) -> list[str]:
+    prompts: list[str] = []
     if args.prompt is not None:
         prompts.append(args.prompt)
     if args.prompt_file:
@@ -61,7 +62,7 @@ def collect_prompts(args: argparse.Namespace, parser: argparse.ArgumentParser, l
     return prompts
 
 
-def emit_results(results: Iterable["PromptResult"], output_format: str, include_prompts: bool) -> None:
+def emit_results(results: Iterable[PromptResult], output_format: str, include_prompts: bool) -> None:
     metrics = []
     for res in results:
         payload = res.metric.model_dump()
@@ -85,7 +86,7 @@ def emit_results(results: Iterable["PromptResult"], output_format: str, include_
 
 def write_metrics(
     out_dir: Path,
-    results: Iterable["PromptResult"],
+    results: Iterable[PromptResult],
     include_prompts: bool,
     lang: str,
 ) -> None:

--- a/projects/04-llm-adapter/adapter/cli/prompt_runner.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_runner.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
 
 from adapter.core import providers as provider_module
 from adapter.core.config import ProviderConfig
@@ -13,7 +13,7 @@ from adapter.core.metrics import RunMetric, estimate_cost
 from .utils import LOGGER, _sanitize_message
 
 ProviderResponse = provider_module.ProviderResponse
-Classifier = Callable[[Exception, ProviderConfig, str], Tuple[str, str]]
+Classifier = Callable[[Exception, ProviderConfig, str], tuple[str, str]]
 
 
 class RateLimiter:
@@ -44,11 +44,11 @@ class RateLimiter:
 class PromptResult:
     index: int
     prompt: str
-    response: Optional[ProviderResponse]
+    response: ProviderResponse | None
     metric: RunMetric
     output_text: str
-    error: Optional[str]
-    error_kind: Optional[str] = None
+    error: str | None
+    error_kind: str | None = None
 
 
 async def _process_prompt(
@@ -107,14 +107,14 @@ async def _process_prompt(
 
 
 async def execute_prompts(
-    prompts: List[str],
+    prompts: list[str],
     provider: object,
     config: ProviderConfig,
     concurrency: int,
     rpm: int,
     lang: str,
     classify_error: Classifier,
-) -> List[PromptResult]:
+) -> list[PromptResult]:
     limiter = RateLimiter(rpm)
     semaphore = asyncio.Semaphore(max(1, concurrency))
     tasks = [


### PR DESCRIPTION
## Summary
- switch prompt CLI modules to use modern built-in generics and collections.abc imports
- update classifier alias and dataclass optionals to the `| None` style for consistency

## Testing
- ruff check --select UP --fix projects/04-llm-adapter/adapter/cli/prompt_runner.py projects/04-llm-adapter/adapter/cli/prompt_io.py
- mypy projects/04-llm-adapter/adapter/cli/prompt_runner.py projects/04-llm-adapter/adapter/cli/prompt_io.py *(fails: pre-existing errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ef4945d88321a139403c97b3990a