### PR TITLE
Avoid retrying rate limited providers in PARALLEL_ANY mode

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -345,6 +345,8 @@ class AsyncRunner:
                 next_attempt_total = total_providers + retry_attempts + 1
                 delay: float | None = None
                 if isinstance(error, RateLimitError):
+                    if mode == RunnerMode.PARALLEL_ANY:
+                        return None
                     delay = max(0.0, float(self._config.backoff.rate_limit_sleep_s))
                 elif isinstance(error, TimeoutError):
                     if not self._config.backoff.timeout_next_provider:


### PR DESCRIPTION
## Summary
- stop scheduling retries for rate limited providers when running in PARALLEL_ANY mode
- update the async parallel-any rate limit test to ensure no retry events are emitted

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_any_rate_limit_does_not_retry


------
https://chatgpt.com/codex/tasks/task_e_68da63f4864c83218a95adf08c58dd0c