### PR TITLE
Fix SearchStrategy import usage in shadow tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -9,9 +9,10 @@ from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.provider_spi import ProviderRequest
 
 hypothesis = pytest.importorskip("hypothesis")
+from hypothesis.strategies import SearchStrategy
+
 st = hypothesis.strategies
 given = hypothesis.given
-SearchStrategy = st.SearchStrategy
 
 
 def _message_entries() -> SearchStrategy[Mapping[str, Any]]:


### PR DESCRIPTION
## Summary
- import SearchStrategy directly from hypothesis.strategies in the shadow provider request tests
- remove the redundant alias now that the type is directly imported

## Testing
- python -m mypy projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68dad001a8948321970a8d4110080c22