### PR TITLE
Refactor weekly summary IO helpers

### DIFF
--- a/tests/tools/test_weekly_summary_io.py
+++ b/tests/tools/test_weekly_summary_io.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+root_str = str(ROOT)
+if root_str not in sys.path:
+    sys.path.insert(0, root_str)
+
+weekly_summary = importlib.import_module("tools.weekly_summary")
+legacy_load_runs = weekly_summary.load_runs
+legacy_load_flaky = weekly_summary.load_flaky
+
+
+@pytest.mark.parametrize(
+    "loader, filename, payload, expected",
+    [
+        (legacy_load_runs, "runs.jsonl", "{\"status\": \"pass\"}\n", [{"status": "pass"}]),
+        (
+            legacy_load_flaky,
+            "flaky.csv",
+            "canonical_id,score\na,0.1\n",
+            [{"canonical_id": "a", "score": "0.1"}],
+        ),
+    ],
+)
+def test_legacy_exports_continue_to_work(
+    tmp_path: Path, loader, filename: str, payload: str, expected: list[dict[str, object]]
+) -> None:
+    target = tmp_path / filename
+    target.write_text(payload, encoding="utf-8")
+    assert loader(target) == expected
+
+
+def test_io_module_provides_same_interfaces(tmp_path: Path) -> None:
+    io_module = importlib.import_module("tools.weekly_summary.io")
+    load_runs = io_module.load_runs
+    load_flaky = io_module.load_flaky
+    filter_by_window = io_module.filter_by_window
+
+    runs_path = tmp_path / "runs.jsonl"
+    runs_path.write_text(
+        "\n".join(
+            [
+                "{\"status\": \"pass\", \"ts\": \"2024-01-01T00:00:00+00:00\"}",
+                "{\"status\": \"fail\", \"ts\": \"2025-01-01T00:00:00+00:00\"}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    flaky_path = tmp_path / "flaky.csv"
+    flaky_path.write_text("canonical_id,score\na,0.1\n", encoding="utf-8")
+
+    runs = load_runs(runs_path)
+    flaky = load_flaky(flaky_path)
+    window = filter_by_window(
+        runs,
+        dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc),
+        dt.datetime(2024, 6, 1, tzinfo=dt.timezone.utc),
+    )
+
+    assert runs[0]["status"] == "pass"
+    assert flaky == [{"canonical_id": "a", "score": "0.1"}]
+    assert window == [runs[0]]

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Iterable
-import csv
 import datetime as dt
-import json
 from pathlib import Path
 import re
+
+from .io import (
+    coerce_str,
+    filter_by_window,
+    load_flaky,
+    load_runs,
+    parse_iso8601,
+)
 
 __all__ = [
     "parse_iso8601",
@@ -30,63 +36,6 @@ __all__ = [
     "fallback_write",
 ]
 
-ISO_RE = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})")
-
-
-def parse_iso8601(value: str | None) -> dt.datetime | None:
-    if not value:
-        return None
-    try:
-        if value.endswith("Z"):
-            value = value[:-1] + "+00:00"
-        return dt.datetime.fromisoformat(value)
-    except ValueError:
-        match = ISO_RE.match(value)
-        if match:
-            return dt.datetime.fromisoformat(match.group("date") + "T00:00:00+00:00")
-    return None
-
-
-def load_runs(path: Path) -> list[dict[str, object]]:
-    if not path.exists():
-        return []
-    runs: list[dict[str, object]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            runs.append(record)
-    return runs
-
-
-def load_flaky(path: Path) -> list[dict[str, object]]:
-    if not path.exists():
-        return []
-    rows: list[dict[str, object]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        for row in reader:
-            rows.append(row)
-    return rows
-
-
-def filter_by_window(
-    items: Iterable[dict[str, object]], start: dt.datetime, end: dt.datetime
-) -> list[dict[str, object]]:
-    results: list[dict[str, object]] = []
-    for item in items:
-        ts_value = coerce_str(item.get("ts"))
-        ts = parse_iso8601(ts_value)
-        if ts is None:
-            continue
-        if start <= ts < end:
-            results.append(item)
-    return results
 
 
 def aggregate_status(runs: Iterable[dict[str, object]]) -> tuple[int, int, int]:
@@ -150,17 +99,6 @@ def select_flaky_rows(
         if start.date() <= as_of_dt.date() < end.date():
             selected.append(row)
     return selected
-
-
-def coerce_str(value: object | None) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        stripped = value.strip()
-        return stripped or None
-    if isinstance(value, (int, float, bool)):
-        return str(value)
-    return None
 
 
 def to_float(value: object) -> float | None:

--- a/tools/weekly_summary/io.py
+++ b/tools/weekly_summary/io.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+ISO_RE = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})")
+
+__all__ = [
+    "parse_iso8601",
+    "coerce_str",
+    "load_runs",
+    "load_flaky",
+    "filter_by_window",
+]
+
+
+def parse_iso8601(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return dt.datetime.fromisoformat(value)
+    except ValueError:
+        match = ISO_RE.match(value)
+        if match:
+            return dt.datetime.fromisoformat(match.group("date") + "T00:00:00+00:00")
+    return None
+
+
+def coerce_str(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return None
+
+
+def load_runs(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    runs: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            runs.append(record)
+    return runs
+
+
+def load_flaky(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, object]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def filter_by_window(
+    items: Iterable[dict[str, object]], start: dt.datetime, end: dt.datetime
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for item in items:
+        ts_value = coerce_str(item.get("ts"))
+        ts = parse_iso8601(ts_value)
+        if ts is None:
+            continue
+        if start <= ts < end:
+            results.append(item)
+    return results


### PR DESCRIPTION
## Summary
- add tests covering weekly_summary IO helpers via the new tools.weekly_summary.io module
- extract parse/load/filter utilities into tools/weekly_summary/io.py and re-export them from __init__

## Testing
- pytest tests/tools/test_weekly_summary_io.py tests/test_update_readme_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68db59e53740832182be9b8f556d6d59