### PR TITLE
Fix OpenAI default headers initialization

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -234,8 +234,11 @@ class OpenAIClientFactory:
         if organization:
             openai_module.organization = organization  # type: ignore[attr-defined]
         if default_headers:
-            headers = getattr(openai_module, "_default_headers", {})
-            headers = dict(headers)
+            if hasattr(openai_module, "_default_headers"):
+                headers_source = openai_module._default_headers  # type: ignore[attr-defined]
+            else:
+                headers_source = {}
+            headers = dict(headers_source)
             headers.update(default_headers)
             openai_module._default_headers = headers  # type: ignore[attr-defined]
         return openai_module


### PR DESCRIPTION
## Summary
- ensure `_default_headers` is only accessed after confirming it exists
- default to an empty mapping before merging provided headers and store back on the module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0ad89ce88321907a6211c461c1a1