### PR TITLE
Sort imports in consensus test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,5 +1,4 @@
 import pytest
-
 from src.llm_adapter.errors import RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,
@@ -9,9 +8,9 @@ from src.llm_adapter.provider_spi import (
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
-    compute_consensus,
     ConsensusResult,
     ParallelExecutionError,
+    compute_consensus,
 )
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 


### PR DESCRIPTION
## Summary
- align the consensus runner test imports with isort ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68da3c9124bc83219a6b74eff8261883