### PR TITLE
style: format imports in ollama provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import pytest
-from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    RateLimitError,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
 


### PR DESCRIPTION
## Summary
- expand the import from `src.llm_adapter.errors` into a multi-line block to conform with Ruff's import formatting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68da720d013c8321ae3bd8964b40f54e