### PR TITLE
Reorder imports in test runner modes test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_modes.py
@@ -5,6 +5,7 @@ from enum import Enum
 import time
 
 import pytest
+
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import ParallelExecutionError


### PR DESCRIPTION
## Summary
- reorder the test module imports to group standard library, third-party, and local modules

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_runner_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68daa10e98e48321acb7b208f67c984c