### PR TITLE
Fix import grouping in CLI runner config test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 import pytest
+
 from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 
 


### PR DESCRIPTION
## Summary
- ensure the test module separates third-party and local imports to satisfy Ruff import sorting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68daa1191d288321b9a138c1fa088685