### PR TITLE
Reorder async runner test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -10,6 +10,7 @@ from _pytest.recwarn import WarningsRecorder
 import pytest
 
 from src.llm_adapter.errors import RateLimitError, TimeoutError
+from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,
     ProviderResponse,
@@ -17,7 +18,6 @@ from src.llm_adapter.provider_spi import (
 )
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult, Runner
-from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.runner_config import (
     BackoffPolicy,
     ConsensusConfig,


### PR DESCRIPTION
## Summary
- reorder imports in projects/04-llm-adapter-shadow/tests/test_runner_async.py to group them by origin
- alphabetize each import block to satisfy Ruff I001

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_async.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6cff228c8321af5c8015d62979b8