### PR TITLE
style: tidy imports in config tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import (
-    ConfigError,
-    load_provider_config,
-)
+from adapter.core.config import ConfigError, load_provider_config
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- collapse the adapter config imports in the string acceptance test into a single alphabetized statement

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daa11f28b08321ad2283304d3efcb4