### PR TITLE
Fix FakeResponse context manager exit type annotation

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from src.llm_adapter.providers import ollama as ollama_module
 
@@ -46,7 +46,7 @@ class FakeResponse:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> bool:  # pragma: no cover - context protocol
+    ) -> Literal[False]:  # pragma: no cover - context protocol
         self.close()
         return False
 


### PR DESCRIPTION
## Summary
- import `Literal` in the fake response helper used in tests
- annotate `__exit__` to return `Literal[False]` to satisfy mypy's exit-return rule

## Testing
- python -m mypy projects/04-llm-adapter-shadow/tests/helpers/fakes.py

------
https://chatgpt.com/codex/tasks/task_e_68dacffb267c8321857ef474dbb29de2