### PR TITLE
Organize imports in CLI runner test

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 # Third-party
 import pytest
 
+# First-party
 from adapter import run_compare as run_compare_module
 from adapter.cli import doctor
 from adapter.core import runner_api


### PR DESCRIPTION
## Summary
- group the CLI runner config test imports by origin while keeping existing comments

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11af3048321964116dc7604895e