### PR TITLE
Fix CodeQL workflow language configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,9 +37,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: |
-            javascript-typescript
-            python
+          languages: ['javascript', 'python']
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Summary
- adjust the CodeQL workflow to pass separate language identifiers for JavaScript and Python so initialization succeeds

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d9fdd4e688832189441be460e4894d