### PR TITLE
Adjust OpenAI response choice access guard

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -41,7 +41,7 @@ def extract_text_from_response(response: Any) -> str:
     text = getattr(response, "text", None)
     if isinstance(text, str) and text.strip():
         return text
-    choices = getattr(response, "choices", None)
+    choices = response.choices if hasattr(response, "choices") else None
     if isinstance(choices, Sequence) and choices:
         first = choices[0]
         if isinstance(first, Mapping):


### PR DESCRIPTION
## Summary
- ensure extract_text_from_response only reads response.choices when available

## Testing
- ruff check --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11dad1c48321aaa1dfa1c8497161