### PR TITLE
Fix mypy warnings in tooling modules

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
 import datetime as dt
 import json
 from pathlib import Path
 import sys
-from typing import Any
 
 try:
     from ci_metrics import compute_recent_deltas, compute_run_history
@@ -19,7 +17,6 @@ try:
         load_runs,
         select_flaky_rows,
     )
-    from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
     from tools.ci_report.processing import (
         compute_last_updated,
         normalize_flaky_rows,
@@ -39,7 +36,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
         load_runs,
         select_flaky_rows,
     )
-    from weekly_summary import coerce_str, format_percentage, parse_iso8601, to_float
     from tools.ci_report.processing import (
         compute_last_updated,
         normalize_flaky_rows,
@@ -73,202 +69,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--days", type=int, default=7, help="Window size in days")
     return parser.parse_args()
-
-
-def compute_last_updated(runs: list[dict[str, object]]) -> str | None:
-    timestamps: list[dt.datetime] = []
-    for run in runs:
-        ts = weekly_summary.parse_iso8601(coerce_str(run.get("ts")))
-        if ts is not None:
-            timestamps.append(ts)
-    if not timestamps:
-        return None
-    latest = max(timestamps)
-    return latest.isoformat().replace("+00:00", "Z")
-
-
-def summarize_failure_kinds(
-    runs: list[dict[str, object]], limit: int = 3
-) -> list[dict[str, object]]:
-    counter: collections.Counter[str] = collections.Counter()
-    for run in runs:
-        status_raw = coerce_str(run.get("status"))
-        if status_raw is None:
-            continue
-        status = status_raw.lower()
-        if status not in {"fail", "failed", "error"}:
-            continue
-        kind = coerce_str(run.get("failure_kind")) or "unknown"
-        counter[kind] += 1
-    most_common = counter.most_common(limit)
-    return [
-        {"kind": kind, "count": count}
-        for kind, count in most_common
-    ]
-
-
-def normalize_flaky_rows(
-    rows: list[dict[str, object]], limit: int = 3
-) -> list[dict[str, object]]:
-    if not rows:
-        return []
-    sorted_rows = sorted(
-        rows,
-        key=lambda row: to_float(coerce_str(row.get("score"))) or 0.0,
-        reverse=True,
-    )
-    normalized: list[dict[str, object]] = []
-    for idx, row in enumerate(sorted_rows[:limit], start=1):
-        attempts_value = row.get("attempts") or row.get("Attempts")
-        attempts = 0
-        if isinstance(attempts_value, bool):
-            attempts = int(attempts_value)
-        elif isinstance(attempts_value, int):
-            attempts = attempts_value
-        elif isinstance(attempts_value, float):
-            attempts = int(attempts_value)
-        else:
-            attempts_str = coerce_str(attempts_value)
-            attempts_float = to_float(attempts_str)
-            if attempts_float is not None:
-                attempts = int(attempts_float)
-        normalized.append(
-            {
-                "rank": idx,
-                "canonical_id": (
-                    coerce_str(row.get("canonical_id"))
-                    or coerce_str(row.get("Canonical ID"))
-                    or "-"
-                ),
-                "attempts": attempts,
-                "p_fail": to_float(coerce_str(row.get("p_fail"))),
-                "score": to_float(coerce_str(row.get("score"))),
-                "as_of": (
-                    coerce_str(row.get("as_of"))
-                    or coerce_str(row.get("generated_at"))
-                ),
-            }
-        )
-    return normalized
-
-
-def build_json_payload(
-    *,
-    generated_at: dt.datetime,
-    window_days: int,
-    passes: int,
-    fails: int,
-    errors: int,
-    failure_kinds: list[dict[str, object]],
-    flaky_rows: list[dict[str, object]],
-    last_updated: str | None,
-    recent_runs: list[dict[str, object]],
-) -> dict[str, object]:
-    total = passes + fails + errors
-    pass_rate = (passes / total) if total else None
-    return {
-        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
-        "window_days": window_days,
-        "totals": {
-            "passes": passes,
-            "fails": fails,
-            "errors": errors,
-            "executions": total,
-        },
-        "pass_rate": pass_rate,
-        "failure_kinds": failure_kinds,
-        "top_flaky": flaky_rows,
-        "last_updated": last_updated,
-        "recent_runs": recent_runs,
-    }
-
-
-def format_flaky_markdown(rows: list[dict[str, object]]) -> list[str]:
-    header = "| Rank | Canonical ID | Attempts | p_fail | Score |"
-    divider = "|-----:|--------------|---------:|------:|------:|"
-    lines = [header, divider]
-    if not rows:
-        lines.append("| - | データなし | 0 | 0.00 | 0.00 |")
-        return lines
-    for row in rows:
-        p_fail_value = row.get("p_fail")
-        p_fail = float(p_fail_value) if isinstance(p_fail_value, int | float) else None
-        score_value = row.get("score")
-        score = float(score_value) if isinstance(score_value, int | float) else None
-        lines.append(
-            "| {rank} | {cid} | {attempts} | {p_fail:.2f} | {score:.2f} |".format(
-                rank=row.get("rank", "-"),
-                cid=row.get("canonical_id", "-"),
-                attempts=row.get("attempts", 0),
-                p_fail=p_fail or 0.0,
-                score=score or 0.0,
-            )
-        )
-    return lines
-
-
-def render_markdown(
-    *,
-    today: dt.date,
-    window_days: int,
-    totals: dict[str, int],
-    pass_rate: float | None,
-    failure_kinds: list[dict[str, object]],
-    flaky_rows: list[dict[str, object]],
-    last_updated: str | None,
-    runs_path: Path,
-    flaky_path: Path,
-) -> list[str]:
-    kinds_summary = (
-        " / ".join(f"{item['kind']} {item['count']}" for item in failure_kinds)
-        if failure_kinds
-        else "-"
-    )
-    pass_rate_args = {
-        "pass_rate": weekly_summary.format_percentage(pass_rate),
-        "passes": totals["passes"],
-        "executions": totals["executions"],
-    }
-    failures_args = {"fails": totals["fails"]}
-    errors_args = {"errors": totals["errors"]}
-    failure_kinds_args = {"summary": kinds_summary}
-    kpi_lines = [
-        "| 指標 | 値 |",
-        "|------|----|",
-        "| Pass Rate | {pass_rate} ({passes}/{executions}) |".format(
-            **pass_rate_args
-        ),
-        "| Failures | {fails} |".format(**failures_args),
-        "| Errors | {errors} |".format(**errors_args),
-        "| Top Failure Kinds | {summary} |".format(**failure_kinds_args),
-        "| ソースJSON | [latest.json](./latest.json) |",
-    ]
-    lines: list[str] = [
-        "---",
-        "layout: default",
-        f"title: QA Reliability Snapshot — {today.isoformat()}",
-        "description: CI pass rate and flaky ranking (auto-generated)",
-        "---",
-        "",
-        f"# QA Reliability Snapshot — {today.isoformat()}",
-        "",
-        f"- Window: Last {window_days} days",
-        f"- Data Last Updated: {last_updated or 'N/A'}",
-        "",
-        "## KPI",
-        *kpi_lines,
-        "",
-        "## Top Flaky Tests",
-        *format_flaky_markdown(flaky_rows),
-        "",
-        "<details><summary>Generation</summary>",
-        f"Source: runs={runs_path} / flaky={flaky_path}",
-        f"Window: {window_days} days / Executions: {totals['executions']}",
-        "Automation: tools/generate_ci_report.py (GitHub Actions)",
-        "</details>",
-        "",
-    ]
-    return lines
 
 
 def update_index(index_path: Path, *, today: dt.date) -> None:

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -8,13 +8,7 @@ import datetime as dt
 from pathlib import Path
 import re
 
-from .io import (
-    coerce_str,
-    filter_by_window,
-    load_flaky,
-    load_runs,
-    parse_iso8601,
-)
+from .io import filter_by_window, load_flaky, load_runs, parse_iso8601
 
 __all__ = [
     "parse_iso8601",
@@ -107,7 +101,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, bool | int | float):
+    if isinstance(value, (bool, int, float)):
         return str(value)
     return None
 
@@ -116,7 +110,7 @@ def to_float(value: object) -> float | None:
         return None
     if isinstance(value, bool):
         return float(value)
-    if isinstance(value, int | float):
+    if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):
         s = value.strip()


### PR DESCRIPTION
## Summary
- remove duplicate helper implementations from generate_ci_report in favor of shared modules
- resolve coerce_str redefinition in weekly_summary and tighten runtime isinstance checks

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools

------
https://chatgpt.com/codex/tasks/task_e_68db73edae688321a72c62cfb40fbb66