### PR TITLE
Sort test helpers import in ollama offline test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -5,7 +5,7 @@ import pytest
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
-from tests.helpers import fakes
+import tests.helpers.fakes as fakes
 
 
 def test_ollama_offline_skips_without_custom_session(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- update the ollama offline test to import the helpers module via its package path so the project imports remain grouped after the third-party import

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68dab0f1a2448321ad1e1ab85f4daecc