### PR TITLE
Adjust lint line-length policy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,11 +66,12 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: pip install -r projects/04-llm-adapter-shadow/requirements.txt ruff mypy
+        run: pip install -r projects/04-llm-adapter-shadow/requirements.txt ruff mypy black
 
       - name: Run linters and checks
         run: |
           npm run lint:js
-          ruff check projects/04-llm-adapter-shadow tools
+          ruff check .
+          black --check .
           mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools
           python -m compileall projects/04-llm-adapter-shadow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
+[tool.black]
+line-length = 120
+
 [tool.ruff]
-line-length = 100
-target-version = "py311"
+line-length = 120
+target-version = "py312"
 extend-exclude = [
   "node_modules",
   "packages",
@@ -9,7 +12,8 @@ extend-exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]
-ignore = []
+ignore = ["E501"]
+extend-select = ["B950"]
 
 [tool.ruff.lint.isort]
 force-single-line = false


### PR DESCRIPTION
## Summary
- align Black and Ruff configuration on a 120 character line length while preferring B950 over E501
- update the lint workflow to install Black and run Ruff and Black checks across the repository

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da00063afc83218c42ce61264d2bab