### PR TITLE
Fix import order configuration for compare runner test

### DIFF
--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 
 import pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ ignore = ["E501"]
 [tool.ruff.lint.isort]
 force-single-line = false
 known-first-party = ["llm_adapter"]
+order-by-type = false
+force-sort-within-sections = true
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Summary
- reorder the pathlib Path import ahead of sys in the compare runner parallel test
- configure Ruff isort settings so alphabetical stdlib ordering stays compliant

## Testing
- ruff check projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68da5cbc2ef8832198b9600ccdc39010