### PR TITLE
Refine OpenAI adapter attribute handling

### DIFF
--- a/projects/04-llm-adapter/tests/conftest.py
+++ b/projects/04-llm-adapter/tests/conftest.py
@@ -8,4 +8,4 @@ if str(PROJECT_ROOT) not in sys.path:
 
 def pytest_configure(config):  # pragma: no cover - pytest hook
     if config.pluginmanager.hasplugin("asyncio"):
-        setattr(config.option, "asyncio_default_fixture_loop_scope", "function")
+        config.option.asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary
- replace setattr usage with direct attribute assignments in the OpenAI client factory and pytest configuration hook
- refactor token accounting helpers to avoid long lines and clarify fallbacks for ruff compliance

## Testing
- ruff check --select B010,E501 projects/04-llm-adapter/adapter/core/providers/openai_utils.py projects/04-llm-adapter/tests/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fd14d4788321962eb16528f75ea3