### PR TITLE
style: reorder provider test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
 import pytest
-
 from src.llm_adapter.provider_spi import ProviderSPI
-from src.llm_adapter.providers.factory import (
-    create_provider_from_spec,
-    parse_provider_spec,
-    provider_from_environment,
-)
+from src.llm_adapter.providers import factory as providers_factory
 
 
 class DummyProvider(ProviderSPI):
@@ -25,18 +20,18 @@ class DummyProvider(ProviderSPI):
 
 
 def test_parse_provider_spec_allows_colons_in_model():
-    prefix, model = parse_provider_spec("ollama:gemma3n:e2b")
+    prefix, model = providers_factory.parse_provider_spec("ollama:gemma3n:e2b")
     assert prefix == "ollama"
     assert model == "gemma3n:e2b"
 
 
 def test_parse_provider_spec_requires_separator():
     with pytest.raises(ValueError):
-        parse_provider_spec("gemini")
+        providers_factory.parse_provider_spec("gemini")
 
 
 def test_create_provider_from_spec_supports_overrides():
-    provider = create_provider_from_spec(
+    provider = providers_factory.create_provider_from_spec(
         "gemini:test-model",
         factories={"gemini": lambda model: DummyProvider(model)},
     )
@@ -46,7 +41,7 @@ def test_create_provider_from_spec_supports_overrides():
 
 def test_provider_from_environment_optional_none(monkeypatch):
     monkeypatch.setenv("SHADOW_PROVIDER", "none")
-    result = provider_from_environment(
+    result = providers_factory.provider_from_environment(
         "SHADOW_PROVIDER",
         optional=True,
         factories={"gemini": lambda model: DummyProvider(model)},
@@ -57,7 +52,7 @@ def test_provider_from_environment_optional_none(monkeypatch):
 def test_provider_from_environment_disabled_requires_optional(monkeypatch):
     monkeypatch.setenv("PRIMARY_PROVIDER", "none")
     with pytest.raises(ValueError):
-        provider_from_environment(
+        providers_factory.provider_from_environment(
             "PRIMARY_PROVIDER",
             optional=False,
             factories={"gemini": lambda model: DummyProvider(model)},

--- a/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 
 


### PR DESCRIPTION
## Summary
- reorder provider test imports to match isort expectations
- update factory usage to route through the module alias and keep local imports single-lined

## Testing
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py
- ruff check --select I001 projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd237f488321bbbb209a9ab58e8f