### PR TITLE
docs: annotate import groupings in runner helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+# Standard library
 from pathlib import Path
 
+# Third-party
 import pytest
 
+# Application
 from adapter.core.budgets import BudgetManager
 from adapter.core.datasets import GoldenTask
 from adapter.core.metrics import BudgetSnapshot


### PR DESCRIPTION
## Summary
- add section comments to clarify import grouping in `test_runners_helpers`

## Testing
- `ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa11547588321a1923dd8b71ab6c1