### PR TITLE
style: normalize imports in ollama provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from src.llm_adapter.errors import (
-    AuthError,
-    RateLimitError,
-    TimeoutError,
-)
+from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
 


### PR DESCRIPTION
## Summary
- condense the llm adapter error imports into a single line to keep the block sorted per Ruff expectations

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_68da7827f3fc8321a9e03df8a0a3cb26