### PR TITLE
chore: drop unused summary from issue markdown

### DIFF
--- a/projects/03-ci-flaky/src/commands/issue.js
+++ b/projects/03-ci-flaky/src/commands/issue.js
@@ -5,7 +5,7 @@ import { ensureDir } from '../fs-utils.js';
 import { runAnalyze, serialiseFlakyEntry } from './analyze.js';
 import { parseBoolean, parseList } from './utils.js';
 
-function formatIssueMarkdown(entry, resolvedConfig, issueConfig, summary) {
+function formatIssueMarkdown(entry, resolvedConfig, issueConfig) {
   const signatureEntries = Object.entries(entry.failure_signatures || {});
   const primarySignature = signatureEntries.sort((a, b) => b[1].count - a[1].count)[0]?.[0] ?? 'unknown';
   const recentRuns = Array.from(new Set((entry.statuses || []).map((s) => s.run_id).filter(Boolean))).slice(-5).join(', ');
@@ -73,7 +73,7 @@ export async function runIssue(args) {
     }
     if (seen.has(key)) continue;
     seen.add(key);
-    const markdown = formatIssueMarkdown(serialized, resolvedConfig, issueConfig, summary);
+    const markdown = formatIssueMarkdown(serialized, resolvedConfig, issueConfig);
     if (issueConfig.dry_run) {
       const filename = `${serialized.canonical_id.replace(/[^a-z0-9-_]+/gi, '_')}.md`;
       const filePath = path.join(issuesDir, filename);


### PR DESCRIPTION
## Summary
- remove the unused summary argument from issue markdown generation
- update runIssue to call the helper with the new signature

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da50e1a6d0832180beb467ced210d8