### PR TITLE
chore: modernize typing for metrics report helpers

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/html_report.py
+++ b/projects/04-llm-adapter/tools/report/metrics/html_report.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
 from string import Template
-from typing import List, Mapping, Sequence
 
 
 def render_html(
@@ -17,7 +17,7 @@ def render_html(
     failure_summary: Sequence[Mapping[str, object]],
     determinism_alerts: Sequence[Mapping[str, object]],
 ) -> str:
-    rows_html: List[str] = []
+    rows_html: list[str] = []
     for row in comparison_table:
         diff_value = row.get("avg_diff_rate")
         diff_text = diff_value if diff_value is not None else "-"


### PR DESCRIPTION
## Summary
- switch metrics data helpers to builtin generic collections and typing syntax
- update HTML report utilities to rely on collections.abc for abstract types
- run targeted Ruff upgrade checks for the modified modules

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src' when importing adapter core aggregation during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ef501c5883219d826fc986a681c9