### PR TITLE
Adjust parallel any mode flag placement

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -248,7 +248,6 @@ class AsyncRunner:
         total_providers = len(providers)
 
         mode = RunnerMode(self._config.mode)
-        is_parallel_any = mode == RunnerMode.PARALLEL_ANY
         attempt_count = 0
         results: list[WorkerResult] | None = None
         failure_records: list[dict[str, str] | None] = [None] * total_providers


### PR DESCRIPTION
## Summary
- remove the early initialization of the parallel-any flag so the logic uses the value defined alongside the capture_shadow setup

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dab2633de8832181775ee5b08cd177