### PR TITLE
chore: tidy CLI prompt imports

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/prompts.py
+++ b/projects/04-llm-adapter/adapter/cli/prompts.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
-import textwrap
 import socket
+import textwrap
 from collections.abc import Iterable
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- reorder standard-library imports in the CLI prompt module to satisfy isort grouping

## Testing
- ruff check projects/04-llm-adapter/adapter/cli/prompts.py
- PYTHONPATH=/tmp:$PYTHONPATH pytest projects/04-llm-adapter/tests/test_cli_single_prompt.py


------
https://chatgpt.com/codex/tasks/task_e_68da3c930e388321abd59bfa15fa322d