### PR TITLE
chore: sort imports in metrics threadsafe test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -1,9 +1,8 @@
 import json
-from pathlib import Path
 import threading
+from pathlib import Path
 
 import pytest
-
 from src.llm_adapter.metrics import log_event
 
 


### PR DESCRIPTION
## Summary
- reorder the json, threading, and pathlib imports in the metrics threadsafe test to satisfy isort

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
- pytest projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68da3c90e7b0832195203ddc70868f9e