### PR TITLE
Refine Iterable import in CI report rendering

### DIFF
--- a/tools/ci_report/rendering.py
+++ b/tools/ci_report/rendering.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import datetime as dt
 from pathlib import Path
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from tools.weekly_summary import format_percentage
 


### PR DESCRIPTION
## Summary
- import Iterable from collections.abc to satisfy typing modernization guidance

## Testing
- ruff check tools/ci_report/rendering.py --select UP035

------
https://chatgpt.com/codex/tasks/task_e_68db6d22fdf48321a21d5f1b9f089db3