### PR TITLE
Fix import grouping in adapter config test

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import (
-    ConfigError,
-    load_provider_config,
-)
+from adapter.core.config import ConfigError, load_provider_config
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- sort the adapter core config imports alphabetically in the config acceptance test

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11d21dc83219fa71c3be7da620c