### PR TITLE
chore: align future import placement

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -1,10 +1,9 @@
 """トップレベル `adapter` パッケージのシム。"""
-
 from __future__ import annotations
 
-import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import sys
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _TARGET_DIR = _REPO_ROOT / "projects" / "04-llm-adapter" / "adapter"

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -5,7 +5,6 @@ Runner retry policy:
 - ``TimeoutError`` / ``RetriableError`` → immediately try the next provider with no delay.
 - ``ProviderSkip`` → simply recorded as a skip event; control moves on without retrying.
 """
-
 from __future__ import annotations
 
 from enum import Enum

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics.py
@@ -1,11 +1,10 @@
 """Lightweight JSONL metrics helpers with optional exporters."""
-
 from __future__ import annotations
 
-import time
 from collections.abc import Mapping
 from pathlib import Path
 from threading import Lock
+import time
 from types import MappingProxyType
 from typing import Any, Protocol
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/observability.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/observability.py
@@ -1,11 +1,10 @@
 """Shared observability primitives for the shadow adapter."""
-
 from __future__ import annotations
 
-import json
-import sys
 from collections.abc import Iterable, Mapping
+import json
 from pathlib import Path
+import sys
 from threading import Lock
 from typing import Any, Protocol, TextIO
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast
+import inspect
+from typing import Any, cast, Protocol
+import warnings
 
 from .utils import ensure_str_list
 from .utils import extract_prompt_from_messages as _extract_prompt_from_messages

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
@@ -1,12 +1,11 @@
 """Compat utilities for optional ``requests`` dependency."""
-
 from __future__ import annotations
 
-import importlib
-import typing
 from collections.abc import Iterable
+import importlib
 from types import TracebackType
-from typing import Any, Protocol, cast
+import typing
+from typing import Any, cast, Protocol
 
 
 class ResponseProtocol(Protocol):
@@ -49,8 +48,8 @@ requests_exceptions: RequestsExceptionsProtocol
 
 if typing.TYPE_CHECKING:  # pragma: no cover - typing time placeholders
     import requests as _requests_mod  # type: ignore[import-untyped]  # noqa: F401
-    from requests import Response as _RequestsResponse  # noqa: F401
     from requests import exceptions as _RequestsExceptions  # noqa: F401
+    from requests import Response as _RequestsResponse  # noqa: F401
 
 
 def _initialize_requests() -> tuple[

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/base.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/base.py
@@ -1,5 +1,4 @@
 """共通プロバイダ基底クラス。"""
-
 from __future__ import annotations
 
 from abc import ABC

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/factory.py
@@ -1,9 +1,8 @@
 """Helpers for instantiating providers from configuration strings."""
-
 from __future__ import annotations
 
-import os
 from collections.abc import Callable, Mapping
+import os
 
 from ..provider_spi import ProviderSPI
 from .gemini import GeminiProvider

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini.py
@@ -1,11 +1,10 @@
 """Gemini provider integration for the minimal adapter."""
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import os
 import re
 import time
-from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ..errors import (

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini_client.py
@@ -1,5 +1,4 @@
 """Client helpers for interacting with the Gemini SDK."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini_helpers.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/gemini_helpers.py
@@ -1,5 +1,4 @@
 """Helper utilities for Gemini provider message and config handling."""
-
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/mock.py
@@ -1,10 +1,9 @@
 """Mock provider that can deterministically trigger failure modes."""
-
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 import random
 import time
-from collections.abc import Iterable, Mapping, Sequence
 
 from ..errors import AdapterError, RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, TokenUsage

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -1,18 +1,17 @@
 """Ollama provider with automatic model management."""
-
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import os
 import time
-from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ..errors import ConfigError, ProviderSkip, RetriableError
 from ..provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from ._requests_compat import (
-    SessionProtocol,
     create_session,
     requests_exceptions,
+    SessionProtocol,
 )
 from .base import BaseProvider
 from .ollama_client import OllamaClient

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -5,7 +5,7 @@ from types import TracebackType
 from typing import Any, cast
 
 from ..errors import AuthError, RateLimitError, RetriableError, TimeoutError
-from ._requests_compat import ResponseProtocol, SessionProtocol, requests_exceptions
+from ._requests_compat import requests_exceptions, ResponseProtocol, SessionProtocol
 
 _streaming_error_candidates: list[type[BaseException]] = []
 _requests_exceptions_any = cast(Any, requests_exceptions)

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner.py
@@ -1,5 +1,4 @@
 """Public runner API exports."""
