### PR TITLE
Align import grouping in err case tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_err_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_err_cases.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from src.llm_adapter.errors import TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.providers.mock import MockProvider


### PR DESCRIPTION
## Summary
- separate standard library, third-party, and local imports in the err case tests

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/test_err_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa109fed48321882a96fb22b166e1