### PR TITLE
Normalize provider imports in runner helper tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_runners_helpers.py
+++ b/projects/04-llm-adapter/tests/test_runners_helpers.py
@@ -16,7 +16,10 @@ from adapter.core.models import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import BaseProvider, ProviderResponse
+from adapter.core.providers import (
+    BaseProvider,
+    ProviderResponse,
+)
 from adapter.core.runners import CompareRunner
 
 


### PR DESCRIPTION
## Summary
- format the adapter.core.providers import in the runner helper tests to follow the multi-line alphabetical convention

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_runners_helpers.py
- pytest -q projects/04-llm-adapter/tests/test_runners_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3ae0e0883219bf5f95106daa7c4