### PR TITLE
Fix CI report type handling

### DIFF
--- a/tools/weekly_summary/__main__.py
+++ b/tools/weekly_summary/__main__.py
@@ -17,6 +17,7 @@ from . import (
     filter_by_window,
     format_percentage,
     format_table,
+    coerce_str,
     load_flaky,
     load_runs,
     select_flaky_rows,
@@ -79,10 +80,11 @@ def _main_impl() -> None:
 
     failure_counter: Counter[str] = Counter()
     for run in current_runs:
-        status = (run.get("status") or "").lower()
+        status_raw = coerce_str(run.get("status"))
+        status = status_raw.lower() if status_raw is not None else ""
         if status not in {"fail", "failed", "error"}:
             continue
-        kind = run.get("failure_kind") or "unknown"
+        kind = coerce_str(run.get("failure_kind")) or "unknown"
         failure_counter[kind] += 1
 
     top_failure = compute_failure_top(failure_counter)
@@ -92,7 +94,11 @@ def _main_impl() -> None:
     previous_flaky = select_flaky_rows(flaky_rows, previous_start, current_start)
 
     def sort_flaky(rows: list[dict[str, object]]) -> list[dict[str, object]]:
-        return sorted(rows, key=lambda row: to_float(row.get("score")) or 0.0, reverse=True)
+        return sorted(
+            rows,
+            key=lambda row: to_float(coerce_str(row.get("score"))) or 0.0,
+            reverse=True,
+        )
 
     current_flaky_sorted = sort_flaky(current_flaky)[:5]
     previous_flaky_sorted = sort_flaky(previous_flaky)[:5]
@@ -100,14 +106,16 @@ def _main_impl() -> None:
     table_lines = format_table(current_flaky_sorted)
 
     entered, exited = week_over_week_notes(current_flaky_sorted, previous_flaky_sorted)
-    wow_delta = None
+    wow_delta: float | None = None
+    prev_rate_for_note: float | None = None
     if pass_rate is not None and prev_pass_rate is not None:
         wow_delta = (pass_rate - prev_pass_rate) * 100
+        prev_rate_for_note = prev_pass_rate
 
     notes: list[str] = []
-    if wow_delta is not None:
+    if wow_delta is not None and prev_rate_for_note is not None:
         notes.append(
-            f"PassRate WoW: {wow_delta:+.2f}pp (prev {prev_pass_rate * 100:.2f}%)."
+            f"PassRate WoW: {wow_delta:+.2f}pp (prev {prev_rate_for_note * 100:.2f}%)."
         )
     elif pass_rate is not None:
         notes.append(f"PassRate: {pass_rate * 100:.2f}% (過去週データ不足)")


### PR DESCRIPTION
## Summary
- ensure CI metrics helpers expose a shared `coerce_str` utility and use it when normalizing data from JSON/CSV inputs
- tighten type hints and numeric coercion in `generate_ci_report` and `ci_metrics` so status and score fields are safely parsed
- align the weekly summary CLI with the new coercion helpers to keep mypy strict mode passing

## Testing
- mypy --config-file pyproject.toml tools

------
https://chatgpt.com/codex/tasks/task_e_68dacff796b883218f44a14b3681af36