### PR TITLE
Fix status code detection in error classification

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/prompts.py
+++ b/projects/04-llm-adapter/adapter/cli/prompts.py
@@ -85,7 +85,7 @@ def _classify_error(
         )
     if has_auth_env and ("environment variable" in lower or "api key" in lower):
         return _msg(lang, "api_key_missing", env=auth_env), "env"
-    status_code = getattr(exc, "status_code", None)
+    status_code = exc.status_code if hasattr(exc, "status_code") else None
     if status_code == 429 or "429" in lower or "rate" in lower or "quota" in lower:
         return _msg(lang, "rate_limited"), "rate"
     if isinstance(exc, OSError | socket.gaierror | TimeoutError) or "ssl" in lower or "dns" in lower:


### PR DESCRIPTION
## Summary
- guard access to `status_code` in `_classify_error` without using `getattr`

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/cli/prompts.py

------
https://chatgpt.com/codex/tasks/task_e_68da11e1fc508321a44b18a916064a06