### PR TITLE
Reorder pytest import in CLI runner config test

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from adapter.cli import doctor
-
 import pytest
+
 from adapter import run_compare as run_compare_module
+from adapter.cli import doctor
 from adapter.core import runner_api
 
 


### PR DESCRIPTION
## Summary
- reorder the pytest import ahead of first-party modules in the CLI runner config test
- tidy blank lines between import groups to satisfy the formatter

## Testing
- `ruff check projects/04-llm-adapter/tests/test_cli_runner_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68da5cb910b08321b12573635b6c7162