### PR TITLE
Add comment to clarify standard library imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# Standard library
 from pathlib import Path
 from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- add a comment labeling the standard-library imports in `test_cli_runner_config`

## Testing
- `ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa1116dd883219f79c3d388a78ac6