### PR TITLE
Fix getattr usage in Ollama client stream error test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -98,11 +98,12 @@ def test_ollama_client_closes_responses_on_http_error(
 
 
 def test_ollama_client_closes_responses_on_stream_error():
-    stream_error_cls = getattr(
-        requests_exceptions,
-        "ChunkedEncodingError",
-        getattr(requests_exceptions, "ProtocolError", requests_exceptions.RequestException),
-    )
+    if hasattr(requests_exceptions, "ChunkedEncodingError"):
+        stream_error_cls = requests_exceptions.ChunkedEncodingError
+    elif hasattr(requests_exceptions, "ProtocolError"):
+        stream_error_cls = requests_exceptions.ProtocolError
+    else:
+        stream_error_cls = requests_exceptions.RequestException
 
     class Session(FakeSession):
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- replace chained getattr calls with explicit hasattr checks to avoid Ruff B009

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68da34f3d7f08321a64fa3dc791e91f1