### PR TITLE
Fix import ordering and string formatting in update_readme_metrics tool

### DIFF
--- a/tools/update_readme_metrics.py
+++ b/tools/update_readme_metrics.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-
 README_MARKERS_NOT_FOUND = (
     "README markers <!-- qa-metrics:start --> / <!-- qa-metrics:end --> not found"
 )
@@ -87,10 +86,8 @@ def format_recent_runs(items: list[dict[str, Any]]) -> list[str]:
         flaky_count = item.get("flaky_count") or 0
         flaky_delta = format_int_delta(item.get("flaky_delta"))
         lines.append(
-            (
-                f"- {run_id} ({ts}): Pass Rate {pass_rate}{pass_delta} / "
-                f"Flaky {flaky_count}件{flaky_delta}"
-            )
+            f"- {run_id} ({ts}): Pass Rate {pass_rate}{pass_delta} / "
+            f"Flaky {flaky_count}件{flaky_delta}"
         )
     return lines
 


### PR DESCRIPTION
## Summary
- sort and tidy the imports in `tools/update_readme_metrics.py`
- simplify string assembly when appending recent run lines

## Testing
- ruff check tools/update_readme_metrics.py
- python tools/update_readme_metrics.py --help

------
https://chatgpt.com/codex/tasks/task_e_68da3c957f50832187a44e64b8b449ef