### PR TITLE
refactor: import Callable from collections.abc

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 from src.llm_adapter.providers import ollama as ollama_module
 

--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import pytest
 from src.llm_adapter.errors import (

--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import lru_cache
 from importlib import import_module
 from types import ModuleType
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 try:  # pragma: no cover - optional dependency
     import typer


### PR DESCRIPTION
## Summary
- import Callable from collections.abc in the Gemini tests and CLI app
- clean up typing imports after the transition

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/helpers/fakes.py
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
- ruff check projects/04-llm-adapter/adapter/cli/app.py
- pytest projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68da3c8e293c8321953a43a01bfea6ad