### PR TITLE
refactor: modernize regression summary typing

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 import html
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .data import load_baseline_expectations
 from .utils import coerce_optional_float, latest_metrics_by_key
 
 
-def _format_rate(value: Optional[float]) -> str:
+def _format_rate(value: float | None) -> str:
     if value is None:
         return "-"
     return f"{value:.3f}"
 
 
-def _extract_diff_rate(metric: Mapping[str, object]) -> Optional[float]:
+def _extract_diff_rate(metric: Mapping[str, object]) -> float | None:
     eval_payload = metric.get("eval")
     if isinstance(eval_payload, Mapping):
         diff = eval_payload.get("diff_rate")
@@ -30,7 +30,7 @@ def _extract_diff_rate(metric: Mapping[str, object]) -> Optional[float]:
 
 
 def build_regression_summary(
-    metrics: Sequence[Mapping[str, object]], golden_dir: Optional[Path]
+    metrics: Sequence[Mapping[str, object]], golden_dir: Path | None
 ) -> str:
     if not golden_dir:
         return "<p>baseline データが指定されていません。</p>"
@@ -41,8 +41,8 @@ def build_regression_summary(
     if not expectations:
         return "<p>baseline 出力がまだ登録されていません。</p>"
     latest_map = latest_metrics_by_key(metrics)
-    rows: List[Dict[str, object]] = []
-    seen_keys: set[Tuple[str, str, str]] = set()
+    rows: list[dict[str, object]] = []
+    seen_keys: set[tuple[str, str, str]] = set()
     for expectation in expectations:
         provider = str(expectation.get("provider", "")).strip()
         model = str(expectation.get("model", "")).strip()
@@ -131,7 +131,7 @@ def build_regression_summary(
     summary_html = (
         f"<p>PASS: {pass_count} / FAIL: {fail_count} / OTHER: {other_count}</p>"
     )
-    table_rows: List[str] = []
+    table_rows: list[str] = []
     for row in rows:
         notes_parts = [row["notes"], row["detail"]]
         notes_cell = "<br />".join(

--- a/projects/04-llm-adapter/tools/report/metrics/utils.py
+++ b/projects/04-llm-adapter/tools/report/metrics/utils.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Dict, Mapping, Sequence, Tuple
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 
 
 def parse_iso_ts(value: object) -> datetime:
@@ -14,11 +14,11 @@ def parse_iso_ts(value: object) -> datetime:
         try:
             parsed = datetime.fromisoformat(normalized)
         except ValueError:
-            return datetime.min.replace(tzinfo=timezone.utc)
+            return datetime.min.replace(tzinfo=UTC)
         if parsed.tzinfo is None:
-            return parsed.replace(tzinfo=timezone.utc)
+            return parsed.replace(tzinfo=UTC)
         return parsed
-    return datetime.min.replace(tzinfo=timezone.utc)
+    return datetime.min.replace(tzinfo=UTC)
 
 
 def coerce_optional_float(value: object) -> float | None:
@@ -34,10 +34,10 @@ def coerce_optional_float(value: object) -> float | None:
 
 def latest_metrics_by_key(
     metrics: Sequence[Mapping[str, object]]
-) -> Dict[Tuple[str, str, str], Mapping[str, object]]:
+) -> dict[tuple[str, str, str], Mapping[str, object]]:
     """Return the latest metric for each ``(provider, model, prompt_id)`` tuple."""
 
-    latest: Dict[Tuple[str, str, str], Tuple[datetime, Mapping[str, object]]] = {}
+    latest: dict[tuple[str, str, str], tuple[datetime, Mapping[str, object]]] = {}
     for metric in metrics:
         provider = metric.get("provider")
         model = metric.get("model")


### PR DESCRIPTION
## Summary
- replace typing imports in regression summary utilities with collections.abc and built-in generics
- update optional annotations to use PEP 604 unions and adjust helper imports
- refresh datetime handling to rely on datetime.UTC after Ruff modernization fixes

## Testing
- `ruff check --select UP --fix projects/04-llm-adapter/tools/report/metrics/regression_summary.py projects/04-llm-adapter/tools/report/metrics/utils.py`
- `python - <<'PY'
import sys
from pathlib import Path

sys.path.insert(0, str(Path('projects/04-llm-adapter/tools/report')))

from metrics.regression_summary import build_regression_summary

sample_metrics = [
    {
        "provider": "p",
        "model": "m",
        "prompt_id": "id",
        "status": "ok",
        "eval": {"diff_rate": 0.1},
        "ts": "2024-01-01T00:00:00Z",
    }
]
print(build_regression_summary(sample_metrics, Path('nonexistent')))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d9ef5014d08321b8a9a0ddb6595760