### PR TITLE
Adjust CI node test command order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           bash scripts/run-node-suite.sh
           npm run ci:analyze
           npm run ci:issue
-          PYTHON=python3 node --test tests/e2e-shadow.test.mjs
+          node --test tests/e2e-shadow.test.mjs
       - name: Run Python tests (verbose, timeout, no network)
         env:
           LLM_ADAPTER_OFFLINE: "1"


### PR DESCRIPTION
## Summary
- ensure the Node test suite step runs the required commands in the documented order
- drop the temporary PYTHON environment override so the `node --test` command matches the expected invocation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da613a13f88321bce25b2dbf9841ea