### PR TITLE
chore: reorder imports in parallel all runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_all.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_all.py
@@ -5,7 +5,7 @@ from ..parallel_exec import ParallelAllResult, run_parallel_all_async
 from ..runner_shared import estimate_cost, log_run_metric
 from ..utils import elapsed_ms
 from .base import ParallelStrategyBase
-from .context import AsyncRunContext, StrategyResult, collect_failure_details
+from .context import AsyncRunContext, collect_failure_details, StrategyResult
 
 
 class ParallelAllRunStrategy(ParallelStrategyBase):


### PR DESCRIPTION
## Summary
- reorder imports in `parallel_all.py` to satisfy import sorting rules

## Testing
- `ruff check --select I --fix`


------
https://chatgpt.com/codex/tasks/task_e_68dba096047c83218288924549cc8026