### PR TITLE
Refactor provider path list comprehension formatting

### DIFF
--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -106,7 +106,11 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
 
-    provider_paths = [Path(p.strip()).expanduser().resolve() for p in args.providers.split(",") if p.strip()]
+    provider_paths = [
+        Path(p.strip()).expanduser().resolve()
+        for p in args.providers.split(",")
+        if p.strip()
+    ]
     if not provider_paths:
         raise SystemExit("--providers に有効なパスが指定されていません")
     prompt_path = Path(args.prompts).expanduser().resolve()


### PR DESCRIPTION
## Summary
- reformat provider path collection in run_compare to use a multi-line list comprehension for readability

## Testing
- ruff check --select E501 projects/04-llm-adapter/adapter/run_compare.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd1b2c6c83219ea30ff031b2de27