### PR TITLE
Organize imports in Ollama client tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pytest
+
 from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.providers._requests_compat import requests_exceptions
 from src.llm_adapter.providers.ollama_client import OllamaClient
-
 from tests.helpers.fakes import FakeResponse, FakeSession
 
 


### PR DESCRIPTION
## Summary
- reorder the imports in the Ollama client tests to follow the standard, third-party, and local grouping

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68daa0fed9808321946663337998260c