### PR TITLE
style: reorder runner_async imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -25,11 +25,11 @@ from .provider_spi import (
 )
 from .runner_async_modes import (
     AsyncRunContext,
+    collect_failure_details,
     ConsensusRunStrategy,
     ParallelAllRunStrategy,
     ParallelAnyRunStrategy,
     SequentialRunStrategy,
-    collect_failure_details,
     WorkerResult,
 )
 from .runner_config import RunnerConfig, RunnerMode


### PR DESCRIPTION
## Summary
- reorder runner_async imports to follow standard library, third-party, local grouping
- format imports via ruff check --select I

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68dba35a1aec83218d6efd35f678ea11