### PR TITLE
chore: tidy ollama provider test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -5,7 +5,6 @@ import pytest
 
 # First-party imports
 from src.llm_adapter.errors import AuthError, RateLimitError, TimeoutError
-
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers.ollama import OllamaProvider
 from tests.helpers.fakes import FakeResponse, FakeSession


### PR DESCRIPTION
## Summary
- normalize import grouping in the Ollama provider test to satisfy Ruff sorting rules

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dab6c289bc83218c59e28837e8c92d