### PR TITLE
Remove unsupported Ruff rule B950 from configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ extend-exclude = [
 [tool.ruff.lint]
 select = ["E", "F", "B", "I", "UP"]
 ignore = ["E501"]
-extend-select = ["B950"]
 
 [tool.ruff.lint.isort]
 force-single-line = false


### PR DESCRIPTION
## Summary
- drop the B950 selector from the Ruff lint configuration to avoid parsing failures on Ruff 0.12.11
- retain the rest of the lint settings so the workflow can load the configuration again

## Testing
- ruff check . *(fails: existing lint violations in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68da055ccbcc83218b9961e8bd1e5936