### PR TITLE
Align import grouping in Ollama offline test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -5,6 +5,8 @@ import pytest
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
+
+# isort: split
 from tests.helpers import fakes
 
 


### PR DESCRIPTION
## Summary
- separate internal tests helper import into its own section to satisfy Ruff import grouping rules

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68dab266ee388321be8f49da8563c98a