### PR TITLE
Check output_text attribute before fallback in OpenAI utils

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -35,7 +35,11 @@ def build_chat_messages(system_prompt: str | None, user_prompt: str) -> list[Map
 
 
 def extract_text_from_response(response: Any) -> str:
-    text = getattr(response, "output_text", None)
+    text: Any
+    if hasattr(response, "output_text"):
+        text = response.output_text
+    else:
+        text = getattr(response, "output_text", None)
     if isinstance(text, str) and text.strip():
         return text
     text = getattr(response, "text", None)


### PR DESCRIPTION
## Summary
- ensure `extract_text_from_response` reads `output_text` directly when present before applying fallbacks

## Testing
- `ruff check --select B009 projects/04-llm-adapter/adapter/core/providers/openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68da11d9d8e083219393ff51b29f1402