### PR TITLE
Harden CI pytest execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,16 @@ jobs:
           npm run ci:analyze
           npm run ci:issue
           PYTHON=python3 node --test tests/e2e-shadow.test.mjs
-      - name: Run Python tests
+      - name: Run Python tests (verbose, timeout, no network)
+        env:
+          LLM_ADAPTER_OFFLINE: "1"
+          OLLAMA_AUTO_PULL: "0"
+          OLLAMA_TIMEOUT_S: "5"
+          OLLAMA_PULL_TIMEOUT_S: "20"
+          OLLAMA_BASE_URL: "http://127.0.0.1:9"
         run: |
           set -euxo pipefail
-          pytest -q projects/04-llm-adapter-shadow/tests
+          python -c "import pytest, sys; sys.exit(pytest.main(['-vv', '-s', '--maxfail=1', '--durations=20', '--disable-socket', 'projects/04-llm-adapter-shadow/tests']))"
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/projects/04-llm-adapter-shadow/pytest.ini
+++ b/projects/04-llm-adapter-shadow/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = strict
+addopts = -ra --durations=20
+timeout = 60

--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -1,5 +1,7 @@
 pytest>=8.2.0
 pytest-cov>=5.0.0
 pytest-asyncio>=0.23.6
+pytest-timeout>=2.3.1
+pytest-socket>=0.6.0
 google-genai>=0.3
 requests>=2.31.0

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from src.llm_adapter.errors import ProviderSkip
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.providers.ollama import OllamaProvider
+from tests.helpers.fakes import FakeResponse, FakeSession
+
+
+def test_ollama_offline_skips_without_custom_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_ADAPTER_OFFLINE", "1")
+
+    provider = OllamaProvider("llama3", auto_pull=False)
+
+    with pytest.raises(ProviderSkip):
+        provider.invoke(ProviderRequest(model="llama3", prompt="hi"))
+
+
+def test_ollama_offline_allows_fake_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_ADAPTER_OFFLINE", "1")
+
+    class Session(FakeSession):
+        def post(self, url, json=None, stream=False, timeout=None):  # type: ignore[override]
+            self.calls.append((url, json, stream))
+            if url.endswith("/api/show"):
+                return FakeResponse(status_code=200, payload={})
+            if url.endswith("/api/chat"):
+                return FakeResponse(
+                    status_code=200,
+                    payload={
+                        "message": {"content": "ok"},
+                        "prompt_eval_count": 1,
+                        "eval_count": 2,
+                        "done_reason": "stop",
+                    },
+                )
+            raise AssertionError(f"unexpected url: {url}")
+
+    session = Session()
+    provider = OllamaProvider("llama3", session=session, auto_pull=False, host="http://localhost")
+
+    response = provider.invoke(ProviderRequest(model="llama3", prompt="hi"))
+
+    assert response.text == "ok"
+    assert response.token_usage.prompt == 1
+    assert response.token_usage.completion == 2
+    assert response.finish_reason == "stop"


### PR DESCRIPTION
## Summary
- add pytest-timeout and pytest-socket dependencies for enforcing timeouts and blocking network calls in tests
- introduce a pytest.ini with shared strict asyncio mode and duration reporting defaults
- run CI python tests with verbose output, disable-socket, and short ollama timeouts via environment guards

## Testing
- Not run (network access to install new pytest plugins is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da1c99128c8321823096393d2ba7f3