### PR TITLE
Use module-qualified parse_iso8601 references

### DIFF
--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 import datetime as dt
 from pathlib import Path
 
-from weekly_summary import coerce_str, load_runs, parse_iso8601
+import weekly_summary
+from weekly_summary import coerce_str, load_runs
 
 PASS_STATUSES = {"pass", "passed"}
 FAIL_STATUSES = {"fail", "failed"}
@@ -50,7 +51,7 @@ def _group_runs(runs: Iterable[dict]) -> list[RunRecord]:
         run_id = coerce_str(record.get("run_id"))
         if not run_id:
             continue
-        ts = parse_iso8601(coerce_str(record.get("ts")))
+        ts = weekly_summary.parse_iso8601(coerce_str(record.get("ts")))
         if run_id not in grouped:
             grouped[run_id] = RunRecord(run_id=run_id, timestamp=ts, records=[record])
         else:
@@ -86,7 +87,7 @@ def compute_run_history(
         total = passes = fails = errors = 0
         for record in sorted(
             run.records,
-            key=lambda item: parse_iso8601(coerce_str(item.get("ts")))
+            key=lambda item: weekly_summary.parse_iso8601(coerce_str(item.get("ts")))
             or run.timestamp
             or dt.datetime.min.replace(tzinfo=dt.UTC),
         ):

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -10,6 +10,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+import weekly_summary
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -22,7 +24,7 @@ from weekly_summary import (
     load_runs,
     select_flaky_rows,
 )
-from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
+from weekly_summary import coerce_str, format_percentage, to_float
 
 from tools.ci_report.processing import (
     compute_last_updated,
@@ -61,7 +63,7 @@ def parse_args() -> argparse.Namespace:
 def compute_last_updated(runs: list[dict[str, object]]) -> str | None:
     timestamps: list[dt.datetime] = []
     for run in runs:
-        ts = parse_iso8601(coerce_str(run.get("ts")))
+        ts = weekly_summary.parse_iso8601(coerce_str(run.get("ts")))
         if ts is not None:
             timestamps.append(ts)
     if not timestamps:


### PR DESCRIPTION
## Summary
- update CI tooling scripts to reference parse_iso8601 via the weekly_summary module
- ensure imports remain accurate by removing now-unused direct parse_iso8601 imports

## Testing
- ruff check tools --select F401

------
https://chatgpt.com/codex/tasks/task_e_68db6d1b82e08321969a4caa1da7c504