### PR TITLE
fix: import process in spec2cases script

### DIFF
--- a/projects/01-spec2cases-md2json/scripts/spec2cases.mjs
+++ b/projects/01-spec2cases-md2json/scripts/spec2cases.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 import { SPEC2CASES_SAMPLE_CASES_PATH } from '../../../scripts/paths.mjs';
 import { parseSpecText } from '../src/parse-spec.js';


### PR DESCRIPTION
## Summary
- import the Node process module in the spec2cases script to satisfy ESLint no-undef

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da55709e048321a9dd98532fe86d60