### PR TITLE
Refactor async parallel executor retry handling

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
@@ -21,6 +21,9 @@ S = TypeVar("S")
 SyncWorker = Callable[[], T]
 AsyncWorker = Callable[[], Awaitable[T]]
 
+_SuccessCallback = Callable[[T], Awaitable[None]]
+_FailureCallback = Callable[[BaseException], Awaitable[None]]
+
 RetryDirective = float | tuple[int, float] | None
 
 
@@ -153,6 +156,83 @@ async def _resolve_retry_directive(
     return cast(RetryDirective, awaited_directive)
 
 
+class _AsyncParallelExecutor(Generic[T]):
+    def __init__(
+        self,
+        workers: Sequence[AsyncWorker[T]],
+        *,
+        max_concurrency: int | None,
+        max_attempts: int | None,
+        on_retry: Callable[[int, int, BaseException], Awaitable[RetryDirective] | RetryDirective]
+        | None,
+    ) -> None:
+        limit = _normalize_concurrency(len(workers), max_concurrency)
+        self._semaphore = asyncio.Semaphore(limit)
+        self._max_attempts = max_attempts
+        self._on_retry = on_retry
+        self._attempts_lock = asyncio.Lock()
+        self._attempts_used = 0
+
+    async def _reserve_attempt(self) -> bool:
+        async with self._attempts_lock:
+            if self._max_attempts is not None and self._attempts_used >= self._max_attempts:
+                return False
+            self._attempts_used += 1
+            return True
+
+    async def _maybe_retry(
+        self, index: int, attempt: int, exc: BaseException
+    ) -> tuple[int, bool]:
+        if self._on_retry is None:
+            return attempt, False
+        directive = self._on_retry(index, attempt, exc)
+        awaited = await _resolve_retry_directive(directive)
+        next_attempt, delay = _normalize_retry_directive(awaited)
+        if delay is not None and delay >= 0:
+            if next_attempt is not None:
+                attempt = max(next_attempt - 1, attempt)
+            if delay > 0:
+                await asyncio.sleep(delay)
+            return attempt, True
+        return attempt, False
+
+    async def run_worker(
+        self,
+        index: int,
+        worker: AsyncWorker[T],
+        *,
+        on_success: _SuccessCallback,
+        on_failure: _FailureCallback,
+        propagate_failure: bool,
+    ) -> None:
+        attempt = 0
+        while await self._reserve_attempt():
+            attempt += 1
+            try:
+                async with self._semaphore:
+                    result = await worker()
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:  # noqa: BLE001
+                attempt, should_retry = await self._maybe_retry(index, attempt, exc)
+                if should_retry:
+                    continue
+                await on_failure(exc)
+                if propagate_failure:
+                    raise
+                return
+            await on_success(result)
+            return
+        final_exc: BaseException
+        if propagate_failure:
+            final_exc = ParallelExecutionError("max attempts exhausted")
+        else:
+            final_exc = RuntimeError("max attempts exhausted")
+        await on_failure(final_exc)
+        if propagate_failure:
+            raise final_exc
+
+
 async def run_parallel_any_async(
     workers: Sequence[AsyncWorker[T]],
     *,
@@ -165,58 +245,39 @@ async def run_parallel_any_async(
 
     if not workers:
         raise ValueError("workers must not be empty")
-    limit = _normalize_concurrency(len(workers), max_concurrency)
-    semaphore = asyncio.Semaphore(limit)
+    executor = _AsyncParallelExecutor(
+        workers,
+        max_concurrency=max_concurrency,
+        max_attempts=max_attempts,
+        on_retry=on_retry,
+    )
     winner: asyncio.Future[T] = asyncio.get_running_loop().create_future()
-    attempts_lock = asyncio.Lock()
     failure_lock = asyncio.Lock()
-    attempts_used = failures = 0
+    failures = 0
 
-    async def _reserve_attempt() -> bool:
-        nonlocal attempts_used
-        async with attempts_lock:
-            if max_attempts is not None and attempts_used >= max_attempts:
-                return False
-            attempts_used += 1
-            return True
+    async def _on_success(result: T) -> None:
+        if not winner.done():
+            winner.set_result(result)
 
-    async def _record_failure(error: BaseException | None) -> None:
+    async def _on_failure(exc: BaseException) -> None:  # noqa: ARG001
         nonlocal failures
         async with failure_lock:
             failures += 1
             if failures == len(workers) and not winner.done():
                 winner.set_exception(ParallelExecutionError("all workers failed"))
 
-    async def runner(index: int, worker: AsyncWorker[T]) -> None:
-        attempt = 0
-        while await _reserve_attempt():
-            attempt += 1
-            try:
-                async with semaphore:
-                    result = await worker()
-            except asyncio.CancelledError:
-                raise
-            except BaseException as exc:  # noqa: BLE001
-                delay: float | None = None
-                next_attempt: int | None = None
-                if on_retry is not None:
-                    directive = on_retry(index, attempt, exc)
-                    awaited = await _resolve_retry_directive(directive)
-                    next_attempt, delay = _normalize_retry_directive(awaited)
-                if delay is not None and delay >= 0:
-                    if next_attempt is not None:
-                        attempt = max(next_attempt - 1, attempt)
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                    continue
-                await _record_failure(exc)
-                return
-            if not winner.done():
-                winner.set_result(result)
-            return
-        await _record_failure(RuntimeError("max attempts exhausted"))
-
-    tasks = [asyncio.create_task(runner(idx, worker)) for idx, worker in enumerate(workers)]
+    tasks = [
+        asyncio.create_task(
+            executor.run_worker(
+                idx,
+                worker,
+                on_success=_on_success,
+                on_failure=_on_failure,
+                propagate_failure=False,
+            )
+        )
+        for idx, worker in enumerate(workers)
+    ]
     try:
         return await winner
     finally:
@@ -258,48 +319,35 @@ async def run_parallel_all_async(
 
     if not workers:
         raise ValueError("workers must not be empty")
-    limit = _normalize_concurrency(len(workers), max_concurrency)
-    semaphore = asyncio.Semaphore(limit)
+    executor = _AsyncParallelExecutor(
+        workers,
+        max_concurrency=max_concurrency,
+        max_attempts=max_attempts,
+        on_retry=on_retry,
+    )
     responses: list[T | None] = [None] * len(workers)
-    attempts_lock = asyncio.Lock()
-    attempts_used = 0
 
-    async def _reserve_attempt() -> bool:
-        nonlocal attempts_used
-        async with attempts_lock:
-            if max_attempts is not None and attempts_used >= max_attempts:
-                return False
-            attempts_used += 1
-            return True
+    async def _noop_failure(_: BaseException) -> None:
+        return None
 
-    async def runner(index: int, worker: AsyncWorker[T]) -> None:
-        attempt = 0
-        while await _reserve_attempt():
-            attempt += 1
-            try:
-                async with semaphore:
-                    responses[index] = await worker()
-            except asyncio.CancelledError:
-                raise
-            except BaseException as exc:  # noqa: BLE001
-                delay: float | None = None
-                next_attempt: int | None = None
-                if on_retry is not None:
-                    directive = on_retry(index, attempt, exc)
-                    awaited = await _resolve_retry_directive(directive)
-                    next_attempt, delay = _normalize_retry_directive(awaited)
-                if delay is not None and delay >= 0:
-                    if next_attempt is not None:
-                        attempt = max(next_attempt - 1, attempt)
-                    if delay > 0:
-                        await asyncio.sleep(delay)
-                    continue
-                raise
-            else:
-                return
-        raise ParallelExecutionError("max attempts exhausted")
+    def _success_factory(idx: int) -> _SuccessCallback:
+        async def _on_success(value: T) -> None:
+            responses[idx] = value
 
-    tasks = [asyncio.create_task(runner(idx, worker)) for idx, worker in enumerate(workers)]
+        return _on_success
+
+    tasks = [
+        asyncio.create_task(
+            executor.run_worker(
+                idx,
+                worker,
+                on_success=_success_factory(idx),
+                on_failure=_noop_failure,
+                propagate_failure=True,
+            )
+        )
+        for idx, worker in enumerate(workers)
+    ]
     try:
         await asyncio.gather(*tasks)
     except BaseException:

--- a/projects/04-llm-adapter-shadow/tests/test_parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/tests/test_parallel_exec.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.llm_adapter.parallel_exec import run_parallel_all_async, run_parallel_any_async
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_any_async_retries_until_success() -> None:
+    attempts: list[int] = []
+
+    async def worker() -> str:
+        attempts.append(1)
+        if len(attempts) < 2:
+            raise ValueError("boom")
+        return "ok"
+
+    calls: list[tuple[int, int, type[BaseException]]] = []
+
+    async def on_retry(index: int, attempt: int, exc: BaseException) -> float:
+        calls.append((index, attempt, type(exc)))
+        return 0.0
+
+    result = await run_parallel_any_async(
+        [worker],
+        max_attempts=5,
+        on_retry=on_retry,
+    )
+
+    assert result == "ok"
+    assert attempts == [1, 1]
+    assert calls == [(0, 1, ValueError)]
+
+
+@pytest.mark.asyncio
+async def test_run_parallel_all_async_retry_directive_abort() -> None:
+    async def worker() -> None:
+        raise RuntimeError("fail")
+
+    call_count = 0
+
+    async def on_retry(index: int, attempt: int, exc: BaseException) -> float:
+        nonlocal call_count
+        call_count += 1
+        return -1.0
+
+    with pytest.raises(RuntimeError):
+        await run_parallel_all_async(
+            [worker],
+            max_attempts=3,
+            on_retry=on_retry,
+        )
+
+    assert call_count == 1


### PR DESCRIPTION
## Summary
- extract an internal async executor helper to centralize retry handling
- delegate the any/all async runners to the helper while preserving existing behaviour
- add targeted tests covering retry directives for both execution modes

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_parallel_exec.py

------
https://chatgpt.com/codex/tasks/task_e_68db9c1cdb088321b96ac4bdb307ba12