### PR TITLE
style: organize imports in config tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import ConfigError, load_provider_config
+from adapter.core.config import (
+    ConfigError,
+    load_provider_config,
+)
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- format the adapter config test imports to keep standard, third-party, and in-repo modules grouped

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68daad26c1b483219f804a4c493a377e