### PR TITLE
Fix import order in generate_ci_report

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -10,26 +10,28 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
-
 from ci_metrics import compute_recent_deltas, compute_run_history
-from weekly_summary import (
-    aggregate_status,
-    filter_by_window,
-    load_flaky,
-    load_runs,
-    select_flaky_rows,
-)
-from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
-
 from tools.ci_report.processing import (
     compute_last_updated,
     normalize_flaky_rows,
     summarize_failure_kinds,
 )
 from tools.ci_report.rendering import build_json_payload, render_markdown
+from weekly_summary import (
+    aggregate_status,
+    coerce_str,
+    filter_by_window,
+    format_percentage,
+    load_flaky,
+    load_runs,
+    parse_iso8601,
+    select_flaky_rows,
+    to_float,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- move local imports in tools/generate_ci_report.py into the top import block
- ensure ordering prevents isort I001 regressions

## Testing
- ruff check tools/generate_ci_report.py --select E402

------
https://chatgpt.com/codex/tasks/task_e_68db6d1f6ec48321b697642b284bdb21