### PR TITLE
Add YAML typing support for adapter configs

### DIFF
--- a/projects/04-llm-adapter-shadow/requirements.txt
+++ b/projects/04-llm-adapter-shadow/requirements.txt
@@ -6,3 +6,4 @@ pytest-socket>=0.6.0
 google-genai>=0.3
 requests>=2.31.0
 PyYAML>=6.0
+types-PyYAML>=6.0.12.20240311

--- a/projects/04-llm-adapter-shadow/yaml/__init__.pyi
+++ b/projects/04-llm-adapter-shadow/yaml/__init__.pyi
@@ -1,0 +1,36 @@
+from typing import Any, IO, Mapping, Sequence
+
+class Loader: ...
+
+class Dumper: ...
+
+class YAMLError(Exception):
+    ...
+
+def safe_load(stream: str | bytes | IO[str] | IO[bytes]) -> Any: ...
+
+def safe_dump(
+    data: Any,
+    stream: IO[str] | IO[bytes] | None = ...,
+    *,
+    default_flow_style: bool | None = ...,
+    encoding: str | None = ...,
+) -> str | bytes | None: ...
+
+def load(
+    stream: str | bytes | IO[str] | IO[bytes],
+    Loader: type[Loader] | None = ...,
+) -> Any: ...
+
+def dump(
+    data: Any,
+    stream: IO[str] | IO[bytes] | None = ...,
+    Dumper: type[Dumper] | None = ...,
+    *,
+    default_flow_style: bool | None = ...,
+    encoding: str | None = ...,
+) -> str | bytes | None: ...
+
+def safe_load_all(
+    stream: str | bytes | IO[str] | IO[bytes]
+) -> Sequence[Mapping[str, Any]]: ...

--- a/projects/04-llm-adapter/adapter/core/loader.py
+++ b/projects/04-llm-adapter/adapter/core/loader.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, MutableMapping
+from types import ModuleType
 from pathlib import Path
 from typing import cast
 
@@ -18,10 +19,14 @@ from .models import (
 )
 from .schema import ProviderConfigModel
 
+yaml: ModuleType | None
+
 try:  # pragma: no cover - 依存がある場合はこちらを利用
-    import yaml  # type: ignore
-except Exception:  # pragma: no cover - フォールバックで処理
+    import yaml as _yaml
+except ImportError:  # pragma: no cover - フォールバックで処理
     yaml = None
+else:  # pragma: no cover - 依存がある場合はこちらを利用
+    yaml = _yaml
 
 __all__ = [
     "ConfigError",


### PR DESCRIPTION
## Summary
- add the types-PyYAML stub dependency to the shadow adapter requirements and vendor a minimal stub so type checking can run offline
- switch the adapter loader to a regular `import yaml` guarded by an ImportError fallback to keep strict typing without ignores

## Testing
- mypy adapter/core/config.py

------
https://chatgpt.com/codex/tasks/task_e_68dac6d158308321943698bceb4a0b1a