### PR TITLE
Handle rate limit retries in parallel any mode

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -341,8 +341,6 @@ class AsyncRunner:
                 worker_index: int, attempt_index: int, error: BaseException
             ) -> tuple[int, float] | None:
                 nonlocal retry_attempts, attempt_count
-                if mode == RunnerMode.PARALLEL_ANY and isinstance(error, RateLimitError):
-                    return None
                 provider, _ = providers[worker_index]
                 next_attempt_total = total_providers + retry_attempts + 1
                 delay: float | None = None


### PR DESCRIPTION
## Summary
- allow parallel-any retries to be scheduled after rate limit errors using configured backoff delay

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py -k "parallel_retry_behaviour"

------
https://chatgpt.com/codex/tasks/task_e_68da6a806964832194d203ec38db1d1b