### PR TITLE
chore: sort imports in async runner init

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/__init__.py
@@ -1,16 +1,16 @@
 """Async runner strategies and shared utilities."""
 from __future__ import annotations
 
-from .base import ParallelStrategyBase, compute_parallel_retry_decision
+from .base import compute_parallel_retry_decision, ParallelStrategyBase
 from .consensus import ConsensusRunStrategy
 from .context import (
     AsyncRunContext,
     AsyncRunStrategy,
+    collect_failure_details,
     InvokeProviderFn,
     StrategyResult,
     WorkerFactory,
     WorkerResult,
-    collect_failure_details,
 )
 from .parallel_all import ParallelAllRunStrategy
 from .parallel_any import ParallelAnyRunStrategy


### PR DESCRIPTION
## Summary
- sort the runner_async_modes module imports to satisfy ruff import rules

## Testing
- ruff check --select I --fix projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dba092966083218ea5c350a03cea11