### PR TITLE
Reorder imports in async runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async.py
@@ -10,7 +10,6 @@ from _pytest.recwarn import WarningsRecorder
 import pytest
 
 from src.llm_adapter.errors import RateLimitError, TimeoutError
-import src.llm_adapter.runner_async_modes as runner_async_modes
 from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import (
     ProviderRequest,
@@ -19,6 +18,7 @@ from src.llm_adapter.provider_spi import (
 )
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult, Runner
+import src.llm_adapter.runner_async_modes as runner_async_modes
 from src.llm_adapter.runner_config import (
     BackoffPolicy,
     ConsensusConfig,


### PR DESCRIPTION
## Summary
- reorder the async runner test imports so local modules follow ruff's grouping

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_async.py --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68dba09ac5a88321bfc616f16ae3eb11