### PR TITLE
Fix Prometheus metrics numeric handling

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
@@ -75,17 +75,17 @@ class PrometheusMetricsExporter:
             ).inc()
 
             latency_ms = record.get("latency_ms")
-            if isinstance(latency_ms, (int | float)) and latency_ms >= 0:
+            if isinstance(latency_ms, (int, float)) and latency_ms >= 0:  # noqa: UP038
                 self._provider_call_latency_ms.labels(
                     provider=provider, status=status
                 ).observe(float(latency_ms))
 
             tokens_in = record.get("tokens_in")
-            if isinstance(tokens_in, (int | float)) and tokens_in >= 0:
+            if isinstance(tokens_in, (int, float)) and tokens_in >= 0:  # noqa: UP038
                 self._provider_tokens_in.labels(provider=provider).inc(float(tokens_in))
 
             tokens_out = record.get("tokens_out")
-            if isinstance(tokens_out, (int | float)) and tokens_out >= 0:
+            if isinstance(tokens_out, (int, float)) and tokens_out >= 0:  # noqa: UP038
                 self._provider_tokens_out.labels(provider=provider).inc(
                     float(tokens_out)
                 )
@@ -96,7 +96,7 @@ class PrometheusMetricsExporter:
             self._run_total.labels(provider=provider, status=status).inc()
 
             latency_ms = record.get("latency_ms")
-            if isinstance(latency_ms, (int | float)) and latency_ms >= 0:
+            if isinstance(latency_ms, (int, float)) and latency_ms >= 0:  # noqa: UP038
                 self._run_latency_ms.labels(status=status).observe(float(latency_ms))
 
 

--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -1,9 +1,11 @@
 import json
+import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from src.llm_adapter.metrics import log_event
+from src.llm_adapter.metrics import PrometheusMetricsExporter, log_event
 
 
 @pytest.mark.parametrize("thread_count,event_per_thread", [(8, 200)])
@@ -36,3 +38,66 @@ def test_log_event_threadsafe(tmp_path: Path, thread_count: int, event_per_threa
         assert record["event"] == "test"
         assert "thread" in record
         assert "index" in record
+
+
+def test_prometheus_exporter_accepts_numeric_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyCounter:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.label_args: list[dict[str, str]] = []
+            self.inc_values: list[float] = []
+
+        def labels(self, **kwargs: str) -> "DummyCounter":
+            self.label_args.append(kwargs)
+            return self
+
+        def inc(self, amount: float = 1.0) -> None:
+            self.inc_values.append(amount)
+
+    class DummyHistogram(DummyCounter):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)
+            self.observe_values: list[float] = []
+
+        def observe(self, amount: float) -> None:
+            self.observe_values.append(amount)
+
+    dummy_module = SimpleNamespace(Counter=DummyCounter, Histogram=DummyHistogram)
+    monkeypatch.setitem(sys.modules, "prometheus_client", dummy_module)
+
+    exporter = PrometheusMetricsExporter(namespace="test")
+
+    exporter.handle_event(
+        "provider_call",
+        {
+            "provider": "stub",
+            "status": "ok",
+            "shadow_used": True,
+            "latency_ms": 10,
+            "tokens_in": 5,
+            "tokens_out": 8,
+        },
+    )
+    exporter.handle_event(
+        "provider_call",
+        {
+            "provider": "stub",
+            "status": "ok",
+            "shadow_used": False,
+            "latency_ms": 12.5,
+            "tokens_in": 7.5,
+            "tokens_out": 9.5,
+        },
+    )
+    exporter.handle_event(
+        "run_metric",
+        {"provider": "stub", "status": "success", "latency_ms": 3},
+    )
+    exporter.handle_event(
+        "run_metric",
+        {"provider": "stub", "status": "success", "latency_ms": 4.5},
+    )
+
+    assert exporter._provider_tokens_in.inc_values == [5.0, 7.5]
+    assert exporter._provider_tokens_out.inc_values == [8.0, 9.5]
+    assert exporter._provider_call_latency_ms.observe_values == [10.0, 12.5]
+    assert exporter._run_latency_ms.observe_values == [3.0, 4.5]


### PR DESCRIPTION
## Summary
- ensure Prometheus metrics exporter accepts both integers and floats by using tuple-based isinstance checks
- add a regression test that stubs prometheus_client and verifies numeric latency and token metrics are recorded without errors

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
- pytest projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68da40f7a5b083218daf177fa6af03ea