### PR TITLE
Fix import grouping in shadow runner config tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 import pytest
+
 from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 
 


### PR DESCRIPTION
## Summary
- ensure the shadow runner config test file keeps third-party and local imports in separate groups

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11e812c83218b5ffadace63b576