### PR TITLE
Align FakeSession post signature with production type hints

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from src.llm_adapter.providers import ollama as ollama_module
 
@@ -46,7 +46,7 @@ class FakeResponse:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> bool:  # pragma: no cover - context protocol
+    ) -> Literal[False]:  # pragma: no cover - context protocol
         self.close()
         return False
 

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from src.llm_adapter.errors import ProviderSkip
@@ -21,7 +23,13 @@ def test_ollama_offline_allows_fake_session(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("LLM_ADAPTER_OFFLINE", "1")
 
     class Session(fakes.FakeSession):
-        def post(self, url, json=None, stream=False, timeout=None):  # type: ignore[override]
+        def post(
+            self,
+            url: str,
+            json: dict[str, Any] | None = None,
+            stream: bool = False,
+            timeout: float | None = None,
+        ) -> fakes.FakeResponse:
             self.calls.append((url, json, stream))
             if url.endswith("/api/show"):
                 return fakes.FakeResponse(status_code=200, payload={})


### PR DESCRIPTION
## Summary
- annotate the FakeSession.post override used in offline Ollama tests with the expected argument and return types
- drop the now-unnecessary ignore and adjust FakeResponse.__exit__ typing to satisfy mypy

## Testing
- python -m mypy projects/04-llm-adapter-shadow/tests/providers/test_ollama_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68dacfffc6348321a781693cef0a7b34