### PR TITLE
refactor: read provider response metrics directly

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -40,17 +40,14 @@ class RunMetric(BaseModel):
         cost_usd: float = 0.0,
         error: str | None = None,
     ) -> RunMetric:
-        latency_ms = getattr(resp, "latency_ms", 0)
-        input_tokens = getattr(resp, "input_tokens", 0)
-        output_tokens = getattr(resp, "output_tokens", 0)
         digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
         return cls(
             provider=cfg.provider,
             model=cfg.model,
             endpoint=(cfg.endpoint or "responses"),
-            latency_ms=int(latency_ms),
-            input_tokens=int(input_tokens),
-            output_tokens=int(output_tokens),
+            latency_ms=int(resp.latency_ms),
+            input_tokens=int(resp.input_tokens),
+            output_tokens=int(resp.output_tokens),
             cost_usd=float(cost_usd),
             status="error" if error else "ok",
             error=error,


### PR DESCRIPTION
## Summary
- access ProviderResponse metric fields directly in `RunMetric.from_resp`
- keep the existing type conversions while relying on dataclass defaults

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68da11df45e083219a3e88f4b1e16388