### PR TITLE
Refine CLI test import grouping

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -7,8 +7,12 @@ import sys
 import types
 
 from adapter import cli as cli_module
-from adapter.cli import prompt_runner
-from adapter.cli import prompts as prompts_module
+from adapter.cli import (
+    prompt_runner,
+)
+from adapter.cli import (
+    prompts as prompts_module,
+)
 from adapter.core import providers as provider_module
 from adapter.core.models import (
     PricingConfig,


### PR DESCRIPTION
## Summary
- group the adapter CLI imports in the CLI test using a shared block structure for clarity

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68da720f1d208321ab8e3d47dc029bb2