### PR TITLE
chore: organize ollama client test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -5,6 +5,8 @@ import pytest
 from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
 from src.llm_adapter.providers._requests_compat import requests_exceptions
 from src.llm_adapter.providers.ollama_client import OllamaClient
+
+# isort: split
 from tests.helpers.fakes import FakeResponse, FakeSession
 
 


### PR DESCRIPTION
## Summary
- add an isort split comment so the pytest, adapter, and helper imports stay in separate blocks

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f060f88321a75982760c6eb39f