### PR TITLE
style: annotate test helper import grouping

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -16,6 +16,8 @@ from src.llm_adapter.errors import (
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers import gemini as gemini_module
 from src.llm_adapter.providers.gemini import GeminiProvider
+
+# Test helpers
 from tests.helpers.fakes import RecordGeminiClient
 
 


### PR DESCRIPTION
## Summary
- add a clarifying comment to mark the test helper import grouping in the Gemini provider tests

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dab26491ac832193385c42b41e9866