### PR TITLE
Add adapter shim for run_compare CLI

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -1,0 +1,31 @@
+"""トップレベル `adapter` パッケージのシム。"""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TARGET_DIR = _REPO_ROOT / "projects" / "04-llm-adapter" / "adapter"
+_SHADOW_SRC_ROOT = _REPO_ROOT / "projects" / "04-llm-adapter-shadow"
+if not _TARGET_DIR.exists():  # pragma: no cover - 開発環境の構成不備
+    raise ImportError("projects/04-llm-adapter/adapter が見つかりません")
+if _SHADOW_SRC_ROOT.exists():
+    shadow_path = str(_SHADOW_SRC_ROOT)
+    if shadow_path not in sys.path:
+        sys.path.insert(0, shadow_path)
+
+_spec = spec_from_file_location(
+    __name__,
+    _TARGET_DIR / "__init__.py",
+    submodule_search_locations=[str(_TARGET_DIR)],
+)
+if _spec is None or _spec.loader is None:  # pragma: no cover - importlib 異常
+    raise ImportError("adapter モジュールのロードに失敗しました")
+
+_module = module_from_spec(_spec)
+sys.modules[__name__] = _module
+_spec.loader.exec_module(_module)
+
+globals().update({k: v for k, v in _module.__dict__.items() if k != "__dict__"})

--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -106,7 +106,11 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
 
-    provider_paths = [Path(p.strip()).expanduser().resolve() for p in args.providers.split(",") if p.strip()]
+    provider_paths = [
+        Path(p.strip()).expanduser().resolve()
+        for p in args.providers.split(",")
+        if p.strip()
+    ]
     if not provider_paths:
         raise SystemExit("--providers に有効なパスが指定されていません")
     prompt_path = Path(args.prompts).expanduser().resolve()


### PR DESCRIPTION
## Summary
- add a top-level adapter shim that loads the existing projects/04-llm-adapter implementation
- extend sys.path for the shadow sources so src.llm_adapter imports resolve when running the CLI

## Testing
- ruff check --select E501 adapter/__init__.py projects/04-llm-adapter/adapter/run_compare.py
- python -m adapter.run_compare --help

------
https://chatgpt.com/codex/tasks/task_e_68d9fd1b2c6c83219ea30ff031b2de27