### PR TITLE
Reorder imports in Ollama offline test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -5,10 +5,7 @@ import pytest
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
-
-# isort: split
 from tests.helpers import fakes
-
 
 
 def test_ollama_offline_skips_without_custom_session(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- reorder the Ollama offline test imports to group third-party and local modules consistently

## Testing
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py


------
https://chatgpt.com/codex/tasks/task_e_68dab3ab75d4832182ded68b6ea34805