### PR TITLE
Fix import formatting in runner async base

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py
@@ -1,7 +1,6 @@
 """Base helpers for async runner strategies."""
 from __future__ import annotations
 
-
 from ..errors import RateLimitError, RetryableError, TimeoutError
 from ..provider_spi import AsyncProviderSPI, ProviderSPI
 from .context import AsyncRunContext, WorkerFactory, WorkerResult


### PR DESCRIPTION
## Summary
- normalize import block formatting in runner async base module

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/base.py --select I --fix

------
https://chatgpt.com/codex/tasks/task_e_68dba35b255c8321a363114cfcd6bb84