### PR TITLE
Fix lint issues in adapter core modules

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, cast, Protocol, runtime_checkable, TYPE_CHECKING
 
 __path__ = [str(Path(__file__).with_name("aggregation"))]
 
@@ -200,9 +200,6 @@ class MaxScoreStrategy:
         )
 
 
-from .aggregation.judge import DEFAULT_JUDGE_TEMPLATE, JudgeStrategy
-
-
 # 便利ヘルパー：API/CLI から簡単に呼べるように
 def AggregationResolver(kind: str, **kwargs: Any) -> AggregationStrategy:
     return AggregationStrategy.from_string(kind, **kwargs)
@@ -221,3 +218,15 @@ __all__ = [
     "MajorityVoteStrategy",
     "MaxScoreStrategy",
 ]
+
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .aggregation.judge import DEFAULT_JUDGE_TEMPLATE, JudgeStrategy
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - 動的リレーエクスポート
+    if name in {"DEFAULT_JUDGE_TEMPLATE", "JudgeStrategy"}:
+        from .aggregation.judge import DEFAULT_JUDGE_TEMPLATE, JudgeStrategy
+
+        return DEFAULT_JUDGE_TEMPLATE if name == "DEFAULT_JUDGE_TEMPLATE" else JudgeStrategy
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/projects/04-llm-adapter/adapter/core/aggregation/judge.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/judge.py
@@ -1,10 +1,10 @@
 """LLM ジャッジ集約の実装。"""
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 import re
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from ..aggregation import (
     AggregationCandidate,

--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -10,9 +10,11 @@ from time import perf_counter, sleep
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
-    from src.llm_adapter.runner_parallel import ParallelExecutionError
-    from src.llm_adapter.runner_parallel import run_parallel_all_sync
-    from src.llm_adapter.runner_parallel import run_parallel_any_sync
+    from src.llm_adapter.runner_parallel import (
+        ParallelExecutionError,
+        run_parallel_all_sync,
+        run_parallel_any_sync,
+    )
 else:  # pragma: no cover - 実行時フォールバック
     try:
         from src.llm_adapter.runner_parallel import (
@@ -46,7 +48,7 @@ else:  # pragma: no cover - 実行時フォールバック
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import BudgetSnapshot, RunMetrics, estimate_cost
+from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .providers import BaseProvider, ProviderResponse
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用

--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -59,14 +59,7 @@ from .metrics import (
     RunMetrics,
 )
 from .providers import BaseProvider, ProviderFactory, ProviderResponse
-from .runner_execution import (
-    RunnerExecution,
-    SingleRunResult,
-    _SchemaValidator,
-    _TokenBucket,
-    run_parallel_all_sync,
-    run_parallel_any_sync,
-)
+from .runner_execution import _SchemaValidator, _TokenBucket, RunnerExecution, SingleRunResult
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import RunnerConfig

--- a/projects/04-llm-adapter/tests/conftest.py
+++ b/projects/04-llm-adapter/tests/conftest.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import importlib
-import sys
 from pathlib import Path
+import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 project_path = str(PROJECT_ROOT)

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -166,9 +166,9 @@ def format_flaky_markdown(rows: list[dict[str, object]]) -> list[str]:
         return lines
     for row in rows:
         p_fail_value = row.get("p_fail")
-        p_fail = float(p_fail_value) if isinstance(p_fail_value, (int, float)) else None
+        p_fail = float(p_fail_value) if isinstance(p_fail_value, int | float) else None
         score_value = row.get("score")
-        score = float(score_value) if isinstance(score_value, (int, float)) else None
+        score = float(score_value) if isinstance(score_value, int | float) else None
         lines.append(
             "| {rank} | {cid} | {attempts} | {p_fail:.2f} | {score:.2f} |".format(
                 rank=row.get("rank", "-"),

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -158,7 +158,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, (int, float, bool)):
+    if isinstance(value, bool | int | float):
         return str(value)
     return None
 


### PR DESCRIPTION
## Summary
- reorganized imports across adapter core modules and tests to satisfy Ruff ordering, adding a lazy re-export for judge helpers to avoid circular imports
- updated CI tooling helpers to use modern union syntax in isinstance checks for Ruff compliance

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68db5a65f5088321a8853a0df7ee8016