### PR TITLE
Fix failure detail extraction in consensus tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -486,7 +486,7 @@ def test_async_consensus_failure_details() -> None:
         asyncio.run(runner.run_async(request))
 
     error = exc_info.value
-    failures = getattr(error, "failures", None)
+    failures = error.failures if hasattr(error, "failures") else None
     expected = [
         {
             "provider": "timeout",

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -209,7 +209,7 @@ def test_runner_consensus_failure_details(monkeypatch: pytest.MonkeyPatch) -> No
         runner.run(request)
 
     error = exc_info.value
-    failures = getattr(error, "failures", None)
+    failures = error.failures if hasattr(error, "failures") else None
     expected = [
         {
             "provider": invocation.provider.name(),


### PR DESCRIPTION
## Summary
- access ParallelExecutionError.failures attribute defensively in async consensus failure test
- align synchronous consensus failure test with the same attribute access pattern

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_consensus_failure_details
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py::test_runner_consensus_failure_details
- ruff check --select B009 projects/04-llm-adapter-shadow/tests/test_runner_async.py projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68da34f292a0832184a7996185a9d411