### PR TITLE
Avoid overriding existing judge provider in run_compare

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -124,7 +124,7 @@ def run_compare(
         )
     else:
         config = runner_config
-        if judge_provider is not None and getattr(config, "judge_provider", None) is None:
+        if config.judge_provider is None and judge_provider is not None:
             config = replace(config, judge=judge_path, judge_provider=judge_provider)
 
     provider_configs = load_provider_configs(list(provider_paths))


### PR DESCRIPTION
## Summary
- ensure `run_compare` only injects a judge provider when the supplied runner config lacks one

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/runner_api.py

------
https://chatgpt.com/codex/tasks/task_e_68da11d6b5f4832199981f49db93475a