### PR TITLE
Sort imports in async runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -10,6 +10,7 @@ from _pytest.recwarn import WarningsRecorder
 import pytest
 
 from src.llm_adapter.errors import RateLimitError, TimeoutError
+from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,
     ProviderResponse,
@@ -17,7 +18,6 @@ from src.llm_adapter.provider_spi import (
 )
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult, Runner
-from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.runner_config import (
     BackoffPolicy,
     ConsensusConfig,


### PR DESCRIPTION
## Summary
- reorder standard, third-party, and local imports in the async runner test module to meet style guidelines

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_async.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6d284ec483218d97c85900108da5