### PR TITLE
Fix generator spacing in fs-utils

### DIFF
--- a/projects/03-ci-flaky/src/fs-utils.js
+++ b/projects/03-ci-flaky/src/fs-utils.js
@@ -6,7 +6,7 @@ export function ensureDir(dirPath) {
   fs.mkdirSync(dirPath, { recursive: true });
 }
 
-export async function * readJsonl(filePath) {
+export async function* readJsonl(filePath) {
   if (!fs.existsSync(filePath)) return;
   const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });


### PR DESCRIPTION
## Summary
- update the readJsonl export to comply with the generator-star-spacing rule

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da493fb3b48321a70539ddf7067ee2