### PR TITLE
Adjust import grouping for CLI tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -7,8 +7,10 @@ import sys
 import types
 
 from adapter import cli as cli_module
-from adapter.cli import prompt_runner
-from adapter.cli import prompts as prompts_module
+from adapter.cli import (
+    prompt_runner,
+    prompts as prompts_module,
+)
 from adapter.core import providers as provider_module
 from adapter.core.models import (
     PricingConfig,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ select = ["E", "F", "B", "I", "UP"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
+combine-as-imports = true
 force-single-line = false
 known-first-party = ["llm_adapter", "src.llm_adapter", "src", "tests"]
 order-by-type = false


### PR DESCRIPTION
## Summary
- enable combining aliased imports in the Ruff isort configuration
- consolidate adapter.cli test imports into a single grouped statement

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11326688321bac288018d72c60a