### PR TITLE
Fix import order in config acceptance test

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -1,6 +1,4 @@
-from pathlib import (
-    Path,
-)
+from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder the pathlib import to be on a single line above pytest and adapter imports

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6aba3808321a4c894b9a06f4c25