### PR TITLE
Avoid retry delay for parallel-any rate limits

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -341,12 +341,12 @@ class AsyncRunner:
                 worker_index: int, attempt_index: int, error: BaseException
             ) -> tuple[int, float] | None:
                 nonlocal retry_attempts, attempt_count
+                if mode == RunnerMode.PARALLEL_ANY and isinstance(error, RateLimitError):
+                    return None
                 provider, _ = providers[worker_index]
                 next_attempt_total = total_providers + retry_attempts + 1
                 delay: float | None = None
                 if isinstance(error, RateLimitError):
-                    if mode == RunnerMode.PARALLEL_ANY:
-                        return None
                     delay = max(0.0, float(self._config.backoff.rate_limit_sleep_s))
                 elif isinstance(error, TimeoutError):
                     if not self._config.backoff.timeout_next_provider:


### PR DESCRIPTION
## Summary
- short-circuit parallel-any retries when a RateLimitError is raised to avoid scheduling follow-up attempts

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py -k "parallel_any and rate_limit"

------
https://chatgpt.com/codex/tasks/task_e_68da666bcf348321ba3e5bd6c2277328