### PR TITLE
Fix ruff lint failures

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -1,7 +1,7 @@
-import sys
-import warnings
 from collections.abc import Generator
 from pathlib import Path
+import sys
+import warnings
 
 import pytest
 

--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from types import SimpleNamespace, TracebackType
-from typing import Any, Literal, cast
+from typing import Any, cast, Literal
 
 from src.llm_adapter.providers import ollama as ollama_module
 from src.llm_adapter.providers.gemini_client import (

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -9,9 +9,9 @@ from src.llm_adapter import provider_spi as provider_spi_module
 from src.llm_adapter.provider_spi import ProviderRequest
 
 hypothesis = pytest.importorskip("hypothesis")
-from hypothesis.strategies import SearchStrategy
 
 st = hypothesis.strategies
+SearchStrategy = hypothesis.strategies.SearchStrategy
 given = hypothesis.given
 
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 import json
 from pathlib import Path
 import time
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import pytest
 

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -157,7 +157,7 @@ def select_flaky_rows(
 def to_float(value: object) -> float | None:
     if isinstance(value, bool):
         return float(value)
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return float(value)
     if isinstance(value, str):
         if value == "":
@@ -174,7 +174,7 @@ def coerce_str(value: object) -> str | None:
         return value
     if isinstance(value, bool):
         return str(value)
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return str(value)
     return None
 

--- a/tools/weekly_summary/__main__.py
+++ b/tools/weekly_summary/__main__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from . import (
     aggregate_status,
     build_front_matter,
+    coerce_str,
     compute_failure_top,
     count_new_defects,
     extract_defect_dates,
@@ -19,7 +20,6 @@ from . import (
     format_table,
     load_flaky,
     load_runs,
-    coerce_str,
     select_flaky_rows,
     to_float,
     week_over_week_notes,


### PR DESCRIPTION
## Summary
- reorder and group imports in the llm adapter shadow tests to satisfy ruff
- tidy weekly summary imports and update isinstance checks to modern syntax

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68dad2be8ce48321b6e703cd066c0ce6