### PR TITLE
Fix getattr usage in Gemini provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable, cast
 
 from src.llm_adapter.providers import ollama as ollama_module
 
@@ -80,10 +80,9 @@ class RecordGeminiClient:
 
             def generate_content(self, **kwargs: Any):
                 config_obj = kwargs.get("config")
-                if config_obj is not None:
-                    to_dict = getattr(config_obj, "to_dict", None)
-                    if callable(to_dict):
-                        kwargs["_config_dict"] = to_dict()
+                if config_obj is not None and hasattr(config_obj, "to_dict"):
+                    to_dict = cast(Callable[[], dict[str, Any]], config_obj.to_dict)
+                    kwargs["_config_dict"] = to_dict()
                 self._outer.calls.append(kwargs)
                 return SimpleNamespace(**self._outer._response_fields)
 

--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable, cast
 
 import pytest
 from src.llm_adapter.errors import (
@@ -61,8 +61,8 @@ def test_gemini_provider_invokes_client_with_config():
     config_dict = recorded.get("_config_dict")
     if isinstance(config_dict, Mapping):
         config_view.update(config_dict)
-    to_dict = getattr(recorded_config, "to_dict", None)
-    if callable(to_dict):
+    if hasattr(recorded_config, "to_dict"):
+        to_dict = cast(Callable[[], Any], recorded_config.to_dict)
         maybe = to_dict()
         if isinstance(maybe, Mapping):
             config_view.update(maybe)


### PR DESCRIPTION
## Summary
- replace getattr default usage in Gemini test helper with explicit hasattr guard
- update Gemini provider test configuration extraction to call to_dict directly

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
- ruff check --select B009 projects/04-llm-adapter-shadow/tests/helpers/fakes.py projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68da34f1b1f483218f1dba0828ed8b39