### PR TITLE
Fix B009 attribute access in provider SPI

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -197,10 +197,10 @@ class _AsyncProviderAdapter(AsyncProviderSPI):
         if self._async_invoke is not None:
             return await self._async_invoke(request)
         provider = self._provider
-        attr_name = "invoke"
-        if not hasattr(provider, attr_name):
+        if not hasattr(provider, "invoke"):
             raise TypeError("Provider does not expose a synchronous invoke() method")
-        invoke_attr = getattr(provider, attr_name)
+        provider_spi = cast(ProviderSPI, provider)
+        invoke_attr = provider_spi.invoke
         if not callable(invoke_attr):
             raise TypeError("Provider invoke attribute is not callable")
         invoke = cast(Callable[[ProviderRequest], ProviderResponse], invoke_attr)


### PR DESCRIPTION
## Summary
- replace getattr-based invoke resolution with direct attribute access to satisfy B009 without altering runtime behaviour

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_consensus_error_details
- ruff check --select B009 projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py

------
https://chatgpt.com/codex/tasks/task_e_68da392f51a08321bfb868f67e30329e