### PR TITLE
Sort imports in adapter CLI and budgets modules

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/__init__.py
+++ b/projects/04-llm-adapter/adapter/cli/__init__.py
@@ -8,8 +8,10 @@ from adapter.core import providers as provider_module
 
 from .app import app, main
 from .doctor import run_doctor
-from .prompt_runner import PromptResult as _PromptResult, RateLimiter as _RateLimiter
-from .prompts import ProviderFactory as _ProviderFactory, run_prompts
+from .prompt_runner import PromptResult as _PromptResult
+from .prompt_runner import RateLimiter as _RateLimiter
+from .prompts import ProviderFactory as _ProviderFactory
+from .prompts import run_prompts
 from .utils import (
     EXIT_ENV_ERROR,
     EXIT_INPUT_ERROR,

--- a/projects/04-llm-adapter/adapter/core/budgets.py
+++ b/projects/04-llm-adapter/adapter/core/budgets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+
 from .config import BudgetBook, BudgetRule
 
 


### PR DESCRIPTION
## Summary
- reorder CLI imports to satisfy the import-sorting rules
- align budgets module import spacing with isort expectations

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/cli/__init__.py projects/04-llm-adapter/adapter/core/budgets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd225b648321b561b0c156828235