### PR TITLE
Refine parallel runner mode flag handling

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -337,7 +337,6 @@ class AsyncRunner:
             attempt_count = total_providers
 
             capture_shadow, retry_attempts = mode == RunnerMode.CONSENSUS, 0
-            is_parallel_any = mode == RunnerMode.PARALLEL_ANY
             attempt_labels = [index for index in range(1, total_providers + 1)]
             pending_retry_events: dict[int, dict[str, Any]] = {}
             limit = self._config.max_attempts


### PR DESCRIPTION
## Summary
- define the parallel-any mode flag once in AsyncRunner.run_async
- reuse the cached flag in parallel retry logic

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0ee65608321986032b04cefb257