### PR TITLE
Organize runner helper imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,7 +16,10 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import BaseProvider, ProviderResponse
+from adapter.core.providers import (
+    BaseProvider,
+    ProviderResponse,
+)
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- format the `adapter.core.providers` import in `test_runners_helpers.py` to align with the sorted import blocks

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68daad27e614832194439d9f74422d15