### PR TITLE
Fix mypy generator annotation in test fixture

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -1,6 +1,7 @@
-from pathlib import Path
 import sys
 import warnings
+from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
@@ -15,7 +16,7 @@ def _fast_mock_provider_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _suppress_provider_response_alias_deprecations() -> None:
+def _suppress_provider_response_alias_deprecations() -> Generator[None, None, None]:
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",


### PR DESCRIPTION
## Summary
- import Generator in the test fixture module to support typed yields
- annotate the provider response suppression fixture with Generator

## Testing
- mypy projects/04-llm-adapter-shadow/tests/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68dacff979848321a703a644c74c4ce2