### PR TITLE
Fix fast-xml-parser tests by importing node:test

### DIFF
--- a/tests/fast-xml-parser.test.mjs
+++ b/tests/fast-xml-parser.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import { XMLParser } from 'fast-xml-parser';
 


### PR DESCRIPTION
## Summary
- add the missing node:test import in fast-xml-parser tests so `test()` is defined

## Testing
- node --test tests/fast-xml-parser.test.mjs


------
https://chatgpt.com/codex/tasks/task_e_68db97beb6f4832197856184dc0c890b