### PR TITLE
Remove unused asyncio import from shadow async tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest


### PR DESCRIPTION
## Summary
- remove the unused asyncio import from the shadow async test suite

## Testing
- ruff check --select F401 projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68da3e6294a48321be71c8f14cb57d2c