### PR TITLE
Fix undefined is_parallel_any guard in async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -248,6 +248,7 @@ class AsyncRunner:
         total_providers = len(providers)
 
         mode = RunnerMode(self._config.mode)
+        is_parallel_any = mode == RunnerMode.PARALLEL_ANY
         attempt_count = 0
         results: list[WorkerResult] | None = None
         failure_records: list[dict[str, str] | None] = [None] * total_providers


### PR DESCRIPTION
## Summary
- define `is_parallel_any` immediately after resolving the configured runner mode to reuse within the async runner

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3a6131c8321b7871638e8e1688b