### PR TITLE
Handle RateLimitError retries in async parallel runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -343,10 +343,11 @@ class AsyncRunner:
                 nonlocal retry_attempts, attempt_count
                 provider, _ = providers[worker_index]
                 next_attempt_total = total_providers + retry_attempts + 1
+                delay: float | None
                 if isinstance(error, RateLimitError):
-                    return None
-
-                delay: float | None = None
+                    delay = max(0.0, self._config.backoff.rate_limit_sleep_s)
+                else:
+                    delay = None
                 if isinstance(error, TimeoutError):
                     if not self._config.backoff.timeout_next_provider:
                         delay = 0.0


### PR DESCRIPTION
## Summary
- convert RateLimitError handling in the async parallel retry helper to use the configured rate limit backoff delay
- ensure retry bookkeeping and events fire for rate limited attempts while clamping negative delays to zero

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_retry_behaviour

------
https://chatgpt.com/codex/tasks/task_e_68da456ed42c8321a2363f7bdced5126