### PR TITLE
Fix concurrency normalization in parallel runner

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -300,9 +300,17 @@ class CompareRunner:
     ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
         if not providers:
             return [], None
-        max_workers = self._normalize_concurrency(
-            len(providers), getattr(config, "max_concurrency", None)
-        )
+        try:
+            max_concurrency = config.max_concurrency  # type: ignore[attr-defined]
+        except AttributeError:
+            max_concurrency = None
+
+        if max_concurrency is None:
+            max_workers = self._normalize_concurrency(len(providers), None)
+        else:
+            max_workers = self._normalize_concurrency(
+                len(providers), max_concurrency
+            )
         stop_reason: str | None = None
         results: list[SingleRunResult | None] = [None] * len(providers)
 


### PR DESCRIPTION
## Summary
- extract the runner configuration's max_concurrency before normalization
- preserve the None fallback when the attribute is unset while avoiding getattr defaults

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68da11d2cdd083219948e787ad0752b6