### PR TITLE
chore: ignore docs coverage from eslint linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ export default [
       'packages/**',
       'dist/**',
       'coverage/**',
+      'docs/reports/coverage/**',
       'projects/04-llm-adapter-shadow/**',
       'tests/playwright-report/**',
       'projects/02-blueprint-to-playwright/tests/generated/**',


### PR DESCRIPTION
## Summary
- add the generated docs coverage directory to the ESLint ignore list

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da692dca3c8321bb31bffa13f5684e