### PR TITLE
Allow RunnerConfig.mode to accept string and Enum values

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -37,7 +37,7 @@ class BackoffPolicy:
 class RunnerConfig:
     backoff: BackoffPolicy = field(default_factory=BackoffPolicy)
     max_attempts: int | None = None
-    mode: RunnerMode = RunnerMode.SEQUENTIAL
+    mode: RunnerMode | str | Enum = RunnerMode.SEQUENTIAL
     max_concurrency: int | None = None
     rpm: int | None = None
     consensus: ConsensusConfig | None = None


### PR DESCRIPTION
## Summary
- widen RunnerConfig.mode type hint to accept strings and foreign Enum values while preserving normalization

## Testing
- mypy tests/test_runner_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68dacff7a40c8321aca9297d93d189c4