### PR TITLE
Refine import layout in config acceptance test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import ConfigError, load_provider_config
+from adapter.core.config import (
+    ConfigError,
+    load_provider_config,
+)
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- format the adapter config import over multiple lines to satisfy import-group ordering

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py`

------
https://chatgpt.com/codex/tasks/task_e_68daa6a6bc808321a575f096a158ea83