### PR TITLE
Add comments to clarify import grouping in Ollama provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+# Third-party imports
 import pytest
 
+# First-party imports
 from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider


### PR DESCRIPTION
## Summary
- add explanatory comments separating third-party and first-party imports in the Ollama provider test module

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3aa745c8321829a39065f10e536