### PR TITLE
Use module-qualified Counter in CI report

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -6,7 +6,7 @@ import argparse
 import datetime as dt
 import json
 import sys
-from collections import Counter
+import collections
 from pathlib import Path
 from typing import Any
 
@@ -73,7 +73,7 @@ def compute_last_updated(runs: list[dict[str, object]]) -> str | None:
 def summarize_failure_kinds(
     runs: list[dict[str, object]], limit: int = 3
 ) -> list[dict[str, object]]:
-    counter: Counter[str] = Counter()
+    counter: collections.Counter[str] = collections.Counter()
     for run in runs:
         status_raw = coerce_str(run.get("status"))
         if status_raw is None:


### PR DESCRIPTION
## Summary
- import the collections module for runtime Counter usage
- reference Counter via collections.Counter to satisfy linting

## Testing
- ruff check tools/generate_ci_report.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68db6d2193cc8321a7decfc8a11327c2