### PR TITLE
Fix import order in config test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import (
-    ConfigError,
-    load_provider_config,
-)
+from adapter.core.config import ConfigError, load_provider_config
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ ignore = ["E501"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-single-line = false
-known-first-party = ["llm_adapter", "src.llm_adapter", "src", "tests"]
+known-first-party = ["adapter", "llm_adapter", "src.llm_adapter", "src", "tests"]
 order-by-type = false
 force-sort-within-sections = true
 


### PR DESCRIPTION
## Summary
- sort the imports in `test_config_accepts_str.py` to follow the desired standard/third-party/first-party order
- register the `adapter` package as first-party so Ruff treats it correctly during import sorting

## Testing
- `ruff check --select I projects/04-llm-adapter-shadow/tests/test_config_accepts_str.py`


------
https://chatgpt.com/codex/tasks/task_e_68daad24fe4c8321831abc1d248938fa