### PR TITLE
Normalize provider import order in runner helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,10 +16,7 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import (
-    BaseProvider,
-    ProviderResponse,
-)
+from adapter.core.providers import BaseProvider, ProviderResponse
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- normalize the adapter.core.providers import statement in the runner helper tests to match isort ordering

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11cf7c4832183353a169848aa37