### PR TITLE
Fix import ordering for ruff compliance

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from types import SimpleNamespace
-from typing import Any, NoReturn, cast
+from typing import Any, cast, NoReturn
 
 import pytest
 
@@ -16,8 +16,6 @@ from src.llm_adapter.errors import (
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.providers import gemini as gemini_module
 from src.llm_adapter.providers.gemini import GeminiProvider
-
-# Test helpers
 from tests.helpers.fakes import RecordGeminiClient
 
 

--- a/projects/04-llm-adapter-shadow/yaml/__init__.pyi
+++ b/projects/04-llm-adapter-shadow/yaml/__init__.pyi
@@ -1,4 +1,5 @@
-from typing import Any, IO, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, IO
 
 class Loader: ...
 

--- a/projects/04-llm-adapter/adapter/core/loader.py
+++ b/projects/04-llm-adapter/adapter/core/loader.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, MutableMapping
-from types import ModuleType
 from pathlib import Path
+from types import ModuleType
 from typing import cast
 
 from pydantic import ValidationError


### PR DESCRIPTION
## Summary
- reorder imports in test and loader modules to satisfy Ruff formatting
- import typing stubs from the preferred modules to silence Ruff hints

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68dacc6c88d4832188a7afd752072a61