### PR TITLE
chore: tidy runner_parallel imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
-from collections.abc import Callable as TypingCallable
+from collections.abc import (
+    Awaitable,
+    Callable,
+    Callable as TypingCallable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from concurrent.futures import (
     as_completed,
     FIRST_COMPLETED,


### PR DESCRIPTION
## Summary
- reformat the collections.abc imports in runner_parallel to a single consolidated block
- ensure standard library import statements are alphabetized for runner_parallel

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6a5bc108321807709c7ff438083