### PR TITLE
Align shadow test imports with isort

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -5,10 +5,10 @@ from typing import Any
 
 import pytest
 
-pytest.importorskip("hypothesis")
-from hypothesis import given
-from hypothesis import strategies as st
-from hypothesis.strategies import SearchStrategy
+hypothesis = pytest.importorskip("hypothesis")
+st = hypothesis.strategies
+given = hypothesis.given
+SearchStrategy = st.SearchStrategy
 
 from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.provider_spi import ProviderRequest

--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
 from src.llm_adapter.errors import TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.providers.mock import MockProvider


### PR DESCRIPTION
## Summary
- reorder the shadow normalization test imports to keep hypothesis usage in a single group after ensuring availability
- tidy the error-case test imports to satisfy the isort layout rules

## Testing
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/test_err_cases.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd251d2083219d55cfaaba90a4f6