### PR TITLE
Reorder CLI test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_cli_single_prompt.py
+++ b/projects/04-llm-adapter/tests/test_cli_single_prompt.py
@@ -10,8 +10,6 @@ from adapter.cli import (
     prompt_runner,
     prompts as prompts_module,
 )
-
-cli_module = sys.modules["adapter.cli"]
 from adapter.core import providers as provider_module
 from adapter.core.models import (
     PricingConfig,
@@ -20,6 +18,8 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
+
+cli_module = sys.modules["adapter.cli"]
 
 
 def test_cli_help_smoke() -> None:


### PR DESCRIPTION
## Summary
- reorder the CLI single prompt test imports so standard library modules are grouped together and custom module access happens after all imports

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_cli_single_prompt.py
- pytest -q projects/04-llm-adapter/tests/test_cli_single_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3ac45848321a8b443e3fb6df93e