### PR TITLE
style: organize imports in Ollama provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pytest
+
 from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
-
 from tests.helpers.fakes import FakeResponse, FakeSession
 
 


### PR DESCRIPTION
## Summary
- ensure pytest imports are separated from first-party modules
- align the ollama provider test imports with the repository's ruff configuration

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa100a7b083218ff0f3306ed29ee4