### PR TITLE
Adjust import sorting for Ollama offline tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pytest
+
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
-
 from tests.helpers import fakes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ ignore = ["E501"]
 
 [tool.ruff.lint.isort]
 force-single-line = false
-known-first-party = ["llm_adapter"]
+known-first-party = ["llm_adapter", "src.llm_adapter"]
 order-by-type = false
 force-sort-within-sections = true
 


### PR DESCRIPTION
## Summary
- configure Ruff to recognize `src.llm_adapter` as a first-party module for import sorting
- reorganize imports in the Ollama offline provider test to separate third-party and local modules

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py`


------
https://chatgpt.com/codex/tasks/task_e_68da782742bc832189b16f1eec3e76d2