### PR TITLE
chore: align provider test imports with isort

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
 from src.llm_adapter.errors import (
     AuthError,
     ProviderSkip,

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider


### PR DESCRIPTION
## Summary
- sort provider test imports to follow the configured isort grouping
- apply ruff I001 autofix to Gemini and Ollama provider tests

## Testing
- `ruff check --select I001 projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py`
- `ruff check --select I001 projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9fd2252488321ae0f8a2d29a9e5eb