### PR TITLE
Normalize provider import formatting in runner helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,10 +16,7 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import (
-    BaseProvider,
-    ProviderResponse,
-)
+from adapter.core.providers import BaseProvider, ProviderResponse
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- collapse the provider import in `test_runners_helpers.py` to a single sorted line to match the surrounding import style

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py
- pytest -q projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f547688321bc03827b0fb3108c