### PR TITLE
Fix serve-static process reference lint error

### DIFF
--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
+import process from 'node:process';
 
 const [,, dirArg = 'public', portArg = '5173'] = process.argv;
 const rootDir = path.resolve(process.cwd(), dirArg);


### PR DESCRIPTION
## Summary
- add explicit process import to the serve-static script to use the `process` binding explicitly

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da50dfdc508321b910b14d3408196e