-
 from __future__ import annotations
 
 from .runner_async import AsyncRunner

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -1,10 +1,9 @@
 """Asynchronous runner implementation."""
-
 from __future__ import annotations
 
 import asyncio
-import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+import time
 from typing import Any, cast
 
 from .errors import (
@@ -18,31 +17,31 @@ from .errors import (
 from .observability import EventLogger
 from .provider_spi import (
     AsyncProviderSPI,
+    ensure_async_provider,
     ProviderRequest,
     ProviderResponse,
     ProviderSPI,
-    ensure_async_provider,
 )
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import (
+    compute_consensus,
     ParallelAllResult,
     ParallelExecutionError,
-    compute_consensus,
     run_parallel_all_async,
     run_parallel_any_async,
 )
 from .runner_shared import (
-    MetricsPath,
-    RateLimiter,
     error_family,
     estimate_cost,
     log_provider_call,
     log_provider_skipped,
     log_run_metric,
+    MetricsPath,
+    RateLimiter,
     resolve_event_logger,
     resolve_rate_limiter,
 )
-from .shadow import DEFAULT_METRICS_PATH, ShadowMetrics, run_with_shadow_async
+from .shadow import DEFAULT_METRICS_PATH, run_with_shadow_async, ShadowMetrics
 from .utils import content_hash, elapsed_ms
 
 WorkerResult = tuple[

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -1,5 +1,4 @@
 """Configuration objects for runner orchestration behavior."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -1,23 +1,22 @@
 """Parallel and consensus orchestration helpers for runner implementations."""
-
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable as TypingCallable
+from concurrent.futures import (
+    as_completed,
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
+from dataclasses import dataclass, field
 import importlib
 import inspect
 import json
 import math
-from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
-from collections.abc import Callable as TypingCallable
-from concurrent.futures import (
-    FIRST_COMPLETED,
-    Future,
-    ThreadPoolExecutor,
-    as_completed,
-    wait,
-)
-from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, cast, Generic, TypeVar
 
 from .provider_spi import ProviderResponse
 from .runner_config import ConsensusConfig

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -1,13 +1,12 @@
 """Shared helpers for runner modules."""
-
 from __future__ import annotations
 
 import asyncio
-import threading
-import time
 from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+import threading
+import time
+from typing import Any, TYPE_CHECKING
 
 from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -1,10 +1,9 @@
 """Synchronous runner implementation."""
-
 from __future__ import annotations
 
-import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+import time
 from typing import cast
 
 from .errors import (
@@ -19,24 +18,24 @@ from .observability import EventLogger
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import (
+    compute_consensus,
     ParallelAllResult,
     ParallelExecutionError,
-    compute_consensus,
     run_parallel_all_sync,
     run_parallel_any_sync,
 )
 from .runner_shared import (
-    MetricsPath,
-    RateLimiter,
     error_family,
     estimate_cost,
     log_provider_call,
     log_provider_skipped,
     log_run_metric,
+    MetricsPath,
+    RateLimiter,
     resolve_event_logger,
     resolve_rate_limiter,
 )
-from .shadow import DEFAULT_METRICS_PATH, ShadowMetrics, run_with_shadow
+from .shadow import DEFAULT_METRICS_PATH, run_with_shadow, ShadowMetrics
 from .utils import content_hash, elapsed_ms
 
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -1,23 +1,22 @@
 """Shadow execution helpers."""
-
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import threading
-import time
 from collections.abc import Mapping
+import contextlib
 from dataclasses import dataclass
 from pathlib import Path
+import threading
+import time
 from typing import Any
 
 from .observability import EventLogger, JsonlLogger
 from .provider_spi import (
     AsyncProviderSPI,
+    ensure_async_provider,
     ProviderRequest,
     ProviderResponse,
     ProviderSPI,
-    ensure_async_provider,
 )
 from .utils import content_hash
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/utils.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/utils.py
@@ -1,8 +1,8 @@
 """Utility helpers for hashing request payloads and message normalization."""
 
+from collections.abc import Mapping, Sequence
 import hashlib
 import time
-from collections.abc import Mapping, Sequence
 from typing import Any
 
 

--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 import sys
 import warnings
-from pathlib import Path
 
 import pytest
 

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
@@ -8,11 +8,10 @@ from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMod
 from src.llm_adapter.runner_parallel import ParallelExecutionError
 
 from tests.shadow._runner_test_helpers import (
-    FakeLogger,
     _ErrorProvider,
     _SuccessProvider,
+    FakeLogger,
 )
-
 
 pytestmark = pytest.mark.usefixtures("socket_enabled")
 

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
@@ -8,11 +8,11 @@ from src.llm_adapter.provider_spi import ProviderSPI
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig
 
 from ._runner_test_helpers import (
-    FakeLogger,
     _ErrorProvider,
     _run_and_collect,
     _SkipProvider,
     _SuccessProvider,
+    FakeLogger,
 )
 
 

--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -1,11 +1,11 @@
 import json
+from pathlib import Path
 import sys
 import threading
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from src.llm_adapter.metrics import PrometheusMetricsExporter, log_event
+from src.llm_adapter.metrics import log_event, PrometheusMetricsExporter
 
 
 @pytest.mark.parametrize("thread_count,event_per_thread", [(8, 200)])

--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import Callable, Mapping
+import json
 from pathlib import Path
 from typing import Any, TypeVar
 
-import pytest
 from _pytest.recwarn import WarningsRecorder
+import pytest
 from src.llm_adapter.errors import RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -8,9 +8,9 @@ from src.llm_adapter.provider_spi import (
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
+    compute_consensus,
     ConsensusResult,
     ParallelExecutionError,
-    compute_consensus,
 )
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from enum import Enum
+import time
 
 import pytest
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import time
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
+import json
 from pathlib import Path
+import time
 from typing import Any
 
 import pytest
@@ -15,9 +15,9 @@ from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
+    compute_consensus,
     ConsensusConfig,
     ParallelExecutionError,
-    compute_consensus,
     run_parallel_all_async,
     run_parallel_all_sync,
     run_parallel_any_sync,

--- a/projects/04-llm-adapter-shadow/tests/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
+import json
 from pathlib import Path
 from typing import Any
 

--- a/projects/04-llm-adapter-shadow/tools/consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tools/consume_cases.py
@@ -1,11 +1,10 @@
 """Utility script to aggregate Node pipeline outputs for the shadow adapter demo."""
-
 from __future__ import annotations
 
 import argparse
-import json
 from collections import Counter
 from collections.abc import Iterable, Mapping, MutableMapping
+import json
 from pathlib import Path
 from typing import Any
 

--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable, Iterable
 from functools import lru_cache
 from importlib import import_module
+import sys
 from types import ModuleType
 from typing import TypeVar
 

--- a/projects/04-llm-adapter/adapter/cli/doctor.py
+++ b/projects/04-llm-adapter/adapter/cli/doctor.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import closing
 import http.client
 import os
+from pathlib import Path
 import platform
 import socket
 import sys
-from contextlib import closing
-from pathlib import Path
 from types import ModuleType
 
 from .utils import (
-    EXIT_ENV_ERROR,
-    EXIT_OK,
     _coerce_exit_code,
     _msg,
     _resolve_lang,
+    EXIT_ENV_ERROR,
+    EXIT_OK,
 )
 
 

--- a/projects/04-llm-adapter/adapter/cli/prompt_io.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_io.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import json
 from collections.abc import Iterable
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .utils import LOGGER, _msg, _sanitize_message
+from .utils import _msg, _sanitize_message, LOGGER
 
 if TYPE_CHECKING:
     from .prompt_runner import PromptResult

--- a/projects/04-llm-adapter/adapter/cli/prompt_runner.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_runner.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+import time
 from typing import cast
 
 from adapter.core import providers as provider_module
 from adapter.core.config import ProviderConfig
-from adapter.core.metrics import RunMetric, estimate_cost
+from adapter.core.metrics import estimate_cost, RunMetric
 
-from .utils import LOGGER, _sanitize_message
+from .utils import _sanitize_message, LOGGER
 
 ProviderResponse = provider_module.ProviderResponse
 Classifier = Callable[[Exception, ProviderConfig, str], tuple[str, str]]

--- a/projects/04-llm-adapter/adapter/cli/prompts.py
+++ b/projects/04-llm-adapter/adapter/cli/prompts.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections.abc import Iterable
 import os
+from pathlib import Path
 import socket
 import textwrap
-from collections.abc import Iterable
-from pathlib import Path
 
 from adapter.core import providers as provider_module
-from adapter.core.config import ProviderConfig, load_provider_config
+from adapter.core.config import load_provider_config, ProviderConfig
 
 from .prompt_io import collect_prompts, emit_results, write_metrics
-from .prompt_runner import PromptResult, RateLimiter, execute_prompts
+from .prompt_runner import execute_prompts, PromptResult, RateLimiter
 from .utils import (
+    _coerce_exit_code,
+    _configure_logging,
+    _msg,
+    _resolve_lang,
+    _sanitize_message,
     EXIT_ENV_ERROR,
     EXIT_INPUT_ERROR,
     EXIT_NETWORK_ERROR,
@@ -21,11 +26,6 @@ from .utils import (
     EXIT_PROVIDER_ERROR,
     EXIT_RATE_LIMIT,
     LOGGER,
-    _coerce_exit_code,
-    _configure_logging,
-    _msg,
-    _resolve_lang,
-    _sanitize_message,
 )
 
 ProviderFactory = provider_module.ProviderFactory

--- a/projects/04-llm-adapter/adapter/core/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/__init__.py
@@ -15,22 +15,22 @@ from .budgets import BudgetManager  # noqa: F401
 from .config import (  # noqa: F401
     BudgetBook,
     BudgetRule,
-    ProviderConfig,
     load_budget_book,
     load_provider_config,
     load_provider_configs,
+    ProviderConfig,
 )
 from .datasets import GoldenTask, load_golden_tasks  # noqa: F401
 from .metrics import (  # noqa: F401
     BudgetSnapshot,
-    EvalMetrics,
-    RunMetric,
-    RunMetrics,
     compute_cost_usd,
     compute_diff_rate,
     estimate_cost,
+    EvalMetrics,
     hash_text,
     now_ts,
+    RunMetric,
+    RunMetrics,
 )
 from .providers import ProviderFactory  # noqa: F401
 from .runners import CompareRunner  # noqa: F401

--- a/projects/04-llm-adapter/adapter/core/aggregation.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, cast, Protocol, runtime_checkable
 
 # 依存は実行時読み込み。型は実体を使う（mypy用に直import）
 try:  # pragma: no cover - 実環境では src.* が存在する

--- a/projects/04-llm-adapter/adapter/core/budgets.py
+++ b/projects/04-llm-adapter/adapter/core/budgets.py
@@ -1,5 +1,4 @@
 """予算制御ロジック。"""
-
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/projects/04-llm-adapter/adapter/core/config.py
+++ b/projects/04-llm-adapter/adapter/core/config.py
@@ -1,5 +1,4 @@
 """設定ファイル関連の公開 API ファサード。"""
-
 from __future__ import annotations
 
 from .loader import ConfigError, load_budget_book, load_provider_config, load_provider_configs

--- a/projects/04-llm-adapter/adapter/core/datasets.py
+++ b/projects/04-llm-adapter/adapter/core/datasets.py
@@ -1,12 +1,11 @@
 """データセット読み込みとプロンプト整形。"""
-
 from __future__ import annotations
 
-import json
-import re
 from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
+import json
 from pathlib import Path
+import re
 
 _PROMPT_PATTERN = re.compile(r"{{\s*(?P<key>[a-zA-Z0-9_\.]+)\s*}}")
 

--- a/projects/04-llm-adapter/adapter/core/loader.py
+++ b/projects/04-llm-adapter/adapter/core/loader.py
@@ -1,5 +1,4 @@
 """設定ファイルの読み込みユーティリティ。"""
-
 from __future__ import annotations
 
 from collections.abc import Iterable, MutableMapping

--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -1,13 +1,12 @@
 """メトリクス関連ユーティリティ。"""
-
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, UTC
+import hashlib
 from statistics import median
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 

--- a/projects/04-llm-adapter/adapter/core/models.py
+++ b/projects/04-llm-adapter/adapter/core/models.py
@@ -1,5 +1,4 @@
 """設定モデルの dataclass 定義。"""
-
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/projects/04-llm-adapter/adapter/core/providers/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/providers/__init__.py
@@ -1,11 +1,10 @@
 """プロバイダとのインタフェース。"""
-
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
 import logging
 import time
-from dataclasses import dataclass
 from typing import Any
 
 from ..config import ProviderConfig

--- a/projects/04-llm-adapter/adapter/core/providers/gemini.py
+++ b/projects/04-llm-adapter/adapter/core/providers/gemini.py
@@ -1,11 +1,10 @@
 """Google Gemini プロバイダ実装。"""
-
 from __future__ import annotations
 
+from collections.abc import Mapping, MutableMapping, Sequence
 import os
 import textwrap
 import time
-from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any
 
 from ..config import ProviderConfig

--- a/projects/04-llm-adapter/adapter/core/providers/openai.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai.py
@@ -1,22 +1,21 @@
 """OpenAI プロバイダ実装。"""
-
 from __future__ import annotations
 
+from collections.abc import Mapping, MutableMapping
 import os
 import time
-from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from ..config import ProviderConfig
 from . import BaseProvider, ProviderResponse
 from .openai_utils import (
-    OpenAIClientFactory,
     build_chat_messages,
     build_system_user_contents,
     coerce_raw_output,
     determine_modes,
     extract_text_from_response,
     extract_usage_tokens,
+    OpenAIClientFactory,
 )
 
 __all__ = ["OpenAIProvider"]

--- a/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai_utils.py
@@ -1,6 +1,5 @@
 # mypy: ignore-errors
 """OpenAI プロバイダ用ユーティリティ。"""
-
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -1,20 +1,19 @@
 """共通ランナー API."""
-
 from __future__ import annotations
 
-import inspect
-import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
+import inspect
+import logging
 from pathlib import Path
-from typing import Literal, cast
+from typing import cast, Literal
 
 from .budgets import BudgetManager
 from .config import (
-    ProviderConfig,
     load_budget_book,
     load_provider_config,
     load_provider_configs,
+    ProviderConfig,
 )
 from .datasets import load_golden_tasks
 from .runners import CompareRunner

--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -1,19 +1,18 @@
 """比較ランナーの実装。"""
-
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
 import json
 import logging
 import os
-import re
-import uuid
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, replace
 from pathlib import Path
+import re
 from statistics import median, pstdev
 from threading import Lock
 from time import perf_counter, sleep
 from typing import TYPE_CHECKING
+import uuid
 
 try:  # pragma: no cover - 実環境では src.* が存在する
     from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse
@@ -74,12 +73,12 @@ from .config import ProviderConfig
 from .datasets import GoldenTask
 from .metrics import (
     BudgetSnapshot,
-    EvalMetrics,
-    RunMetrics,
     compute_diff_rate,
     estimate_cost,
+    EvalMetrics,
     hash_text,
     now_ts,
+    RunMetrics,
 )
 from .providers import BaseProvider, ProviderFactory, ProviderResponse
 

--- a/projects/04-llm-adapter/adapter/core/schema.py
+++ b/projects/04-llm-adapter/adapter/core/schema.py
@@ -1,5 +1,4 @@
 """設定ファイル検証用の Pydantic モデル。"""
-
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -1,5 +1,4 @@
 """比較ランナー CLI。"""
-
 from __future__ import annotations
 
 import argparse

--- a/projects/04-llm-adapter/tests/conftest.py
+++ b/projects/04-llm-adapter/tests/conftest.py
@@ -1,5 +1,5 @@
-import sys
 from pathlib import Path
+import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:

--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -1,10 +1,10 @@
 import asyncio
 import json
 import os
+from pathlib import Path
 import subprocess
 import sys
 import types
-from pathlib import Path
 
 from adapter import cli as cli_module
 from adapter.cli import prompt_runner

--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from adapter.core.config import ConfigError, load_provider_config
 
 

--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 
 from adapter.core.budgets import BudgetManager
+from adapter.core.datasets import GoldenTask
+from adapter.core.metrics import BudgetSnapshot
 from adapter.core.models import (
     BudgetBook,
     BudgetRule,
@@ -14,8 +16,6 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.datasets import GoldenTask
-from adapter.core.metrics import BudgetSnapshot
 from adapter.core.providers import BaseProvider, ProviderResponse
 from adapter.core.runners import CompareRunner
 

--- a/projects/04-llm-adapter/tools/report/metrics/cli.py
+++ b/projects/04-llm-adapter/tools/report/metrics/cli.py
@@ -1,5 +1,4 @@
 """Command line entry points for the metrics report generator."""
-
 from __future__ import annotations
 
 import argparse

--- a/projects/04-llm-adapter/tools/report/metrics/data.py
+++ b/projects/04-llm-adapter/tools/report/metrics/data.py
@@ -1,10 +1,9 @@
 """Data loading and aggregation helpers for metrics reports."""
-
 from __future__ import annotations
 
-import json
 from collections import Counter
 from collections.abc import Mapping, Sequence
+import json
 from pathlib import Path
 from statistics import mean, median
 

--- a/projects/04-llm-adapter/tools/report/metrics/html_report.py
+++ b/projects/04-llm-adapter/tools/report/metrics/html_report.py
@@ -1,9 +1,8 @@
 """HTML report templating utilities for metrics outputs."""
-
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping, Sequence
+import json
 from string import Template
 
 

--- a/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
@@ -1,9 +1,8 @@
 """Regression summary HTML generation for metrics reports."""
-
 from __future__ import annotations
 
-import html
 from collections.abc import Mapping, Sequence
+import html
 from pathlib import Path
 
 from .data import load_baseline_expectations

--- a/projects/04-llm-adapter/tools/report/metrics/render.py
+++ b/projects/04-llm-adapter/tools/report/metrics/render.py
@@ -1,5 +1,4 @@
 """Facade exports for metrics rendering helpers."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/projects/04-llm-adapter/tools/report/metrics/utils.py
+++ b/projects/04-llm-adapter/tools/report/metrics/utils.py
@@ -1,9 +1,8 @@
 """Shared helpers for metrics report processing."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import datetime, UTC
 
 
 def parse_iso_ts(value: object) -> datetime:

--- a/projects/04-llm-adapter/tools/report/metrics/weekly_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/weekly_summary.py
@@ -1,9 +1,8 @@
 """Weekly Markdown summary helpers for metrics reports."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import datetime, UTC
 from pathlib import Path
 
 

--- a/projects/04-llm-adapter/tools/report/metrics_to_html.py
+++ b/projects/04-llm-adapter/tools/report/metrics_to_html.py
@@ -1,5 +1,4 @@
 """Backward-compatible shim for the relocated metrics report CLI."""
-
 from __future__ import annotations
 
 from .metrics.cli import main

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -1,11 +1,10 @@
 """Utilities for deriving CI metrics from run history."""
-
 from __future__ import annotations
 
-import datetime as dt
 from collections import deque
 from collections.abc import Iterable
 from dataclasses import dataclass
+import datetime as dt
 from pathlib import Path
 
 from weekly_summary import load_runs, parse_iso8601  # type: ignore

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """Generate CI reliability snapshot in Markdown and JSON."""
-
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import datetime as dt
 import json
-from collections import Counter
 from pathlib import Path
 from typing import Any
 

--- a/tools/generate_gallery_snippets.py
+++ b/tools/generate_gallery_snippets.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Generate helper snippets for docs gallery pages."""
-
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 from collections.abc import Iterable
+import datetime as dt
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tools/plot_ci_metrics.py
+++ b/tools/plot_ci_metrics.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Generate CI pass rate and flaky trend chart (SVG)."""
-
 from __future__ import annotations
 
 import argparse

--- a/tools/update_readme_metrics.py
+++ b/tools/update_readme_metrics.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Update README metrics table from generated CI report."""
-
 from __future__ import annotations
 
 import argparse
-import json
 from datetime import datetime
+import json
 from pathlib import Path
 from typing import Any
 

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """Generate weekly QA summary markdown from run history and flaky ranking."""
-
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Iterable
 import csv
 import datetime as dt
 import json
-import re
-from collections import Counter
-from collections.abc import Iterable
 from pathlib import Path
+import re
 
 __all__ = [
     "parse_iso8601",

--- a/tools/weekly_summary/__main__.py
+++ b/tools/weekly_summary/__main__.py
@@ -1,11 +1,10 @@
 """CLI entry point for the weekly summary generator."""
-
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 from collections import Counter
 from collections.abc import Iterable
+import datetime as dt
 from pathlib import Path
 
 from . import (


### PR DESCRIPTION
## Summary
- remove the blank line between module docstrings and `from __future__ import annotations` so the future import stays at the very top across adapter modules and tools
- run Ruff import sorting to reflow surrounding imports after the adjustment

## Testing
- ruff check --select I --fix
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68da68bfc2a08321a5881a4567368806