### PR TITLE
Fix generate_ci_report module path initialization

### DIFF
--- a/docs/reports/index.md
+++ b/docs/reports/index.md
@@ -8,7 +8,7 @@ description: Snapshot reports generated from CI telemetry
 
 最新のCI信頼性レポートとソースJSONへのリンクです。週次ワークフローで自動更新されます。
 
-- [Latest Snapshot (2025-09-29)](./latest)
+- [Latest Snapshot (2025-09-30)](./latest)
   - [Source JSON](./latest.json)
   - 更新元: tools/generate_ci_report.py
 

--- a/docs/reports/latest.json
+++ b/docs/reports/latest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-09-29T10:39:00.039677Z",
+  "generated_at": "2025-09-30T04:49:21.195650Z",
   "window_days": 7,
   "totals": {
     "passes": 134,

--- a/docs/reports/latest.md
+++ b/docs/reports/latest.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: QA Reliability Snapshot — 2025-09-29
+title: QA Reliability Snapshot — 2025-09-30
 description: CI pass rate and flaky ranking (auto-generated)
 ---
 
-# QA Reliability Snapshot — 2025-09-29
+# QA Reliability Snapshot — 2025-09-30
 
 - Window: Last 7 days
 - Data Last Updated: 2025-09-29T10:38:40.894000Z

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import sys
+from collections import Counter
 from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from ci_metrics import compute_recent_deltas, compute_run_history
 from weekly_summary import (
@@ -15,6 +22,7 @@ from weekly_summary import (
     load_runs,
     select_flaky_rows,
 )
+from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
 
 from tools.ci_report.processing import (
     compute_last_updated,


### PR DESCRIPTION
## Summary
- ensure `generate_ci_report.py` prepends the repository root to `sys.path` so package imports resolve
- refresh the generated CI reliability report artifacts to reflect the latest run

## Testing
- python tools/generate_ci_report.py --runs projects/03-ci-flaky/data/runs.jsonl --flaky projects/03-ci-flaky/out/flaky_rank.csv --out-markdown docs/reports/latest.md --out-json docs/reports/latest.json --index docs/reports/index.md

------
https://chatgpt.com/codex/tasks/task_e_68db608dc29483219816ba065f869747