### PR TITLE
Reformat pathlib import in config tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -1,4 +1,6 @@
-from pathlib import Path
+from pathlib import (
+    Path,
+)
 
 import pytest
 


### PR DESCRIPTION
## Summary
- format the pathlib import in `test_config_accepts_str.py` using parentheses for consistency

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daa112f1c88321b91aac7045b7da58