### PR TITLE
chore: sort imports in metrics threadsafe test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py
@@ -5,6 +5,7 @@ import threading
 from types import SimpleNamespace
 
 import pytest
+
 from src.llm_adapter.metrics import log_event, PrometheusMetricsExporter
 
 


### PR DESCRIPTION
## Summary
- reorder the imports in the metrics threadsafe test to follow the standard/third-party/local grouping

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_metrics_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68daa10a79748321992f7364da13ab15