### PR TITLE
Add runner config normalization tests for shadow project

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
+
+
+@pytest.mark.parametrize(
+    ("mode_value", "expected"),
+    [
+        ("sequential", RunnerMode.SEQUENTIAL),
+        ("parallel_any", RunnerMode.PARALLEL_ANY),
+        ("parallel_all", RunnerMode.PARALLEL_ALL),
+        ("consensus", RunnerMode.CONSENSUS),
+    ],
+)
+def test_runner_config_normalizes_mode(
+    mode_value: str, expected: RunnerMode
+) -> None:
+    config = RunnerConfig(mode=mode_value)
+    assert config.mode is expected
+
+
+def test_runner_config_accepts_enum_members() -> None:
+    config = RunnerConfig(mode=RunnerMode.CONSENSUS)
+    mutated = replace(config, mode=RunnerMode.SEQUENTIAL)
+    assert mutated.mode is RunnerMode.SEQUENTIAL
+    assert config.mode is RunnerMode.CONSENSUS


### PR DESCRIPTION
## Summary
- add a shadow test module for runner config behaviour with sorted imports
- cover string and enum mode normalization on RunnerConfig

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68da720f0c1483218dafbe39bbcfa754