### PR TITLE
Reorder runner_sync imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -15,13 +15,13 @@ from .errors import (
     TimeoutError,
 )
 from .observability import EventLogger
-from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .parallel_exec import (
     ParallelAllResult,
     ParallelExecutionError,
     run_parallel_all_sync,
     run_parallel_any_sync,
 )
+from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerConfig, RunnerMode
 from .runner_parallel import compute_consensus
 from .runner_shared import (


### PR DESCRIPTION
## Summary
- reorder runner_sync imports to follow standard-library, third-party, and local grouping
- alphabetize imports within each group

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6cff75788321a2ae6d132384bcb8