### PR TITLE
chore: tidy ollama provider test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -11,7 +11,6 @@ from tests.helpers.fakes import FakeResponse, FakeSession
 def test_ollama_provider_prefers_base_url_over_legacy(monkeypatch):
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://env-base")
     monkeypatch.setenv("OLLAMA_HOST", "http://legacy-host")
-
     provider = OllamaProvider(
         "test-model",
         session=FakeSession(),
@@ -24,7 +23,6 @@ def test_ollama_provider_prefers_base_url_over_legacy(monkeypatch):
 def test_ollama_provider_legacy_host_fallback(monkeypatch):
     monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
     monkeypatch.setenv("OLLAMA_HOST", "http://legacy-host")
-
     provider = OllamaProvider(
         "test-model",
         session=FakeSession(),


### PR DESCRIPTION
## Summary
- tidy the top-level setup in the Ollama provider tests by removing redundant blank lines around the fixture setup

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f1df8c8321824ae8d6a459e804