### PR TITLE
Refactor to_float usage in CI reporting tools

### DIFF
--- a/tools/ci_report/processing.py
+++ b/tools/ci_report/processing.py
@@ -5,7 +5,8 @@ import datetime as dt
 from collections import Counter
 from typing import Iterable
 
-from tools.weekly_summary import coerce_str, parse_iso8601, to_float
+from tools import weekly_summary
+from tools.weekly_summary import coerce_str, parse_iso8601
 
 
 def compute_last_updated(runs: Iterable[dict[str, object]]) -> str | None:
@@ -49,7 +50,9 @@ def normalize_flaky_rows(
         return []
     sorted_rows = sorted(
         materialized,
-        key=lambda row: to_float(coerce_str(row.get("score"))) or 0.0,
+        key=lambda row: (
+            weekly_summary.to_float(coerce_str(row.get("score"))) or 0.0
+        ),
         reverse=True,
     )
     normalized: list[dict[str, object]] = []
@@ -64,7 +67,7 @@ def normalize_flaky_rows(
             attempts = int(attempts_value)
         else:
             attempts_str = coerce_str(attempts_value)
-            attempts_float = to_float(attempts_str)
+            attempts_float = weekly_summary.to_float(attempts_str)
             if attempts_float is not None:
                 attempts = int(attempts_float)
         normalized.append(
@@ -76,8 +79,8 @@ def normalize_flaky_rows(
                     or "-"
                 ),
                 "attempts": attempts,
-                "p_fail": to_float(coerce_str(row.get("p_fail"))),
-                "score": to_float(coerce_str(row.get("score"))),
+                "p_fail": weekly_summary.to_float(coerce_str(row.get("p_fail"))),
+                "score": weekly_summary.to_float(coerce_str(row.get("score"))),
                 "as_of": (
                     coerce_str(row.get("as_of"))
                     or coerce_str(row.get("generated_at"))

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -15,14 +15,15 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from ci_metrics import compute_recent_deltas, compute_run_history
-from weekly_summary import (
+from tools import weekly_summary
+from tools.weekly_summary import (
     aggregate_status,
     filter_by_window,
     load_flaky,
     load_runs,
     select_flaky_rows,
 )
-from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
+from tools.weekly_summary import coerce_str, format_percentage, parse_iso8601
 
 from tools.ci_report.processing import (
     compute_last_updated,
@@ -97,7 +98,9 @@ def normalize_flaky_rows(
         return []
     sorted_rows = sorted(
         rows,
-        key=lambda row: to_float(coerce_str(row.get("score"))) or 0.0,
+        key=lambda row: (
+            weekly_summary.to_float(coerce_str(row.get("score"))) or 0.0
+        ),
         reverse=True,
     )
     normalized: list[dict[str, object]] = []
@@ -112,7 +115,7 @@ def normalize_flaky_rows(
             attempts = int(attempts_value)
         else:
             attempts_str = coerce_str(attempts_value)
-            attempts_float = to_float(attempts_str)
+            attempts_float = weekly_summary.to_float(attempts_str)
             if attempts_float is not None:
                 attempts = int(attempts_float)
         normalized.append(
@@ -124,8 +127,8 @@ def normalize_flaky_rows(
                     or "-"
                 ),
                 "attempts": attempts,
-                "p_fail": to_float(coerce_str(row.get("p_fail"))),
-                "score": to_float(coerce_str(row.get("score"))),
+                "p_fail": weekly_summary.to_float(coerce_str(row.get("p_fail"))),
+                "score": weekly_summary.to_float(coerce_str(row.get("score"))),
                 "as_of": (
                     coerce_str(row.get("as_of"))
                     or coerce_str(row.get("generated_at"))


### PR DESCRIPTION
## Summary
- call `weekly_summary.to_float` when computing flaky metrics to satisfy Ruff usage detection
- align CI report generator imports with the `tools.weekly_summary` module

## Testing
- ruff check tools/ci_report/processing.py tools/generate_ci_report.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68db6d1b130483218cc85c982046d270