### PR TITLE
Refine aggregate configuration handling

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -431,7 +431,8 @@ class CompareRunner:
     def _resolve_aggregation_strategy(
         self, mode: str, config: RunnerConfig
     ) -> AggregationStrategy | None:
-        aggregate = (getattr(config, "aggregate", None) or "").strip()
+        aggregate_raw = config.aggregate
+        aggregate = (aggregate_raw or "").strip()
         if not aggregate:
             aggregate = "majority"
         if aggregate.lower() in {"judge", "llm-judge"}:


### PR DESCRIPTION
## Summary
- evaluate the runner aggregation configuration before applying fallback defaults
- keep the existing whitespace stripping and default "majority" behavior

## Testing
- ruff check --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11d498008321a587701049500290