### PR TITLE
Fix tie breaker normalization access

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -451,14 +451,14 @@ class CompareRunner:
         config: RunnerConfig,
         lookup: Mapping[int, SingleRunResult],
     ) -> TieBreaker | None:
-        name = (getattr(config, "tie_breaker", None) or "").strip().lower()
-        if not name:
+        tie_name = (config.tie_breaker or "").strip().lower()
+        if not tie_name:
             return None
-        if name == "latency":
+        if tie_name == "latency":
             return _LatencyTieBreaker(lookup)
-        if name == "cost":
+        if tie_name == "cost":
             return _CostTieBreaker(lookup)
-        if name == "first":
+        if tie_name == "first":
             return FirstTieBreaker()
         return None
 


### PR DESCRIPTION
## Summary
- access the tie_breaker field directly when normalizing CompareRunner tie-breakers
- retain the existing comparisons for latency, cost, and first tie-breaker strategies

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runners.py --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11d5a6d0832192744f78f044824a