### PR TITLE
chore: sort imports in shadow runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 import pytest
-
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from src.llm_adapter.runner import Runner

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
 from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.runner import AsyncRunner


### PR DESCRIPTION
## Summary
- organize the shadow runner helper and async tests imports to satisfy isort ordering

## Testing
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd246af08321ab8b3cdd325c77df