### PR TITLE
chore: drop unused typing import

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -8,7 +8,6 @@ import json
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -146,7 +145,7 @@ def build_json_payload(
     flaky_rows: list[dict[str, object]],
     last_updated: str | None,
     recent_runs: list[dict[str, object]],
-) -> dict[str, Any]:
+) -> dict[str, object]:
     total = passes + fails + errors
     pass_rate = (passes / total) if total else None
     return {


### PR DESCRIPTION
## Summary
- remove the unused typing.Any import from the CI report generator
- adjust the payload return annotation to use the built-in object type

## Testing
- ruff check tools/generate_ci_report.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68db6d2085108321a78763ab15d1d1e0