### PR TITLE
Tidy import order in config acceptance test

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import (
-    ConfigError,
-    load_provider_config,
-)
+from adapter.core.config import ConfigError, load_provider_config
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reorder the adapter config import to comply with the requested style

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py
- pytest -q projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f4103c832182d4cf60bf71716f