### PR TITLE
Annotate third-party import grouping in CLI runner config test

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+# Third-party
 import pytest
 
 from adapter import run_compare as run_compare_module


### PR DESCRIPTION
## Summary
- add a comment to clarify the third-party import section in the CLI runner config tests

## Testing
- `ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68da782a1b34832187b1f73663898c76