### PR TITLE
Fix import ordering in Ollama offline test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pytest
-
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
+
 from tests.helpers.fakes import FakeResponse, FakeSession
 
 


### PR DESCRIPTION
## Summary
- reorder the import block in the Ollama offline provider test to satisfy isort

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68da3c90544083219dafec32746f0896