### PR TITLE
Refactor CompareRunner RPM initialization

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -234,7 +234,8 @@ class CompareRunner:
 
     def run(self, repeat: int, config: RunnerConfig) -> list[RunMetrics]:
         repeat = max(repeat, 1)
-        self._token_bucket = _TokenBucket(getattr(config, "rpm", None))
+        rpm = config.rpm if config.rpm is not None else None
+        self._token_bucket = _TokenBucket(rpm)
         self._schema_validator = _SchemaValidator(getattr(config, "schema", None))
         self._judge_provider_config = getattr(config, "judge_provider", None)
 


### PR DESCRIPTION
## Summary
- initialize the compare runner token bucket from a locally cached rpm value
- avoid getattr usage now that RunnerConfig always exposes rpm

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68da11cf73308321b3495b1f6f558238