### PR TITLE
Reorder runner config monkeypatch setup

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -61,8 +61,8 @@ def test_run_compare_sanitizes_runner_config(
     prompt_path.write_text("{}\n", encoding="utf-8")
     monkeypatch.setattr(
         runner_api,
-        "load_provider_configs",
-        lambda paths: ["cfg"],
+        "load_budget_book",
+        lambda path: "book",
     )
     monkeypatch.setattr(
         runner_api,
@@ -71,8 +71,8 @@ def test_run_compare_sanitizes_runner_config(
     )
     monkeypatch.setattr(
         runner_api,
-        "load_budget_book",
-        lambda path: "book",
+        "load_provider_configs",
+        lambda paths: ["cfg"],
     )
     monkeypatch.setattr(runner_api, "BudgetManager", lambda book: "budget")
     captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- reorder the mocked runner_api loader monkeypatches alphabetically within the test

## Testing
- pytest -q projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3ad3d988321bbdea29eeb984ff1