### PR TITLE
Organize CI report imports

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import datetime as dt
 import json
-import sys
-from collections import Counter
 from pathlib import Path
+import sys
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -17,12 +17,15 @@ if str(REPO_ROOT) not in sys.path:
 from ci_metrics import compute_recent_deltas, compute_run_history
 from weekly_summary import (
     aggregate_status,
+    coerce_str,
     filter_by_window,
+    format_percentage,
     load_flaky,
     load_runs,
+    parse_iso8601,
     select_flaky_rows,
+    to_float,
 )
-from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
 
 from tools.ci_report.processing import (
     compute_last_updated,


### PR DESCRIPTION
## Summary
- consolidate project-specific imports in `tools/generate_ci_report.py`
- ensure import groups are alphabetized and located in the top-level section

## Testing
- ruff check tools/generate_ci_report.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68db6d20c3c883218d8169a3660145d2