### PR TITLE
Refactor llm_adapter import grouping

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/__init__.py
@@ -1,11 +1,15 @@
-from .errors import AuthError as AuthError
-from .errors import FatalError as FatalError
-from .errors import RateLimitError as RateLimitError
-from .errors import RetriableError as RetriableError
-from .errors import TimeoutError as TimeoutError
-from .provider_spi import ProviderRequest as ProviderRequest
-from .provider_spi import ProviderResponse as ProviderResponse
-from .provider_spi import ProviderSPI as ProviderSPI
+from .errors import (
+    AuthError as AuthError,
+    FatalError as FatalError,
+    RateLimitError as RateLimitError,
+    RetriableError as RetriableError,
+    TimeoutError as TimeoutError,
+)
+from .provider_spi import (
+    ProviderRequest as ProviderRequest,
+    ProviderResponse as ProviderResponse,
+    ProviderSPI as ProviderSPI,
+)
 from .runner import Runner as Runner
 from .shadow import run_with_shadow as run_with_shadow
 


### PR DESCRIPTION
## Summary
- group llm_adapter error imports using a parenthesized block sorted alphabetically
- consolidate provider_spi imports into a single parenthesized statement

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/src/llm_adapter/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6a2f7308321868a9c5b32a6724c