### PR TITLE
Fix runner mode comparisons for runner modes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -270,7 +270,7 @@ class AsyncRunner:
                 )
             return details
 
-        if mode is RunnerMode.SEQUENTIAL:
+        if mode == RunnerMode.SEQUENTIAL:
             for attempt_index, (provider, async_provider) in enumerate(providers, start=1):
                 attempt_count = attempt_index
                 try:
@@ -333,7 +333,7 @@ class AsyncRunner:
         else:
             attempt_count = total_providers
 
-            capture_shadow, retry_attempts = mode is RunnerMode.CONSENSUS, 0
+            capture_shadow, retry_attempts = mode == RunnerMode.CONSENSUS, 0
             attempt_labels = [index for index in range(1, total_providers + 1)]
             limit = self._config.max_attempts
 
@@ -345,7 +345,7 @@ class AsyncRunner:
                 next_attempt_total = total_providers + retry_attempts + 1
                 delay: float | None = None
                 if isinstance(error, RateLimitError):
-                    if mode is RunnerMode.PARALLEL_ANY:
+                    if mode == RunnerMode.PARALLEL_ANY:
                         delay = float(
                             max(0.0, self._config.backoff.rate_limit_sleep_s)
                         )
@@ -419,7 +419,7 @@ class AsyncRunner:
             ]
 
             try:
-                if mode is RunnerMode.PARALLEL_ANY:
+                if mode == RunnerMode.PARALLEL_ANY:
                     (
                         attempt_index,
                         provider,
@@ -465,7 +465,7 @@ class AsyncRunner:
                 if results is None or not results:
                     last_err = RuntimeError("No providers succeeded")
                 else:
-                    if mode is RunnerMode.CONSENSUS and results is not None:
+                    if mode == RunnerMode.CONSENSUS and results is not None:
                         successful_entries = [
                             entry
                             for entry in results
@@ -627,12 +627,12 @@ class AsyncRunner:
                             lambda entry: entry[2],
                         )
 
-        if mode is RunnerMode.CONSENSUS and results is not None:
+        if mode == RunnerMode.CONSENSUS and results is not None:
             for _, _, _, metrics in results:
                 if metrics is not None:
                     metrics.emit()
 
-        if mode is RunnerMode.CONSENSUS:
+        if mode == RunnerMode.CONSENSUS:
             failure_details = _collect_failure_details()
             no_success = (
                 results is None

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -249,7 +249,7 @@ class Runner:
         shadow_used = shadow is not None
         mode = self._config.mode
 
-        if mode is RunnerMode.SEQUENTIAL:
+        if mode == RunnerMode.SEQUENTIAL:
             max_attempts = self._config.max_attempts
             attempt_count = 0
             for loop_index, provider in enumerate(self.providers, start=1):
@@ -352,7 +352,7 @@ class Runner:
         total_providers = len(self.providers)
         results: list[ProviderInvocationResult | None] = [None] * total_providers
 
-        capture_shadow = mode is RunnerMode.CONSENSUS
+        capture_shadow = mode == RunnerMode.CONSENSUS
 
         def make_worker(
             index: int, provider: ProviderSPI
@@ -389,7 +389,7 @@ class Runner:
 
         attempts_override: dict[int, int] | None = None
         try:
-            if mode is RunnerMode.PARALLEL_ANY:
+            if mode == RunnerMode.PARALLEL_ANY:
                 winner = run_parallel_any_sync(
                     workers, max_concurrency=self._config.max_concurrency
                 )
@@ -405,7 +405,7 @@ class Runner:
                 attempts_override = {winner.attempt: attempts_final}
                 return response
 
-            if mode is RunnerMode.PARALLEL_ALL:
+            if mode == RunnerMode.PARALLEL_ALL:
                 invocations = run_parallel_all_sync(
                     workers, max_concurrency=self._config.max_concurrency
                 )
@@ -420,7 +420,7 @@ class Runner:
                     lambda invocation: cast(ProviderResponse, invocation.response),
                 )
 
-            if mode is RunnerMode.CONSENSUS:
+            if mode == RunnerMode.CONSENSUS:
                 invocations = run_parallel_all_sync(
                     workers, max_concurrency=self._config.max_concurrency
                 )


### PR DESCRIPTION
## Summary
- replace identity checks against RunnerMode enum with equality checks in async and sync runners
- ensure shadow capture and retry logic still operate for non-RunnerMode values

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_retry_behaviour

------
https://chatgpt.com/codex/tasks/task_e_68da556342cc83219095f739e60b2243