### PR TITLE
Fix Python tooling imports and restore CompareRunner helper

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -212,6 +212,21 @@ class CompareRunner:
                 results.append(attempt.metrics)
                 self._append_metric(attempt.metrics)
 
+    def _run_provider_call(
+        self,
+        provider_config: ProviderConfig,
+        provider: BaseProvider,
+        prompt: str,
+    ) -> tuple[ProviderResponse, str, str | None, str | None, int]:
+        execution = RunnerExecution(
+            token_bucket=self._token_bucket,
+            schema_validator=self._schema_validator,
+            evaluate_budget=self._evaluate_budget,
+            build_metrics=self._build_metrics,
+            normalize_concurrency=self._normalize_concurrency,
+        )
+        return execution._run_provider_call(provider_config, provider, prompt)
+
     @staticmethod
     def _normalize_concurrency(total: int, limit: int | None) -> int:
         if total <= 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,6 @@ ignore_errors = true
 markers = [
     "asyncio: tests that drive asyncio event loops",
 ]
+pythonpath = [
+    ".",
+]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,13 @@
 """Utility scripts and helpers for repository tooling."""
+from __future__ import annotations
+
+from pathlib import Path
+
+_current_dir = Path(__file__).resolve().parent
+_legacy_tools = _current_dir.parent / "projects" / "04-llm-adapter" / "tools"
+
+__path__ = [str(_current_dir)]
+if _legacy_tools.exists():
+    __path__.append(str(_legacy_tools))
+
+__all__ = []


### PR DESCRIPTION
## Summary
- ensure pytest always adds the repository root to `PYTHONPATH`
- extend the `tools` package path so legacy report metrics modules remain importable
- restore the `_run_provider_call` helper on `CompareRunner` for backwards compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db97bb56448321890584254fa19d33