### PR TITLE
Guard async runner tests with timeouts

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -396,7 +396,7 @@ def test_async_parallel_any_returns_first_completion() -> None:
     )
     request = ProviderRequest(prompt="hi", model="model-parallel-any")
 
-    response = asyncio.run(runner.run_async(request))
+    response = asyncio.run(asyncio.wait_for(runner.run_async(request), timeout=0.2))
 
     assert response.text.startswith("fast:")
 
@@ -410,7 +410,7 @@ def test_async_parallel_any_cancellation_waits_for_cleanup() -> None:
     )
     request = ProviderRequest(prompt="hi", model="model-parallel-cancel")
 
-    response = asyncio.run(runner.run_async(request))
+    response = asyncio.run(asyncio.wait_for(runner.run_async(request), timeout=0.3))
 
     assert response.text.startswith("fast:")
     assert slow.cancelled is True


### PR DESCRIPTION
## Summary
- wrap the async parallel any tests in `asyncio.wait_for` so they fail fast if the runner hangs
- use short, stable timeouts that still allow the fake providers to complete successfully

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_any_returns_first_completion
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py::test_async_parallel_any_cancellation_waits_for_cleanup

------
https://chatgpt.com/codex/tasks/task_e_68da693b2dc88321bdbf430312e53a89