### PR TITLE
Remove unused imports from async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -13,7 +13,6 @@ from .errors import (
     RateLimitError,
     RetryableError,
     SkipError,
-    TimeoutError,
 )
 from .observability import EventLogger
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
@@ -34,10 +33,8 @@ from .runner_async_modes import (
     WorkerResult,
 )
 from .runner_config import RunnerConfig, RunnerMode
-from .runner_parallel import compute_consensus
 from .runner_shared import (
     error_family,
-    estimate_cost,
     log_provider_call,
     log_provider_skipped,
     log_run_metric,


### PR DESCRIPTION
## Summary
- remove unused TimeoutError, compute_consensus, and estimate_cost imports from async runner
- tidy the remaining imports to maintain PEP 8 ordering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba091890c8321a9aecae9da3a5998