### PR TITLE
Add process import to analyze-junit CLI test

### DIFF
--- a/tests/analyze-junit-cli.test.mjs
+++ b/tests/analyze-junit-cli.test.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## Summary
- import the Node.js process module in the analyze-junit CLI test so the identifier is defined

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da557c37f483218fe6e7b943c1f050