### PR TITLE
Sort report metrics exports and tidy CLI shim

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/__init__.py
+++ b/projects/04-llm-adapter/tools/report/metrics/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for generating LLM Adapter metric reports."""
 
+from .cli import generate_report, main
 from .data import (
     build_comparison_table,
     build_determinism_alerts,
@@ -13,15 +14,14 @@ from .data import (
 from .html_report import render_html
 from .regression_summary import build_regression_summary
 from .weekly_summary import update_weekly_summary
-from .cli import generate_report, main
 
 __all__ = [
     "build_comparison_table",
     "build_determinism_alerts",
     "build_failure_summary",
     "build_latency_histogram_data",
-    "build_scatter_data",
     "build_regression_summary",
+    "build_scatter_data",
     "compute_overview",
     "generate_report",
     "load_baseline_expectations",

--- a/projects/04-llm-adapter/tools/report/metrics_to_html.py
+++ b/projects/04-llm-adapter/tools/report/metrics_to_html.py
@@ -4,6 +4,5 @@ from __future__ import annotations
 
 from .metrics.cli import main
 
-
 if __name__ == "__main__":  # pragma: no cover - CLI
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- import metrics CLI entry points before other module exports and keep __all__ alphabetical
- remove redundant blank line around the metrics CLI shim import

## Testing
- ruff check --select I001 (from projects/04-llm-adapter/tools/report)


------
https://chatgpt.com/codex/tasks/task_e_68d9fd29238883218ce7683dfdd70ca2