### PR TITLE
Fix import grouping in runner helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,10 +16,7 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import (
-    BaseProvider,
-    ProviderResponse,
-)
+from adapter.core.providers import BaseProvider, ProviderResponse
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- adjust the adapter.core.providers import grouping in `test_runners_helpers.py` to comply with the requested ordering

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py
- pytest -q projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dab26a2d388321ad2631ac999c6d2c