### PR TITLE
Organize provider SPI imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py
@@ -7,9 +7,11 @@ import inspect
 from typing import Any, cast, Protocol
 import warnings
 
-from .utils import ensure_str_list
-from .utils import extract_prompt_from_messages as _extract_prompt_from_messages
-from .utils import normalize_message as _normalize_message
+from .utils import (
+    ensure_str_list,
+    extract_prompt_from_messages as _extract_prompt_from_messages,
+    normalize_message as _normalize_message,
+)
 
 normalize_message = _normalize_message
 extract_prompt_from_messages = _extract_prompt_from_messages


### PR DESCRIPTION
## Summary
- reorganize the provider SPI import block to match the repository lint configuration
- group the internal utils imports into a single parenthesized statement for clarity

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/src/llm_adapter/provider_spi.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa6a3da808321bf871f56fd79f4d6