### PR TITLE
style: organize imports in consensus test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,4 +1,5 @@
 import pytest
+
 from src.llm_adapter.errors import RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,


### PR DESCRIPTION
## Summary
- ensure the pytest import is separated from local modules in the consensus test suite

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/test_runner_consensus.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa10e30888321baeb61f3f1944a4e