### PR TITLE
Format provider imports in test runners helper

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,7 +16,10 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import BaseProvider, ProviderResponse
+from adapter.core.providers import (
+    BaseProvider,
+    ProviderResponse,
+)
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- format the provider import block in the test helper to follow the multi-line style

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68da782d69488321a20444789164d157