### PR TITLE
Organize imports in Ollama client tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import pytest
-from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
+from src.llm_adapter.errors import (
+    RateLimitError,
+    RetriableError,
+    TimeoutError,
+)
 from src.llm_adapter.providers._requests_compat import requests_exceptions
 from src.llm_adapter.providers.ollama_client import OllamaClient
 


### PR DESCRIPTION
## Summary
- wrap the `src.llm_adapter.errors` imports in a parenthesized block so the module-level imports follow the Ruff/Black grouping expectations

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68da720b1d50832193fdccf84790fec0