### PR TITLE
chore: remove unused typing import

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py
@@ -1,8 +1,6 @@
 """Base helpers for async runner strategies."""
 from __future__ import annotations
 
-from typing import Awaitable, Callable
-
 from ..errors import RateLimitError, RetryableError, TimeoutError
 from ..provider_spi import AsyncProviderSPI, ProviderSPI
 from .context import AsyncRunContext, WorkerFactory, WorkerResult


### PR DESCRIPTION
## Summary
- remove unused typing import from the async runner base module

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py

------
https://chatgpt.com/codex/tasks/task_e_68dba092428083219b41804ffa8d08d2