### PR TITLE
chore: reorder imports in runner_sync_modes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 import time
-from typing import Protocol, TYPE_CHECKING, cast
+from typing import cast, Protocol, TYPE_CHECKING
 
 from .errors import (
     FatalError,


### PR DESCRIPTION
## Summary
- reorder the typing import sequence in runner_sync_modes to follow standard library grouping

## Testing
- ruff check --select I --fix projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68dba09960e0832181fa9aff19cc6c1a