### PR TITLE
Stop retrying parallel rate limit errors

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -343,10 +343,11 @@ class AsyncRunner:
                 nonlocal retry_attempts, attempt_count
                 provider, _ = providers[worker_index]
                 next_attempt_total = total_providers + retry_attempts + 1
-                delay: float | None = None
                 if isinstance(error, RateLimitError):
-                    delay = max(self._config.backoff.rate_limit_sleep_s, 0.0)
-                elif isinstance(error, TimeoutError):
+                    return None
+
+                delay: float | None = None
+                if isinstance(error, TimeoutError):
                     if not self._config.backoff.timeout_next_provider:
                         delay = 0.0
                 elif isinstance(error, RetryableError):


### PR DESCRIPTION
## Summary
- prevent the async parallel runner from retrying providers that return RateLimitError

## Testing
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_any_rate_limit_does_not_retry projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_all_rate_limit_does_not_retry

------
https://chatgpt.com/codex/tasks/task_e_68da0a9c19d88321a3b9fb91579abf8a