### PR TITLE
Fix flaky metrics formatting and add tests

### DIFF
--- a/tests/test_update_readme_metrics.py
+++ b/tests/test_update_readme_metrics.py
@@ -1,0 +1,27 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+
+
+def load_update_readme_metrics_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "update_readme_metrics.py"
+    spec = spec_from_file_location("update_readme_metrics", module_path)
+    if spec is None or spec.loader is None:
+        msg = "Failed to load update_readme_metrics module"
+        raise RuntimeError(msg)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_format_top_flaky_includes_numeric_score() -> None:
+    module = load_update_readme_metrics_module()
+
+    rows = [
+        {"canonical_id": "workflow-alpha", "score": 0.12345},
+        {"canonical_id": "workflow-beta", "score": None},
+    ]
+
+    result = module.format_top_flaky(rows)
+
+    assert result == "1. workflow-alpha (score 0.12)<br/>2. workflow-beta"

--- a/tools/update_readme_metrics.py
+++ b/tools/update_readme_metrics.py
@@ -49,8 +49,9 @@ def format_top_flaky(rows: list[dict[str, Any]]) -> str:
     for row in rows[:3]:
         cid = row.get("canonical_id") or "-"
         score = row.get("score")
-        if isinstance(score, int | float):
-            formatted.append(f"{len(formatted) + 1}. {cid} (score {score:.2f})")
+        if isinstance(score, (int, float)):  # noqa: UP038 - 明示的にタプル指定
+            score_display = f"{float(score):.2f}"
+            formatted.append(f"{len(formatted) + 1}. {cid} (score {score_display})")
         else:
             formatted.append(f"{len(formatted) + 1}. {cid}")
     return "<br/>".join(formatted)


### PR DESCRIPTION
## Summary
- ensure format_top_flaky uses tuple-based isinstance check with explicit score formatting
- add unit test verifying numeric score formatting in README metrics helper

## Testing
- ruff check tools/update_readme_metrics.py tests/test_update_readme_metrics.py
- pytest tests/test_update_readme_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68da40f5206883218d998ff010273e24