### PR TITLE
refactor: import collections abc in runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from collections.abc import Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 import pytest
 from src.llm_adapter.errors import RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.providers.mock import MockProvider
-from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
+from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
     ConsensusConfig,
     ParallelExecutionError,


### PR DESCRIPTION
## Summary
- update test imports to use collections.abc variants
- run ruff fixes to satisfy import-order and typing modernizations

## Testing
- ruff check --select UP035,I001 --fix projects/04-llm-adapter-shadow/tests/test_runner_modes.py projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd10dd74832194a475728fe43880