### PR TITLE
Add offline guard for Ollama provider

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from src.llm_adapter.errors import ProviderSkip
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.providers.ollama import OllamaProvider
+from tests.helpers.fakes import FakeResponse, FakeSession
+
+
+def test_ollama_offline_skips_without_custom_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_ADAPTER_OFFLINE", "1")
+
+    provider = OllamaProvider("llama3", auto_pull=False)
+
+    with pytest.raises(ProviderSkip):
+        provider.invoke(ProviderRequest(model="llama3", prompt="hi"))
+
+
+def test_ollama_offline_allows_fake_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_ADAPTER_OFFLINE", "1")
+
+    class Session(FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):  # type: ignore[override]
+            self.calls.append((url, json, stream))
+            if url.endswith("/api/show"):
+                return FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                return FakeResponse(
+                    status_code=200,
+                    payload={
+                        "message": {"content": "ok"},
+                        "prompt_eval_count": 1,
+                        "eval_count": 2,
+                        "done_reason": "stop",
+                    },
+                )
+            raise AssertionError(f"unexpected url: {url}")
+
+    session = Session()
+    provider = OllamaProvider("llama3", session=session, auto_pull=False, host="http://localhost")
+
+    response = provider.invoke(ProviderRequest(model="llama3", prompt="hi"))
+
+    assert response.text == "ok"
+    assert response.token_usage.prompt == 1
+    assert response.token_usage.completion == 2
+    assert response.finish_reason == "stop"


### PR DESCRIPTION
## Summary
- allow OllamaProvider to respect offline environment flags and disable auto-pull/network usage when no custom transport is supplied
- add regression tests to ensure offline mode skips the provider while still allowing fake sessions for unit coverage

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68da1c99128c8321823096393d2ba7f3