### PR TITLE
chore: sort imports in async runner shadow tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pytest
+
 from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.runner import AsyncRunner
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import ParallelExecutionError
-
 from tests.shadow._runner_test_helpers import (
     _ErrorProvider,
     _SuccessProvider,


### PR DESCRIPTION
## Summary
- reorder imports in the async runner shadow test to satisfy Ruff import sorting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/shadow/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68daa105e8a883218fc059b1b4c24326