### PR TITLE
Reorder CI report processing imports

### DIFF
--- a/tools/ci_report/processing.py
+++ b/tools/ci_report/processing.py
@@ -1,9 +1,9 @@
 """Data aggregation helpers for CI report generation."""
 from __future__ import annotations
 
-import datetime as dt
 from collections import Counter
-from typing import Iterable
+from collections.abc import Iterable
+import datetime as dt
 
 from tools.weekly_summary import coerce_str, parse_iso8601, to_float
 


### PR DESCRIPTION
## Summary
- reorder the standard library imports in `tools/ci_report/processing.py`
- switch to `collections.abc.Iterable` and drop the obsolete `typing` import

## Testing
- ruff check tools/ci_report/processing.py --select I001,UP035

------
https://chatgpt.com/codex/tasks/task_e_68db7c6f21448321b1ed17c56f2a7d60