### PR TITLE
style: normalize imports in Ollama client tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from src.llm_adapter.errors import (
-    RateLimitError,
-    RetriableError,
-    TimeoutError,
-)
+from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.providers._requests_compat import requests_exceptions
 from src.llm_adapter.providers.ollama_client import OllamaClient
 


### PR DESCRIPTION
## Summary
- flatten the error imports in `test_ollama_client.py` to match Ruff import sorting expectations

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68da7828d1088321ad14f294241c0c59