### PR TITLE
Normalize imports in shadow provider request normalization test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -4,14 +4,13 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
+from src.llm_adapter import provider_spi as provider_spi_module
+from src.llm_adapter.provider_spi import ProviderRequest
 
 hypothesis = pytest.importorskip("hypothesis")
 st = hypothesis.strategies
 given = hypothesis.given
 SearchStrategy = st.SearchStrategy
-
-from src.llm_adapter import provider_spi as provider_spi_module
-from src.llm_adapter.provider_spi import ProviderRequest
 
 
 def _message_entries() -> SearchStrategy[Mapping[str, Any]]:


### PR DESCRIPTION
## Summary
- move src.llm_adapter imports to the top of the test module to satisfy E402
- ensure the import block follows the expected isort ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68da3c8fdb7883218f1a95e9535206a8