### PR TITLE
Reorder imports in async context module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/context.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/context.py
@@ -1,8 +1,8 @@
 """Shared context and result types for async runner strategies."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 from ..observability import EventLogger


### PR DESCRIPTION
## Summary
- reorder standard library imports in the async runner context module to satisfy lint ordering rules

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/context.py --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68dba35a81608321ad403eb854def90f