### PR TITLE
style: tidy ollama client test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from src.llm_adapter.errors import RateLimitError, RetriableError, TimeoutError
+from src.llm_adapter.errors import (
+    RateLimitError,
+    RetriableError,
+    TimeoutError,
+)
 from src.llm_adapter.providers._requests_compat import requests_exceptions
 from src.llm_adapter.providers.ollama_client import OllamaClient
 from tests.helpers.fakes import FakeResponse, FakeSession


### PR DESCRIPTION
## Summary
- format the error imports in `test_ollama_client.py` to a multi-line block for clarity while keeping the desired grouping order

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dab264f7e883218ee0da0ae63021b3