### PR TITLE
Sort shadow test runner imports

### DIFF
--- a/tests/shadow/test_runner_async.py
+++ b/tests/shadow/test_runner_async.py
@@ -1,11 +1,11 @@
 """pytest shim to expose shadow async runner tests at the repository root."""
 from __future__ import annotations
 
+import pathlib
 import sys
-from pathlib import Path
 
 _PROJECT_ROOT = (
-    Path(__file__).resolve().parents[2]
+    pathlib.Path(__file__).resolve().parents[2]
     / "projects"
     / "04-llm-adapter-shadow"
 )


### PR DESCRIPTION
## Summary
- reorder the shadow test runner's standard-library imports into alphabetical order
- adjust usage to rely on pathlib.Path after renaming the import

## Testing
- ruff check tests/shadow/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68da5cb79da08321a9d364b88b775747