### PR TITLE
Add ConnectionError to requests compatibility layer

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/_requests_compat.py
@@ -32,6 +32,7 @@ class RequestsExceptionsProtocol(Protocol):
     Timeout: type[Exception]
     RequestException: type[Exception]
     HTTPError: type[Exception]
+    ConnectionError: type[Exception]
 
 
 class _RequestsModuleProtocol(Protocol):
@@ -67,6 +68,8 @@ def _initialize_requests() -> tuple[
             class RequestException(Exception): ...
 
             class Timeout(RequestException): ...
+
+            class ConnectionError(RequestException): ...
 
             class HTTPError(RequestException):
                 def __init__(self, message: str | None = None, response: Any | None = None):

--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from src.llm_adapter.providers import ollama as ollama_module
 
@@ -46,7 +46,7 @@ class FakeResponse:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> bool:  # pragma: no cover - context protocol
+    ) -> Literal[False]:  # pragma: no cover - context protocol
         self.close()
         return False
 


### PR DESCRIPTION
## Summary
- expose ConnectionError on the requests exceptions protocol and fallback stub
- fix FakeResponse context manager typing to keep mypy happy

## Testing
- python -m mypy projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dad000f1288321ad547708a78a0d72