### PR TITLE
Fix CLI prompt error classification attribute access

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -6,6 +6,8 @@ import types
 from pathlib import Path
 
 from adapter import cli as cli_module
+from adapter.cli.prompts import _classify_error
+from adapter.cli.utils import _msg
 from adapter.core import providers as provider_module
 
 
@@ -205,6 +207,24 @@ def test_cli_rate_limit_exit_code(monkeypatch, tmp_path: Path, capfd) -> None:
     captured = capfd.readouterr()
     assert exit_code == 6
     assert "レート" in captured.err or "rate" in captured.err.lower()
+
+
+def test_classify_error_rate_limit_status_code() -> None:
+    config = types.SimpleNamespace(provider="fake", auth_env="NONE")
+
+    class RateLimitedError(Exception):
+        status_code = 429
+
+    message, kind = _classify_error(RateLimitedError("Too many requests"), config, "ja")
+    assert kind == "rate"
+    assert message == _msg("ja", "rate_limited")
+
+
+def test_classify_error_system_exit_provider_error() -> None:
+    config = types.SimpleNamespace(provider="fake", auth_env="NONE")
+    message, kind = _classify_error(SystemExit("fatal"), config, "ja")
+    assert kind == "provider"
+    assert message == _msg("ja", "provider_error", error="fatal")
 
 
 def test_cli_doctor(monkeypatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- guard status_code attribute access and use direct SystemExit attributes in the CLI prompt runner
- add regression tests around _classify_error for rate limit and provider errors

## Testing
- ruff check --select B009 projects/04-llm-adapter/adapter/cli/prompts.py
- pytest projects/04-llm-adapter/tests/test_cli_single_prompt.py::test_cli_rate_limit_exit_code projects/04-llm-adapter/tests/test_cli_single_prompt.py::test_classify_error_rate_limit_status_code projects/04-llm-adapter/tests/test_cli_single_prompt.py::test_classify_error_system_exit_provider_error


------
https://chatgpt.com/codex/tasks/task_e_68da305b6b38832195d12232e0b7b6e7