### PR TITLE
refactor: adopt builtin generics in CLI

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable
 from functools import lru_cache
 from importlib import import_module
 from types import ModuleType
-from typing import Iterable, List, Optional
 
 try:  # pragma: no cover - optional dependency
     import typer
@@ -70,7 +70,7 @@ if typer is not None:  # pragma: no branch - import-time decision
 
         _exit_with(_run_doctor_from_iterable(ctx.args))
 
-    def main(argv: Optional[List[str]] = None) -> int:
+    def main(argv: list[str] | None = None) -> int:
         try:
             app(args=list(argv) if argv is not None else None, standalone_mode=False)
         except typer.Exit as exc:  # pragma: no cover - Typer converts to Exit
@@ -85,14 +85,14 @@ else:  # pragma: no cover - exercised when Typer is unavailable
 
     app = _FallbackApp()
 
-    def run(argv: Optional[List[str]] = None) -> int:
+    def run(argv: list[str] | None = None) -> int:
         return _run_prompts_from_iterable(argv or [])
 
-    def doctor(argv: Optional[List[str]] = None) -> int:
+    def doctor(argv: list[str] | None = None) -> int:
         return _run_doctor_from_iterable(argv or [])
 
-    def main(argv: Optional[List[str]] = None) -> int:
-        args = list((argv if argv is not None else sys.argv[1:]))
+    def main(argv: list[str] | None = None) -> int:
+        args = list(argv if argv is not None else sys.argv[1:])
         if args and args[0] == "doctor":
             return doctor(args[1:])
         return run(args)

--- a/projects/04-llm-adapter/adapter/cli/utils.py
+++ b/projects/04-llm-adapter/adapter/cli/utils.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-from typing import Dict, Optional
 
 LOGGER = logging.getLogger("adapter.cli")
 
@@ -15,7 +14,7 @@ EXIT_NETWORK_ERROR = 4
 EXIT_PROVIDER_ERROR = 5
 EXIT_RATE_LIMIT = 6
 
-LANG_MESSAGES: Dict[str, Dict[str, str]] = {
+LANG_MESSAGES: dict[str, dict[str, str]] = {
     "ja": {
         "env_loaded": ".env を読み込みました: {path}",
         "prompt_sources_missing": "--prompt / --prompt-file / --prompts のいずれかを指定してください",
@@ -114,7 +113,7 @@ class JsonLogFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False)
 
 
-def _resolve_lang(requested: Optional[str]) -> str:
+def _resolve_lang(requested: str | None) -> str:
     env_lang = os.getenv("LLM_ADAPTER_LANG")
     for candidate in (requested, env_lang):
         if candidate:
@@ -157,7 +156,7 @@ def _configure_logging(as_json: bool) -> None:
     root.setLevel(logging.INFO)
 
 
-def _coerce_exit_code(value: Optional[int]) -> int:
+def _coerce_exit_code(value: int | None) -> int:
     if value is None:
         return EXIT_INPUT_ERROR
     try:


### PR DESCRIPTION
## Summary
- switch CLI modules to builtin generics and collections.abc imports
- refresh CLI entrypoints and helpers to use modern optional/union syntax

## Testing
- ruff check --select UP --fix

------
https://chatgpt.com/codex/tasks/task_e_68d9ef4b469083218989aee48154982b