### PR TITLE
Organize weekly summary test imports

### DIFF
--- a/tests/tools/test_weekly_summary_io.py
+++ b/tests/tools/test_weekly_summary_io.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import datetime as dt
 import importlib
-import sys
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -15,7 +15,6 @@ if root_str not in sys.path:
 weekly_summary = importlib.import_module("tools.weekly_summary")
 legacy_load_runs = weekly_summary.load_runs
 legacy_load_flaky = weekly_summary.load_flaky
-
 
 @pytest.mark.parametrize(
     "loader, filename, payload, expected",


### PR DESCRIPTION
## Summary
- reorder imports in tests/tools/test_weekly_summary_io.py to satisfy Ruff grouping and sorting
- trim superfluous blank line in the test module

## Testing
- ruff check tests/tools/test_weekly_summary_io.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6d272db48321a4504294b9a3ef6e