### PR TITLE
Fix import grouping in provider factory tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from src.llm_adapter.provider_spi import ProviderSPI
 from src.llm_adapter.providers import factory as providers_factory
 


### PR DESCRIPTION
## Summary
- insert a blank line to separate third-party and local imports in the provider factory tests

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_parse_and_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68daa101636c83219e7036685f4562f3