### PR TITLE
Sort imports in parallel runner test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -9,8 +9,13 @@ import time
 from typing import Any
 
 import pytest
+
 from src.llm_adapter.errors import RateLimitError, TimeoutError
-from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
+from src.llm_adapter.provider_spi import (
+    ProviderRequest,
+    ProviderResponse,
+    TokenUsage,
+)
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode


### PR DESCRIPTION
## Summary
- reorder imports in `test_runner_parallel.py` to follow standard grouping and formatting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68daa110a8688321a0688410edcaedf1