### PR TITLE
Fix weekly summary import lint issues

### DIFF
--- a/tools/weekly_summary/__main__.py
+++ b/tools/weekly_summary/__main__.py
@@ -18,7 +18,6 @@ from . import (
     filter_by_window,
     format_percentage,
     format_table,
-    coerce_str,
     load_flaky,
     load_runs,
     select_flaky_rows,


### PR DESCRIPTION
## Summary
- remove the duplicate `coerce_str` import in the weekly summary CLI module to satisfy linting

## Testing
- ruff check tools/weekly_summary/__main__.py

------
https://chatgpt.com/codex/tasks/task_e_68dad6a740508321880862a8ac11e074