### PR TITLE
Add PyYAML dependency to shadow adapter project

### DIFF
--- a/projects/04-llm-adapter-shadow/pyproject.toml
+++ b/projects/04-llm-adapter-shadow/pyproject.toml
@@ -3,7 +3,7 @@ name = "portfolio-llm-adapter-shadow"
 version = "0.0.1"
 description = "Minimal shadow-execution + error-cases PoC for portfolio"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["PyYAML>=6.0"]
 
 [tool.pytest.ini_options]
 pythonpath = ["projects/04-llm-adapter-shadow"]

--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -5,3 +5,4 @@ pytest-timeout>=2.3.1
 pytest-socket>=0.6.0
 google-genai>=0.3
 requests>=2.31.0
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- declare PyYAML>=6.0 as a project dependency for the LLM adapter shadow package
- add PyYAML to the test requirements so the package is available in CI installs

## Testing
- pytest -vv -s --maxfail=1 --durations=20 --disable-socket projects/04-llm-adapter-shadow/tests


------
https://chatgpt.com/codex/tasks/task_e_68dab9b33b0c8321bf06ff05d379c7ba