### PR TITLE
Add ignore for pytest warns overload

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -131,7 +131,7 @@ T = TypeVar("T")
 
 def _run_without_warnings(action: Callable[[], T]) -> T:
     try:
-        warns_cm = pytest.warns(None)
+        warns_cm = pytest.warns(None)  # type: ignore[call-overload]
     except TypeError:
         warns_cm = WarningsRecorder(_ispytest=True)
     with warns_cm as warnings_record:


### PR DESCRIPTION
## Summary
- add an ignore comment to pytest.warns(None) in the async runner tests to satisfy mypy's call-overload check

## Testing
- mypy projects/04-llm-adapter-shadow *(fails: pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dac6d6c2108321a6eed17c911e9404