### PR TITLE
Reorder imports in runner_sync

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -15,13 +15,13 @@ from .errors import (
     TimeoutError,
 )
 from .observability import EventLogger
-from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .parallel_exec import (
     ParallelAllResult,
     ParallelExecutionError,
     run_parallel_all_sync,
     run_parallel_any_sync,
 )
+from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import compute_consensus
 from .runner_shared import (


### PR DESCRIPTION
## Summary
- reorder local imports in runner_sync to follow standard/third-party/local grouping and alphabetical order

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6d2964888321a9ed324a16e8e1ee