### PR TITLE
chore: normalize server node imports

### DIFF
--- a/projects/02-blueprint-to-playwright/server.mjs
+++ b/projects/02-blueprint-to-playwright/server.mjs
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import http from 'http';
-import path from 'path';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
 import process from 'node:process';
-import url from 'url';
+import url from 'node:url';
 
 import { LLM2PW_DEMO_DIR } from '../../scripts/paths.mjs';
 


### PR DESCRIPTION
## Summary
- reorder the Node.js imports in the demo server to match the lint order and use node: specifiers

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68da692b314883218cb81b66ed3b35a3