### PR TITLE
style: reorder imports in test runner sync

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import pytest
+
 from src.llm_adapter.errors import AuthError, RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderSPI
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig


### PR DESCRIPTION
## Summary
- ensure third-party and local imports are separated in the sync test runner

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa1065e70832182662e51de418541