### PR TITLE
Fix UP035 lint in adapter config imports

### DIFF
--- a/projects/04-llm-adapter-shadow/adapter/core/config.py
+++ b/projects/04-llm-adapter-shadow/adapter/core/config.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from os import PathLike
 from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
+from typing import Any
 
 import yaml
 


### PR DESCRIPTION
## Summary
- move Mapping and MutableMapping imports to collections.abc per ruff UP035

## Testing
- ruff check --select UP035 projects/04-llm-adapter-shadow/adapter/core/config.py

------
https://chatgpt.com/codex/tasks/task_e_68daa0fdbbc8832183886d981b26c62b