### PR TITLE
chore: normalize parallel exec imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -10,9 +10,7 @@ from time import perf_counter, sleep
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
-    from src.llm_adapter.parallel_exec import ParallelExecutionError
-    from src.llm_adapter.parallel_exec import run_parallel_all_sync
-    from src.llm_adapter.parallel_exec import run_parallel_any_sync
+    from src.llm_adapter.parallel_exec import ParallelExecutionError, run_parallel_all_sync, run_parallel_any_sync
 else:  # pragma: no cover - 実行時フォールバック
     try:
         from src.llm_adapter.parallel_exec import (


### PR DESCRIPTION
## Summary
- collapse the TYPE_CHECKING parallel_exec imports onto a single line
- ensure runtime fallback import ordering matches the static import order

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runner_execution.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6d26a5e0832187f139cdb394607d