### PR TITLE
Adjust judge provider assignment

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -236,7 +236,8 @@ class CompareRunner:
         repeat = max(repeat, 1)
         self._token_bucket = _TokenBucket(getattr(config, "rpm", None))
         self._schema_validator = _SchemaValidator(getattr(config, "schema", None))
-        self._judge_provider_config = getattr(config, "judge_provider", None)
+        if config.judge_provider is not None:
+            self._judge_provider_config = config.judge_provider
 
         providers: list[tuple[ProviderConfig, BaseProvider]] = []
         for provider_config in self.provider_configs:
@@ -435,7 +436,9 @@ class CompareRunner:
         if not aggregate:
             aggregate = "majority"
         if aggregate.lower() in {"judge", "llm-judge"}:
-            judge_config = getattr(config, "judge_provider", None) or self._judge_provider_config
+            judge_config = config.judge_provider
+            if judge_config is None:
+                judge_config = self._judge_provider_config
             if judge_config is None:
                 raise ValueError("aggregate=judge requires judge provider configuration")
             factory = _JudgeProviderFactoryAdapter(judge_config)


### PR DESCRIPTION
## Summary
- ensure CompareRunner preserves an existing judge provider unless a new one is provided via the runtime config
- rely on direct RunnerConfig.judge_provider access and reuse stored configuration when aggregation requires a judge

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68da11d1f22c8321a73f32ae33c4cdf7