### PR TITLE
chore: tidy imports in CLI runner config test

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -8,9 +8,9 @@ from types import SimpleNamespace
 import pytest
 
 # First-party
-from adapter import run_compare as run_compare_module
 from adapter.cli import doctor
 from adapter.core import runner_api
+import adapter.run_compare as run_compare_module
 
 
 def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- import the run_compare module via its package path
- reorder first-party imports in the CLI runner config test to keep alphabetical grouping

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6a81d288321993f855952e760c9