### PR TITLE
style: sort imports in cli runner config tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-# Standard library
 from pathlib import Path
 from types import SimpleNamespace
 
-# Third-party
 import pytest
 
-# First-party
 import adapter.cli.doctor as doctor
 import adapter.core.runner_api as runner_api
 import adapter.run_compare as run_compare_module


### PR DESCRIPTION
## Summary
- reorder test imports to follow standard library, third-party, and project grouping

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_runner_config.py
- pytest -q projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f2d5cc8321ae35c5a5c1c4b240