### PR TITLE
fix: import node:process in blueprint server

### DIFF
--- a/projects/02-blueprint-to-playwright/server.mjs
+++ b/projects/02-blueprint-to-playwright/server.mjs
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import http from 'http';
 import path from 'path';
+import process from 'node:process';
 import url from 'url';
 
 import { LLM2PW_DEMO_DIR } from '../../scripts/paths.mjs';


### PR DESCRIPTION
## Summary
- add an explicit node:process import to the blueprint demo server to satisfy lint rules

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da50e009a88321abc9c811a5975e60