### PR TITLE
Add type annotations to provider SPI contract tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py
@@ -9,18 +9,22 @@ from src.llm_adapter.provider_spi import (
 )
 
 
-def test_provider_request_builds_messages_from_prompt(provider_request_model):
+def test_provider_request_builds_messages_from_prompt(
+    provider_request_model: str,
+) -> None:
     request = ProviderRequest(prompt="  hello ", model=provider_request_model)
     assert request.prompt_text == "hello"
     assert request.chat_messages == [{"role": "user", "content": "hello"}]
     assert request.stop is None
 
 
-def test_provider_request_normalizes_messages_and_stop(provider_request_model):
+def test_provider_request_normalizes_messages_and_stop(
+    provider_request_model: str,
+) -> None:
     request = ProviderRequest(
         prompt="",
         messages=[{"role": "User", "content": [" hi ", " there "]}],
-        stop=[" END ", ""],
+        stop=tuple([" END ", ""]),
         model=provider_request_model,
     )
     assert request.prompt_text == "hi"
@@ -28,24 +32,26 @@ def test_provider_request_normalizes_messages_and_stop(provider_request_model):
     assert request.stop == ("END",)
 
 
-def test_provider_request_timeout_defaults_to_30_seconds(provider_request_model):
+def test_provider_request_timeout_defaults_to_30_seconds(
+    provider_request_model: str,
+) -> None:
     request = ProviderRequest(model=provider_request_model)
     assert request.timeout_s == pytest.approx(30.0)
 
 
-def test_provider_request_rejects_empty_model():
+def test_provider_request_rejects_empty_model() -> None:
     with pytest.raises(ValueError):
         ProviderRequest(model="", prompt="hello")
     with pytest.raises(ValueError):
         ProviderRequest(model="   ", prompt="hello")
 
 
-def test_provider_request_requires_model_argument():
+def test_provider_request_requires_model_argument() -> None:
     with pytest.raises(ValueError):
         ProviderRequest(prompt="hello")
 
 
-def test_provider_response_populates_token_usage_from_inputs():
+def test_provider_response_populates_token_usage_from_inputs() -> None:
     response = ProviderResponse(text="ok", latency_ms=10, tokens_in=3, tokens_out=4)
     assert response.token_usage.prompt == 3
     assert response.token_usage.completion == 4
@@ -53,7 +59,7 @@ def test_provider_response_populates_token_usage_from_inputs():
     assert response.output_tokens == 4
 
 
-def test_provider_response_uses_token_usage_if_provided():
+def test_provider_response_uses_token_usage_if_provided() -> None:
     usage = TokenUsage(prompt=5, completion=7)
     response = ProviderResponse(text="ok", latency_ms=10, token_usage=usage)
     assert response.tokens_in == 5


### PR DESCRIPTION
## Summary
- add explicit return annotations and fixture types in provider SPI contract tests
- normalize stop sequences by wrapping in tuple to satisfy type hints

## Testing
- mypy --follow-imports=skip projects/04-llm-adapter-shadow/tests/providers/test_provider_spi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68dac6d2b9988321ab27ac578a233e66