### PR TITLE
Fix flaky table formatting for string metrics

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -52,3 +52,28 @@ def test_render_markdown_includes_summary(sample_runs: list[dict[str, object]]) 
 
     assert any("# QA Reliability Snapshot — 2024-06-05" in line for line in markdown)
     assert any("flake 2" in line for line in markdown)
+
+
+def test_render_markdown_formats_numeric_strings() -> None:
+    markdown = render_markdown(
+        today=dt.date(2024, 6, 5),
+        window_days=7,
+        totals={"passes": 1, "fails": 0, "errors": 0, "executions": 1},
+        pass_rate=1.0,
+        failure_kinds=[],
+        flaky_rows=[
+            {
+                "rank": 1,
+                "canonical_id": "sample",
+                "attempts": "3",
+                "p_fail": "0.25",
+                "score": "0.5",
+            }
+        ],
+        last_updated="2024-06-05T09:00:00Z",
+        runs_path=Path("runs.jsonl"),
+        flaky_path=Path("flaky.csv"),
+    )
+
+    table_line = next(line for line in markdown if line.startswith("| 1 |"))
+    assert table_line.endswith("| 3 | 0.25 | 0.50 |")

--- a/tools/ci_report/rendering.py
+++ b/tools/ci_report/rendering.py
@@ -50,9 +50,9 @@ def _format_flaky_markdown(rows: Iterable[dict[str, object]]) -> list[str]:
         return lines
     for row in materialized:
         p_fail_value = row.get("p_fail")
-        p_fail = float(p_fail_value) if isinstance(p_fail_value, (int, float)) else None
+        p_fail = weekly_summary.to_float(p_fail_value)
         score_value = row.get("score")
-        score = float(score_value) if isinstance(score_value, (int, float)) else None
+        score = weekly_summary.to_float(score_value)
         lines.append(
             "| {rank} | {cid} | {attempts} | {p_fail:.2f} | {score:.2f} |".format(
                 rank=row.get("rank", "-"),


### PR DESCRIPTION
## Summary
- add coverage ensuring CI report markdown preserves numeric strings for flaky metrics
- normalize p_fail and score values with shared float coercion to render correct percentages

## Testing
- pytest tests/test_generate_ci_report.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db97be0284832186266138415a5942