### PR TITLE
Normalize RunnerConfig mode coercion

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -42,3 +42,12 @@ class RunnerConfig:
     max_concurrency: int | None = None
     rpm: int | None = None
     consensus: ConsensusConfig | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.mode, RunnerMode):
+            normalized = self.mode
+        else:
+            mode_value = self.mode.value if isinstance(self.mode, Enum) else self.mode
+            normalized = RunnerMode(mode_value)
+
+        object.__setattr__(self, "mode", normalized)

--- a/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
@@ -2,12 +2,29 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from enum import Enum
 
 import pytest
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import ParallelExecutionError
 from src.llm_adapter.runner_sync import Runner
+
+
+class _ExternalRunnerMode(Enum):
+    PARALLEL_ANY = "parallel_any"
+
+
+def test_runner_config_accepts_string_mode() -> None:
+    config = RunnerConfig(mode="parallel_any")
+
+    assert config.mode is RunnerMode.PARALLEL_ANY
+
+
+def test_runner_config_accepts_foreign_enum() -> None:
+    config = RunnerConfig(mode=_ExternalRunnerMode.PARALLEL_ANY)
+
+    assert config.mode is RunnerMode.PARALLEL_ANY
 
 
 class _FakeClock:


### PR DESCRIPTION
## Summary
- normalize RunnerConfig.mode to the local RunnerMode enum during post init
- add regression tests covering string and foreign enum inputs for RunnerConfig

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68da5564268c8321978fe48567559945