### PR TITLE
fix: add explicit process import for flaky config

### DIFF
--- a/projects/03-ci-flaky/src/config.js
+++ b/projects/03-ci-flaky/src/config.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 const DEFAULT_CONFIG = {
   window: 20,


### PR DESCRIPTION
## Summary
- add the missing node:process import to config handling for the flaky CI project to satisfy linting

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da5f6d7ce8832187655a889a2c9b0c