### PR TITLE
Organize imports in config tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_config_accepts_str.py
+++ b/projects/04-llm-adapter/tests/test_config_accepts_str.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from adapter.core.config import ConfigError, load_provider_config
+from adapter.core.config import (
+    ConfigError,
+    load_provider_config,
+)
 
 
 def test_cfg_accepts_str_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- format the adapter config imports in the config acceptance test to follow the desired grouping

## Testing
- ruff check --select I projects/04-llm-adapter/tests/test_config_accepts_str.py
- pytest -q projects/04-llm-adapter/tests/test_config_accepts_str.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3acfb048321b07026fd4a4ec144