### PR TITLE
refactor: update adapter core config typing

### DIFF
--- a/projects/04-llm-adapter/adapter/core/models.py
+++ b/projects/04-llm-adapter/adapter/core/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any
 
 __all__ = [
     "RetryConfig",
@@ -56,11 +57,11 @@ class ProviderConfig:
     """プロバイダ設定。"""
 
     path: Path
-    schema_version: Optional[int]
+    schema_version: int | None
     provider: str
-    endpoint: Optional[str]
+    endpoint: str | None
     model: str
-    auth_env: Optional[str]
+    auth_env: str | None
     seed: int
     temperature: float
     top_p: float

--- a/projects/04-llm-adapter/adapter/core/schema.py
+++ b/projects/04-llm-adapter/adapter/core/schema.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
@@ -58,11 +56,11 @@ class ProviderConfigModel(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    schema_version: Optional[int] = None
+    schema_version: int | None = None
     provider: str
-    endpoint: Optional[str] = None
+    endpoint: str | None = None
     model: str
-    auth_env: Optional[str] = None
+    auth_env: str | None = None
     seed: int = 0
     temperature: float = 0.0
     top_p: float = 1.0


### PR DESCRIPTION
## Summary
- replace typing.Optional usage in adapter core dataclasses and schemas with PEP 604 unions
- import Mapping from collections.abc to satisfy modern typing guidance

## Testing
- ruff check --select UP --fix projects/04-llm-adapter/adapter/core/models.py projects/04-llm-adapter/adapter/core/schema.py
- mypy adapter/core/models.py adapter/core/schema.py *(fails: pre-existing errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ef4e32cc8321a2d043bcad5b3eaf