### PR TITLE
Add missing process import in text_to_cases script

### DIFF
--- a/projects/01-spec2cases-md2json/scripts/text_to_cases.mjs
+++ b/projects/01-spec2cases-md2json/scripts/text_to_cases.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## Summary
- add explicit process import to text_to_cases.mjs so eslint no-undef passes

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da5574367c8321b0987ea0a6236589