### PR TITLE
Refine CLI test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from types import SimpleNamespace
 
-from adapter import cli as cli_module
+import adapter.cli as cli_module
 from adapter.cli import (
     prompt_runner,
     prompts as prompts_module,


### PR DESCRIPTION
## Summary
- adjust the CLI test module import to use the module alias while keeping standard-library imports grouped alphabetically

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68daa6aa4d148321b7170391df890ec9