### PR TITLE
Refine usage attribute handling in OpenAI utils

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -116,7 +116,7 @@ def extract_text_from_response(response: Any) -> str:
 def extract_usage_tokens(response: Any, prompt: str, output_text: str) -> tuple[int, int]:
     prompt_tokens = 0
     completion_tokens = 0
-    usage = getattr(response, "usage", None)
+    usage = response.usage if hasattr(response, "usage") else None
     if usage is not None:
         prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
         if prompt_tokens <= 0:


### PR DESCRIPTION
## Summary
- adjust usage extraction to rely on hasattr instead of getattr for OpenAI responses
- ensure lint compliance via ruff check for B009 on the updated helper

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/providers/openai_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68da11de02748321b8a451879656e4c4