### PR TITLE
Fix judge invoker prompt attribute access

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -136,7 +136,12 @@ class _JudgeInvoker:
         self._config = config
 
     def invoke(self, request: object) -> JudgeProviderResponse:  # type: ignore[override]
-        prompt = getattr(request, "prompt_text", "") or getattr(request, "prompt", "")
+        if hasattr(request, "prompt_text"):
+            prompt = request.prompt_text or ""
+        elif hasattr(request, "prompt"):
+            prompt = request.prompt or ""
+        else:
+            prompt = ""
         response = self._provider.generate(prompt)
         return JudgeProviderResponse(
             text=response.output_text,


### PR DESCRIPTION
## Summary
- guard judge prompt extraction with explicit attribute checks to satisfy Ruff B009

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68da11cfd9148321ae6afc7beb31fa8a