### PR TITLE
Simplify config test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import (
-    ConfigError,
-    load_provider_config,
-)
+from adapter.core.config import ConfigError, load_provider_config
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- flatten the adapter config imports in the config acceptance test for correct grouping

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daa10939e883219534d0d4037223f5