### PR TITLE
chore(ci): install llm adapter package in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install -r projects/04-llm-adapter-shadow/requirements.txt
+      - run: pip install -e projects/04-llm-adapter-shadow
       - name: Run Node test suites
         run: |
           set -euxo pipefail


### PR DESCRIPTION
## Summary
- install the LLM adapter requirements during CI Python setup
- add an editable install step so the module can be imported during tests

## Testing
- python -m pytest projects/04-llm-adapter-shadow/tests -k 'not slow' -m "" -q

------
https://chatgpt.com/codex/tasks/task_e_68da613c197883219e1eaa079472014f