### PR TITLE
Add explicit process import in e2e shadow test

### DIFF
--- a/tests/e2e-shadow.test.mjs
+++ b/tests/e2e-shadow.test.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## Summary
- add an explicit node:process import in e2e-shadow test
- ensure Node process usage is referenced via the imported binding

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da5575b2488321a5f2270c586c74a0