### PR TITLE
chore: sort runner_parallel imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -1,12 +1,11 @@
 """Consensus orchestration helpers for runner implementations."""
 from __future__ import annotations
 
-import importlib
-import inspect
-import json
-import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+import importlib
+import json
+import math
 from typing import Any, cast
 
 from .parallel_exec import ParallelExecutionError


### PR DESCRIPTION
## Summary
- reorder the runner_parallel imports into standard-library and local groups and drop the unused inspect import

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py --select I001,F401


------
https://chatgpt.com/codex/tasks/task_e_68db7c6ea6d08321892be93c1f6270a2