### PR TITLE
Fix import ordering and satisfy ruff

### DIFF
--- a/projects/04-llm-adapter-shadow/adapter/core/config.py
+++ b/projects/04-llm-adapter-shadow/adapter/core/config.py
@@ -35,7 +35,7 @@ class ProviderConfig:
 def _coerce_path(config: str | Path | PathLike[str]) -> Path:
     if isinstance(config, Path):
         return config
-    if isinstance(config, (str, PathLike)):
+    if isinstance(config, str | PathLike):
         return Path(config)
     raise ConfigError("Config path must be a string or Path instance.")
 

--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:  # pragma: no cover - runtime fallback
 from .doctor import run_doctor
 from .prompts import run_prompts
 
+
 @lru_cache(maxsize=1)
 def _cli_namespace() -> ModuleType:
     return import_module(__name__.rsplit(".", 1)[0])


### PR DESCRIPTION
## Summary
- reorder the CLI application's standard-library imports so they conform to Ruff's expectations
- update the config path coercion helper to use the modern isinstance union syntax

## Testing
- uv run --no-project ruff check projects/04-llm-adapter/adapter/cli/app.py --fix
- uv run --no-project ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68dabc1bc5808321867725d1b2e52673