### PR TITLE
Fix score extraction numeric handling in parallel runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -373,7 +373,7 @@ def _extract_score(response: ProviderResponse) -> float:
     raw = response.raw
     if isinstance(raw, Mapping):
         value = raw.get("score")
-        if isinstance(value, int | float):
+        if isinstance(value, (int, float)):  # noqa: UP038 - tuple form required
             return float(value)
     return 0.0
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -168,6 +168,21 @@ def test_parallel_primitives(monkeypatch: pytest.MonkeyPatch) -> None:
         compute_consensus(responses, config=ConsensusConfig(quorum=3))
 
 
+def test_compute_consensus_accepts_numeric_scores() -> None:
+    responses = [
+        ProviderResponse(text="int", latency_ms=0, raw={"score": 1}),
+        ProviderResponse(text="float", latency_ms=0, raw={"score": 1.5}),
+    ]
+
+    result = compute_consensus(
+        responses,
+        config=ConsensusConfig(strategy="weighted", quorum=1),
+    )
+
+    assert result.response.text == "float"
+    assert result.scores == {"int": 1.0, "float": 1.5}
+
+
 def test_runner_parallel_all_returns_full_result() -> None:
     providers = [
         _StaticProvider("p1", "response-1", latency_ms=5),


### PR DESCRIPTION
## Summary
- ensure consensus score extraction accepts both int and float values in provider responses
- add a regression test covering numeric score handling in compute_consensus

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
- PYTHONPATH=projects/04-llm-adapter-shadow pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68da40f5bfd48321ac95f7e8fe9567e5