### PR TITLE
chore: sort imports in provider normalization test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
+
 from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.provider_spi import ProviderRequest
 


### PR DESCRIPTION
## Summary
- group standard-library imports together in the provider normalization test
- separate third-party and local imports to satisfy Ruff import sorting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68daa104349c832191491ccf0fc3f081