### PR TITLE
fix: import process in run_cases script

### DIFF
--- a/projects/01-spec2cases-md2json/scripts/run_cases.mjs
+++ b/projects/01-spec2cases-md2json/scripts/run_cases.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 import { SPEC2CASES_SAMPLE_CASES_PATH } from '../../../scripts/paths.mjs';
 


### PR DESCRIPTION
## Summary
- import the Node.js process module in the run_cases script to avoid relying on globals
- keep the built-in imports sorted to satisfy linting rules

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da557375cc83219c7c4a199a829107