### PR TITLE
fix: import process in blueprint script

### DIFF
--- a/projects/02-blueprint-to-playwright/scripts/blueprint_to_code.mjs
+++ b/projects/02-blueprint-to-playwright/scripts/blueprint_to_code.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 // ---- CLI / Paths ----


### PR DESCRIPTION
## Summary
- import the Node.js process module in the blueprint_to_code script to satisfy linting

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da556eb7808321b57dcc0c34bf030e