### PR TITLE
Document delay normalization in async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -361,6 +361,8 @@ class AsyncRunner:
                     return None
                 if delay is None:
                     return None
+                # ``delay`` must be reused so that we do not keep an unused helper
+                # variable when normalizing to a non-negative float.
                 delay = max(0.0, float(delay))
                 if limit is not None and next_attempt_total > limit:
                     return None


### PR DESCRIPTION
## Summary
- explain that the retry delay is normalized in-place to avoid unused helper variables

## Testing
- ruff check --select F841 projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
- pytest -q projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dab26373bc832194fdffc06fd2a008