### PR TITLE
chore: tidy imports in runners helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-# Standard library
 from pathlib import Path
 
-# Third-party
 import pytest
 
-# Application
 from adapter.core.budgets import BudgetManager
 from adapter.core.datasets import GoldenTask
 from adapter.core.metrics import BudgetSnapshot


### PR DESCRIPTION
## Summary
- reorder the test helper imports to match the expected grouping and remove redundant section comments

## Testing
- `ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa6abf2588321a119dfaa0ca7dcf9