### PR TITLE
Fix import formatting in adapter package

### DIFF
--- a/projects/04-llm-adapter-shadow/adapter/__init__.py
+++ b/projects/04-llm-adapter-shadow/adapter/__init__.py
@@ -1,4 +1,5 @@
 """Shadow adapter package exposing config loading helpers for tests."""
-from .core.config import ConfigError, ProviderConfig, load_provider_config
+
+from .core.config import ConfigError, load_provider_config, ProviderConfig
 
 __all__ = ["ConfigError", "ProviderConfig", "load_provider_config"]


### PR DESCRIPTION
## Summary
- insert a blank line between the package docstring and imports in the adapter module
- reorder the adapter import list to satisfy Ruff's import sorting rules

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/adapter/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68daa0fcad4083218baf7dfbac9d8e14