### PR TITLE
Add wait_for timeouts to async runner retry tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -534,7 +534,12 @@ def test_async_parallel_retry_behaviour(monkeypatch: pytest.MonkeyPatch) -> None
         ),
     )
 
-    response = asyncio.run(runner_any.run_async(request_any, shadow_metrics_path="unused.jsonl"))
+    response = asyncio.run(
+        asyncio.wait_for(
+            runner_any.run_async(request_any, shadow_metrics_path="unused.jsonl"),
+            timeout=1,
+        )
+    )
     assert response.text == "ok:retry"
     assert (
         flaky.invocations,
@@ -564,7 +569,12 @@ def test_async_parallel_retry_behaviour(monkeypatch: pytest.MonkeyPatch) -> None
     )
 
     with pytest.raises(ParallelExecutionError):
-        asyncio.run(runner_fail.run_async(request_any, shadow_metrics_path="unused.jsonl"))
+        asyncio.run(
+            asyncio.wait_for(
+                runner_fail.run_async(request_any, shadow_metrics_path="unused.jsonl"),
+                timeout=1,
+            )
+        )
 
     assert (
         flaky_fail.invocations,


### PR DESCRIPTION
## Summary
- wrap async runner retry tests with `asyncio.wait_for` to ensure hung coroutines fail fast

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_retry_behaviour

------
https://chatgpt.com/codex/tasks/task_e_68da5f7ce95c8321a65edc8b153edd23