### PR TITLE
Reorder requests typing imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
@@ -48,8 +48,10 @@ requests_exceptions: RequestsExceptionsProtocol
 
 if typing.TYPE_CHECKING:  # pragma: no cover - typing time placeholders
     import requests as _requests_mod  # type: ignore[import-untyped]  # noqa: F401
-    from requests import exceptions as _RequestsExceptions  # noqa: F401
-    from requests import Response as _RequestsResponse  # noqa: F401
+    from requests import (
+        exceptions as _RequestsExceptions,  # noqa: F401
+        Response as _RequestsResponse,  # noqa: F401
+    )
 
 
 def _initialize_requests() -> tuple[


### PR DESCRIPTION
## Summary
- reorder the TYPE_CHECKING requests imports to satisfy Ruff's import-sorting rules while preserving existing comments

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6a4cfec8321a45c5b2d2479a33d