### PR TITLE
Simplify metrics PathLike alias

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
@@ -7,11 +7,11 @@ from collections.abc import Mapping
 from pathlib import Path
 from threading import Lock
 from types import MappingProxyType
-from typing import Any, Protocol, Union
+from typing import Any, Protocol
 
 from .observability import CompositeLogger, JsonlLogger
 
-PathLike = Union[str, "Path"]
+PathLike = str | Path
 
 
 class MetricsExporter(Protocol):


### PR DESCRIPTION
## Summary
- replace the metrics PathLike alias to use modern union syntax and drop the unused typing import

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
- ruff check --select UP007 projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68da3939443483219731bd76e818c85c