### PR TITLE
Format provider SPI contract test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
+
+from src.llm_adapter.provider_spi import (
+    ProviderRequest,
+    ProviderResponse,
+    TokenUsage,
+)
 
 
 def test_provider_request_builds_messages_from_prompt(provider_request_model):


### PR DESCRIPTION
## Summary
- format imports in the provider SPI contract test to follow ruff isort grouping
- switch the provider SPI import to a parenthesized multi-line style for readability

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68daa102e7d08321a85864d352162212