### PR TITLE
chore: organize imports in llm adapter tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -1,6 +1,6 @@
 import json
-import threading
 from pathlib import Path
+import threading
 
 import pytest
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -11,8 +11,8 @@ import pytest
 from src.llm_adapter.errors import RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.providers.mock import MockProvider
-from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
+from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
     ConsensusConfig,
     ParallelExecutionError,


### PR DESCRIPTION
## Summary
- reorder the standard library imports in the metrics thread safety test
- apply isort to the runner parallel test to keep imports consistent

## Testing
- ruff check --select I001 *(fails: reports unrelated unsorted imports elsewhere)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fd25c2308321b7436f1bc72fd200