### PR TITLE
refactor: rely on node timers delay in tests

### DIFF
--- a/tests/e2e-shadow.test.mjs
+++ b/tests/e2e-shadow.test.mjs
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 import { parseSpecFile } from '../projects/01-spec2cases-md2json/scripts/spec2cases.mjs';
@@ -27,7 +28,7 @@ async function waitForFile(targetPath, { timeoutMs = 1000, intervalMs = 25 } = {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (fs.existsSync(targetPath)) return;
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    await delay(intervalMs);
   }
   assert.fail(`expected file to exist within ${timeoutMs}ms: ${targetPath}`);
 }

--- a/tests/pipeline.test.mjs
+++ b/tests/pipeline.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { Readable } from 'node:stream';
 import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 import { parseSpecFile, validateCasesSchema } from '../projects/01-spec2cases-md2json/scripts/spec2cases.mjs';
@@ -105,7 +106,7 @@ test('junit analysis tracks flaky transitions', async () => {
           if (!expected || entries.length === expected) return entries;
         }
       }
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await delay(10);
     }
     throw new Error('timed out waiting for junit log entries');
   };


### PR DESCRIPTION
## Summary
- add the node:timers/promises delay helper to the test suites
- replace manual Promise wrappers with delay to clear the no-undef lint errors

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da5f6c90408321b4d00b5f92894f3e