### PR TITLE
Reorder runner_async imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -16,18 +16,18 @@ from .errors import (
     TimeoutError,
 )
 from .observability import EventLogger
+from .parallel_exec import (
+    ParallelAllResult,
+    ParallelExecutionError,
+    run_parallel_all_async,
+    run_parallel_any_async,
+)
 from .provider_spi import (
     AsyncProviderSPI,
     ensure_async_provider,
     ProviderRequest,
     ProviderResponse,
     ProviderSPI,
-)
-from .parallel_exec import (
-    ParallelAllResult,
-    ParallelExecutionError,
-    run_parallel_all_async,
-    run_parallel_any_async,
 )
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import compute_consensus


### PR DESCRIPTION
## Summary
- reorder standard library and local imports in runner_async to follow grouping and alphabetical order

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6cfe94b483219e7a527f7ae2ce6a