### PR TITLE
Refine CLI test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -6,11 +6,12 @@ import subprocess
 import sys
 from types import SimpleNamespace
 
-import adapter.cli as cli_module
 from adapter.cli import (
     prompt_runner,
     prompts as prompts_module,
 )
+
+cli_module = sys.modules["adapter.cli"]
 from adapter.core import providers as provider_module
 from adapter.core.models import (
     PricingConfig,


### PR DESCRIPTION
## Summary
- derive the adapter.cli module reference via sys.modules while keeping a single grouped import block
- ensure the standard library imports remain alphabetized in the CLI single prompt test

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py
- pytest -q projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f3bbf083219522f79059957dd9