### PR TITLE
Log retry delay for async parallel retries

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -375,6 +375,7 @@ class AsyncRunner:
                         "retry_attempt": retry_attempt,
                         "next_attempt": next_attempt_total,
                         "error_type": type(error).__name__,
+                        "delay_seconds": delay,
                     }
                 return next_attempt_total, delay
             def _build_worker(


### PR DESCRIPTION
## Summary
- include the computed retry delay in pending parallel retry events so observers can inspect the actual wait duration

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0ef03808321b851566878c9cb54