### PR TITLE
Format error imports in Ollama provider test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    RateLimitError,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
 from tests.helpers.fakes import FakeResponse, FakeSession


### PR DESCRIPTION
## Summary
- format the error import list in the Ollama provider test to a multi-line block for consistency with import ordering

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py


------
https://chatgpt.com/codex/tasks/task_e_68dab266f9788321b739e806e474bc16