### PR TITLE
chore: modernize typing imports

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/render.py
+++ b/projects/04-llm-adapter/tools/report/metrics/render.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
 
 from .html_report import render_html as _render_html
 from .regression_summary import build_regression_summary as _build_regression_summary
@@ -11,7 +11,7 @@ from .weekly_summary import update_weekly_summary as _update_weekly_summary
 
 
 def build_regression_summary(
-    metrics: Sequence[Mapping[str, object]], golden_dir: Optional[Path]
+    metrics: Sequence[Mapping[str, object]], golden_dir: Path | None
 ) -> str:
     """Proxy to :func:`regression_summary.build_regression_summary`."""
     return _build_regression_summary(metrics, golden_dir)


### PR DESCRIPTION
## Summary
- replace typing imports with collections.abc equivalents
- adopt `Path | None` for the optional golden directory parameter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0ad49b988321801921b754da8e38