### PR TITLE
Fix mypy issues in weekly summary and tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from src.llm_adapter.runner import ParallelAllResult, Runner
+from src.llm_adapter.runner_sync import ProviderInvocationResult
 from src.llm_adapter.runner_config import RunnerConfig
 
 
@@ -94,7 +95,12 @@ def _run_and_collect(
     prompt: str = "hello",
     expect_exception: type[Exception] | None = None,
     config: RunnerConfig | None = None,
-) -> tuple[ProviderResponse | ParallelAllResult[..., ProviderResponse] | None, FakeLogger]:
+) -> tuple[
+    ProviderResponse
+    | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+    | None,
+    FakeLogger,
+]:
     logger = FakeLogger()
     runner = Runner(list(providers), logger=logger, config=config)
     request = ProviderRequest(prompt=prompt, model="demo-model")

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_provider_request_normalization.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hypothesis.strategies import SearchStrategy
 
 import pytest
 
@@ -11,7 +14,6 @@ from src.llm_adapter.provider_spi import ProviderRequest
 hypothesis = pytest.importorskip("hypothesis")
 
 st = hypothesis.strategies
-SearchStrategy = hypothesis.strategies.SearchStrategy
 given = hypothesis.given
 
 

--- a/tools/weekly_summary/__main__.py
+++ b/tools/weekly_summary/__main__.py
@@ -118,7 +118,7 @@ def _main_impl() -> None:
         prev_rate_for_delta = previous_rate
 
     notes: list[str] = []
-    if wow_delta is not None and prev_pass_rate is not None:
+    if wow_delta is not None and prev_rate_for_delta is not None:
         notes.append(
             f"PassRate WoW: {wow_delta:+.2f}pp (prev {prev_rate_for_delta * 100:.2f}%)."
         )


### PR DESCRIPTION
## Summary
- ensure weekly summary notes only format previous pass rate when available
- tighten runner test helper typing by using ProviderInvocationResult instead of an ellipsis placeholder
- limit hypothesis SearchStrategy import to type-checking time in normalization test

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools

------
https://chatgpt.com/codex/tasks/task_e_68dad6c2976883218a1254e30a7f9626