### PR TITLE
style: format gemini provider imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import (
+    Callable,
+    Mapping,
+)
 from types import SimpleNamespace
 from typing import Any, cast
 


### PR DESCRIPTION
## Summary
- format the collections.abc import in the Gemini provider tests using a multi-line block to comply with import-order linting

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py


------
https://chatgpt.com/codex/tasks/task_e_68dab0ef6e8c83218ecafcde0106d084