### PR TITLE
Refine CLI test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -7,12 +7,8 @@ import sys
 import types
 
 from adapter import cli as cli_module
-from adapter.cli import (
-    prompt_runner,
-)
-from adapter.cli import (
-    prompts as prompts_module,
-)
+from adapter.cli import prompt_runner
+from adapter.cli import prompts as prompts_module
 from adapter.core import providers as provider_module
 from adapter.core.models import (
     PricingConfig,


### PR DESCRIPTION
## Summary
- group the `adapter.cli` imports together in the CLI single prompt test
- tidy the surrounding import order to satisfy Ruff import rules

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68da782b4abc83218955513eb5e97578