### PR TITLE
Reorder CI report imports

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -14,22 +14,26 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from ci_metrics import compute_recent_deltas, compute_run_history
-from weekly_summary import (
+from ci_metrics import compute_recent_deltas, compute_run_history  # noqa: E402
+from tools.ci_report.processing import (  # noqa: E402
+    compute_last_updated,
+    normalize_flaky_rows,
+    summarize_failure_kinds,
+)
+from tools.ci_report.rendering import build_json_payload, render_markdown  # noqa: E402
+from weekly_summary import (  # noqa: E402
     aggregate_status,
     filter_by_window,
     load_flaky,
     load_runs,
     select_flaky_rows,
 )
-from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
-
-from tools.ci_report.processing import (
-    compute_last_updated,
-    normalize_flaky_rows,
-    summarize_failure_kinds,
+from weekly_summary import (  # noqa: E402
+    coerce_str,
+    format_percentage,
+    parse_iso8601,
+    to_float,
 )
-from tools.ci_report.rendering import build_json_payload, render_markdown
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- move the tools.ci_report.processing import into the main import section of generate_ci_report.py
- alphabetize the local import group and add E402 suppressions for local-path imports

## Testing
- ruff check tools/generate_ci_report.py --select E402

------
https://chatgpt.com/codex/tasks/task_e_68db6d1b30448321883538b104d5cc63