### PR TITLE
Adjust Ollama auto-pull override when providing custom client

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -60,20 +60,21 @@ class OllamaProvider(BaseProvider):
             except (TypeError, ValueError):
                 pass
 
-        auto_pull_env = os.environ.get("OLLAMA_AUTO_PULL")
-        if auto_pull_env is not None and auto_pull_env.strip() == "0":
-            auto_pull = False
-
         self._timeout = timeout
         self._pull_timeout = pull_timeout
-        self._auto_pull = auto_pull
         self._offline = (
             os.environ.get("LLM_ADAPTER_OFFLINE") == "1"
             or os.environ.get("CI", "").lower() == "true"
         )
         session_provided = session is not None
         client_provided = client is not None
-        self._allow_network = session_provided or client_provided
+        allow_network = session_provided or client_provided
+        auto_pull_env = os.environ.get("OLLAMA_AUTO_PULL")
+        if auto_pull_env is not None and auto_pull_env.strip() == "0" and not allow_network:
+            auto_pull = False
+
+        self._auto_pull = auto_pull
+        self._allow_network = allow_network
         self._ready_models: set[str] = set()
         if client is None:
             if session is None:

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -34,7 +34,7 @@ def test_ollama_provider_legacy_host_fallback(monkeypatch):
     assert provider._host == "http://legacy-host"
 
 
-def test_ollama_provider_auto_pull_and_chat():
+def test_ollama_provider_auto_pull_and_chat(monkeypatch):
     class Session(FakeSession):
         def __init__(self):
             super().__init__()
@@ -65,6 +65,8 @@ def test_ollama_provider_auto_pull_and_chat():
                     },
                 )
             raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setenv("OLLAMA_AUTO_PULL", "0")
 
     session = Session()
     provider = OllamaProvider("gemma3n:e2b", session=session, host="http://localhost")


### PR DESCRIPTION
## Summary
- prevent OLLAMA_AUTO_PULL=0 from disabling auto-pull when a custom session or client is supplied
- cover the regression by forcing OLLAMA_AUTO_PULL=0 inside the auto-pull chat test

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py -k auto_pull


------
https://chatgpt.com/codex/tasks/task_e_68da2dd460e88321951de9c7936693e1