### PR TITLE
chore: tidy gemini provider test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Mapping,
-)
+from collections.abc import Callable, Mapping
 from types import SimpleNamespace
 from typing import Any, cast
 


### PR DESCRIPTION
## Summary
- collapse the collections.abc import in the Gemini provider tests to maintain the expected import grouping

## Testing
- ruff check --select I projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
- pytest -q projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dab3a53728832199e3eb498aa9a0e4