### PR TITLE
fix: import process in pipeline test

### DIFF
--- a/tests/pipeline.test.mjs
+++ b/tests/pipeline.test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
 import { Readable } from 'node:stream';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- import `process` in `tests/pipeline.test.mjs` so `spawnSync` uses the defined reference
- switch builtin imports in the test to `node:` specifiers to satisfy alphabetized lint ordering

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da557b1e748321839ecdc69d1fc2b9