### PR TITLE
fix: guard OpenAI response output access

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -70,7 +70,7 @@ def extract_text_from_response(response: Any) -> str:
         text_attr = getattr(first, "text", None)
         if isinstance(text_attr, str) and text_attr.strip():
             return text_attr
-    output = getattr(response, "output", None)
+    output = response.output if hasattr(response, "output") else None
     if isinstance(output, Sequence):
         parts: list[str] = []
         for item in output:


### PR DESCRIPTION
## Summary
- guard the OpenAI response output extraction by verifying the attribute exists before access

## Testing
- ruff check --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11dca6f88321bb1dbabc3f618205