### PR TITLE
Fix quorum fallback without getattr

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -422,7 +422,8 @@ class CompareRunner:
                     if result.metrics.status == "ok"
                     and result.raw_output.strip() == winner_output
                 )
-            quorum = getattr(config, "quorum", None) or len(candidates)
+            quorum_value = config.quorum
+            quorum = quorum_value if quorum_value is not None else len(candidates)
             if votes < quorum:
                 self._mark_consensus_failure(lookup.values(), quorum, votes)
                 return None


### PR DESCRIPTION
## Summary
- reference `RunnerConfig.quorum` directly when computing the consensus quorum fallback

## Testing
- ruff check --select B009

------
https://chatgpt.com/codex/tasks/task_e_68da11d321008321bc946033d3add3eb