### PR TITLE
Align import order in tests conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 """pytest グローバル設定: ルートパスと tools パッケージの解決を安定化。"""
+
 from __future__ import annotations
 
 import importlib
-import sys
 from pathlib import Path
+import sys
 
 _REPO_ROOT = Path(__file__).resolve().parent
 if _REPO_ROOT.name == "tests":


### PR DESCRIPTION
## Summary
- ensure the module docstring in `tests/conftest.py` is followed by the `from __future__ import annotations` line with correct spacing
- normalize the standard-library import ordering in `tests/conftest.py` to satisfy Ruff

## Testing
- ruff check tests/conftest.py --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68dba09abb4c8321bd0bb1383c148e89