### PR TITLE
Organize imports in shadow runner test helper

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 import pytest
+
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from src.llm_adapter.runner import Runner


### PR DESCRIPTION
## Summary
- group the pytest import before project imports in the shadow runner test helper

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68daa10430bc8321ba2e105780a9a82f