### PR TITLE
Use datetime.UTC in weekly summary test

### DIFF
--- a/tests/tools/test_weekly_summary_io.py
+++ b/tests/tools/test_weekly_summary_io.py
@@ -61,8 +61,8 @@ def test_io_module_provides_same_interfaces(tmp_path: Path) -> None:
     flaky = load_flaky(flaky_path)
     window = filter_by_window(
         runs,
-        dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc),
-        dt.datetime(2024, 6, 1, tzinfo=dt.timezone.utc),
+        dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
+        dt.datetime(2024, 6, 1, tzinfo=dt.UTC),
     )
 
     assert runs[0]["status"] == "pass"


### PR DESCRIPTION
## Summary
- replace `dt.timezone.utc` with `dt.UTC` in the weekly summary IO test to satisfy linting

## Testing
- ruff check tests/tools/test_weekly_summary_io.py --select UP017

------
https://chatgpt.com/codex/tasks/task_e_68db6d23776883219eb5b45f33783182