### PR TITLE
style: reorder imports in parallel_exec

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
@@ -2,17 +2,17 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from concurrent.futures import (
+    as_completed,
     FIRST_COMPLETED,
     Future,
     ThreadPoolExecutor,
-    as_completed,
     wait,
 )
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar, cast
+import inspect
+from typing import Any, cast, Generic, TypeVar
 
 T = TypeVar("T")
 S = TypeVar("S")


### PR DESCRIPTION
## Summary
- group and alphabetize the standard library imports in parallel_exec.py
- ensure ruff import-order lint passes

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py --select I001


------
https://chatgpt.com/codex/tasks/task_e_68db7c6eef78832184f6cc0a6c8b808f