### PR TITLE
chore: sort imports in consensus runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
@@ -6,7 +6,7 @@ from ..runner_parallel import compute_consensus
 from ..runner_shared import estimate_cost, log_run_metric
 from ..utils import content_hash, elapsed_ms
 from .base import ParallelStrategyBase
-from .context import AsyncRunContext, StrategyResult, collect_failure_details
+from .context import AsyncRunContext, collect_failure_details, StrategyResult
 
 
 class ConsensusRunStrategy(ParallelStrategyBase):


### PR DESCRIPTION
## Summary
- reorder the consensus runner imports to follow Ruff sorting rules

## Testing
- ruff check --select I --fix projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68dba093f3b08321a428e599d4f89f6f