### PR TITLE
style: sort llm adapter test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -8,8 +8,8 @@ from types import SimpleNamespace
 import pytest
 
 # First-party
-from adapter.cli import doctor
-from adapter.core import runner_api
+import adapter.cli.doctor as doctor
+import adapter.core.runner_api as runner_api
 import adapter.run_compare as run_compare_module
 
 


### PR DESCRIPTION
## Summary
- reorder first-party imports in the CLI runner config test to keep them alphabetized

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68daad25c404832197c466f1097fec82