### PR TITLE
chore: reorder imports in metrics render facade

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/render.py
+++ b/projects/04-llm-adapter/tools/report/metrics/render.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 from .html_report import render_html as _render_html
 from .regression_summary import build_regression_summary as _build_regression_summary


### PR DESCRIPTION
## Summary
- reorder the metric render facade imports to satisfy isort ordering

## Testing
- ruff check projects/04-llm-adapter/tools/report/metrics/render.py
- python -m projects.04-llm-adapter.tools.report.metrics.render

------
https://chatgpt.com/codex/tasks/task_e_68da3c9317d883218ce5712be9a30a73