### PR TITLE
Fix import ordering in shadow runner test helper

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py
@@ -8,8 +8,8 @@ import pytest
 from src.llm_adapter.errors import ProviderSkip
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from src.llm_adapter.runner import ParallelAllResult, Runner
-from src.llm_adapter.runner_sync import ProviderInvocationResult
 from src.llm_adapter.runner_config import RunnerConfig
+from src.llm_adapter.runner_sync import ProviderInvocationResult
 
 
 class FakeLogger:


### PR DESCRIPTION
## Summary
- organize the shadow runner test helper imports to satisfy Ruff ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/shadow/_runner_test_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dad88249b08321be025678b15014d5