### PR TITLE
Fix provider skip reason logging

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .errors import FatalError, RateLimitError, RetryableError, SkipError
+from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger
 from .utils import content_hash
 
@@ -183,7 +183,7 @@ def log_provider_skipped(
             "provider": provider_name,
             "attempt": attempt,
             "total_providers": total_providers,
-            "reason": getattr(error, "reason", None),
+            "reason": error.reason if isinstance(error, ProviderSkip) else None,
             "error_message": str(error),
         },
     )


### PR DESCRIPTION
## Summary
- ensure provider skip logging accesses the reason attribute only for ProviderSkip instances
- import ProviderSkip so the logger retains reason values without triggering getattr warnings

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_consensus_error_details
- ruff check --select B009 projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py

------
https://chatgpt.com/codex/tasks/task_e_68da3935ca1c8321bfb59e9c276e914f