### PR TITLE
chore: remove black from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: pip install -r projects/04-llm-adapter-shadow/requirements.txt ruff mypy black
+        run: pip install -r projects/04-llm-adapter-shadow/requirements.txt ruff mypy
 
       - name: Run npm lint
         run: npm run lint:js
@@ -74,8 +74,6 @@ jobs:
       - name: Run ruff
         run: ruff check .
 
-      - name: Run black
-        run: black --check .
 
       - name: Run mypy
         run: mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 180
 target-version = "py311"


### PR DESCRIPTION
## Summary
- drop the Black installation and check from the lint workflow
- remove the obsolete Black configuration from pyproject.toml now that Ruff handles formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabf6688dc83218c464ddc34999962