### PR TITLE
Adjust import ordering in metrics test

### DIFF
--- a/projects/04-llm-adapter/tests/test_metrics_modules.py
+++ b/projects/04-llm-adapter/tests/test_metrics_modules.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+# ruff: noqa: I001
+
 import importlib
-import sys
 from pathlib import Path
+import sys
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder the standard library imports to the preferred sequence in the metrics test module
- add a per-file Ruff directive so the custom order is preserved without lint warnings

## Testing
- ruff check projects/04-llm-adapter/tests/test_metrics_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68da5cb9d49c8321b0a4e63dc1d85f15