### PR TITLE
Fix import ordering in async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -7,9 +7,6 @@ import time
 from typing import Any, cast
 
 from ._event_loop import ensure_socket_free_event_loop_policy
-
-ensure_socket_free_event_loop_policy()
-
 from .errors import (
     FatalError,
     ProviderSkip,
@@ -47,6 +44,8 @@ from .runner_shared import (
 )
 from .shadow import DEFAULT_METRICS_PATH, run_with_shadow_async, ShadowMetrics
 from .utils import content_hash, elapsed_ms
+
+ensure_socket_free_event_loop_policy()
 
 WorkerResult = tuple[
     int,


### PR DESCRIPTION
## Summary
- move all module imports to the top of `runner_async.py`
- invoke `ensure_socket_free_event_loop_policy()` immediately after the imports to satisfy linting

## Testing
- ruff check --select E402 projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68daa0fe80dc8321b57618e06573c7c1