### PR TITLE
Stabilize tools imports and restore CompareRunner helper

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -194,6 +194,26 @@ class CompareRunner:
         return results
 
 
+    def _run_provider_call(
+        self,
+        provider_config: ProviderConfig,
+        provider: BaseProvider,
+        prompt: str,
+    ) -> tuple[ProviderResponse, str, str | None, str | None, int]:
+        """Backward-compatible proxy to :class:`RunnerExecution` helper."""
+
+        response, status, failure_kind, error_message, latency_ms = (
+            RunnerExecution._invoke_provider(provider, prompt)
+        )
+        status, failure_kind = RunnerExecution._check_timeout(
+            provider_config, latency_ms, status, failure_kind
+        )
+        status, failure_kind = RunnerExecution._enforce_output_guard(
+            response.output_text, status, failure_kind
+        )
+        return response, status, failure_kind, error_message, latency_ms
+
+
     def _finalize_task(
         self,
         task: GoldenTask,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""pytest グローバル設定: ルートパスと tools パッケージの解決を安定化。"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent
+if _REPO_ROOT.name == "tests":
+    _REPO_ROOT = _REPO_ROOT.parent
+
+_ROOT_STR = str(_REPO_ROOT)
+if _ROOT_STR not in sys.path:
+    sys.path.insert(0, _ROOT_STR)
+
+_TOOLS_ROOT = (_REPO_ROOT / "tools").resolve()
+_loaded = sys.modules.get("tools")
+if _loaded is not None:
+    module_path = getattr(_loaded, "__file__", None)
+    if module_path is None or not Path(module_path).resolve().is_relative_to(_TOOLS_ROOT):
+        sys.modules.pop("tools", None)
+
+if "tools" not in sys.modules:
+    importlib.import_module("tools")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,44 @@
 """Utility scripts and helpers for repository tooling."""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+
+__all__ = []
+
+
+def _ensure_namespace(package: str, location: Path) -> ModuleType:
+    module = sys.modules.get(package)
+    if module is not None:
+        return module
+    namespace = ModuleType(package)
+    namespace.__file__ = str(location / "__init__.py") if (location / "__init__.py").exists() else str(location)
+    namespace.__path__ = [str(location)]
+    sys.modules[package] = namespace
+    return namespace
+
+
+def _load_package(alias: str, origin: Path) -> None:
+    if alias in sys.modules:
+        return
+    spec = spec_from_file_location(alias, origin, submodule_search_locations=[str(origin.parent)])
+    if spec is None or spec.loader is None:
+        return
+    module = module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_REPORT_ROOT = _REPO_ROOT / "projects" / "04-llm-adapter" / "tools" / "report"
+_METRICS_ROOT = _REPORT_ROOT / "metrics"
+
+if _METRICS_ROOT.exists():
+    _ensure_namespace("tools.report", _REPORT_ROOT)
+    _load_package("tools.report.metrics", _METRICS_ROOT / "__init__.py")
+    metrics_to_html = _REPORT_ROOT / "metrics_to_html.py"
+    if metrics_to_html.exists():
+        _load_package("tools.report.metrics_to_html", metrics_to_html)


### PR DESCRIPTION
## Summary
- ensure pytest uses the repository tools package during collection
- expose the legacy tools.report.metrics modules backed by the adapter project code
- restore CompareRunner._run_provider_call by delegating to RunnerExecution helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db97bcebf0832182175804c02f6f16