### PR TITLE
Normalize spacing around docstrings and constants

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -1,4 +1,5 @@
 """トップレベル `adapter` パッケージのシム。"""
+
 from __future__ import annotations
 
 from importlib.util import module_from_spec, spec_from_file_location

--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -15,14 +15,11 @@ except ModuleNotFoundError:  # pragma: no cover - runtime fallback
 from .doctor import run_doctor
 from .prompts import run_prompts
 
-
 @lru_cache(maxsize=1)
 def _cli_namespace() -> ModuleType:
     return import_module(__name__.rsplit(".", 1)[0])
 
-
 T = TypeVar("T")
-
 
 def _with_cli_namespace(accessor: Callable[[ModuleType], T]) -> T:
     namespace = _cli_namespace()
@@ -117,7 +114,6 @@ else:  # pragma: no cover - exercised when Typer is unavailable
         if args and args[0] == "doctor":
             return doctor(args[1:])
         return run(args)
-
 
 __all__ = ["app", "doctor", "main", "run"]
 


### PR DESCRIPTION
## Summary
- insert an empty line between the adapter package docstring and first import
- collapse duplicate blank lines before top-level constants in the CLI module

## Testing
- uv tool run black adapter/__init__.py projects/04-llm-adapter/adapter/cli/app.py *(fails: unable to fetch black from PyPI in sandbox)*
- uv tool run black --check . *(fails: unable to fetch black from PyPI in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dab96199288321b2a8874a0bbbcf1a