### PR TITLE
Refine Gemini output extraction attribute access

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/gemini.py
+++ b/projects/04-llm-adapter/adapter/core/providers/gemini.py
@@ -157,22 +157,29 @@ def _extract_usage(response: Any, prompt: str, output_text: str) -> tuple[int, i
 
 
 def _extract_output_text(response: Any) -> str:
-    text = getattr(response, "text", None)
-    if isinstance(text, str) and text.strip():
-        return text
-    text = getattr(response, "output_text", None)
-    if isinstance(text, str) and text.strip():
-        return text
-    candidates = getattr(response, "candidates", None)
+    if hasattr(response, "text"):
+        text = response.text
+        if isinstance(text, str) and text.strip():
+            return text
+    if hasattr(response, "output_text"):
+        text = response.output_text
+        if isinstance(text, str) and text.strip():
+            return text
+    candidates: Any
+    if hasattr(response, "candidates"):
+        candidates = response.candidates
+    else:
+        candidates = None
     if isinstance(candidates, Sequence):
         for candidate in candidates:
             if isinstance(candidate, Mapping):
                 candidate_text = candidate.get("text")
                 if isinstance(candidate_text, str) and candidate_text.strip():
                     return candidate_text
-            text_attr = getattr(candidate, "text", None)
-            if isinstance(text_attr, str) and text_attr.strip():
-                return text_attr
+            if hasattr(candidate, "text"):
+                text_attr = candidate.text
+                if isinstance(text_attr, str) and text_attr.strip():
+                    return text_attr
     if hasattr(response, "to_dict"):
         try:
             payload = response.to_dict()


### PR DESCRIPTION
## Summary
- guard Gemini response text fields with `hasattr` before reading attributes
- keep candidate text fallbacks while avoiding defaulted `getattr` usage

## Testing
- ruff check --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11d9244c832186533357ed60b647