### PR TITLE
Fix doctor CLI lang resolution

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/doctor.py
+++ b/projects/04-llm-adapter/adapter/cli/doctor.py
@@ -152,7 +152,8 @@ def run_doctor(
     except SystemExit as exc:
         return _coerce_exit_code(exc.code)
 
-    lang = _resolve_lang(getattr(args, "lang", None))
+    lang_value = args.lang if hasattr(args, "lang") else None
+    lang = _resolve_lang(lang_value)
     socket_mod = socket_module or socket
     http_mod = http_module or http.client
     print(_msg(lang, "doctor_header"))


### PR DESCRIPTION
## Summary
- resolve the doctor CLI language argument using direct attribute access while retaining a guard

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py::test_doctor_windows_encoding
- ruff check --select B009 projects/04-llm-adapter/adapter/cli/doctor.py

------
https://chatgpt.com/codex/tasks/task_e_68da34de78a0832181bd4187d7a989b7