### PR TITLE
Fix mypy runner strategy typing issues

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -25,6 +25,7 @@ from .provider_spi import (
 )
 from .runner_async_modes import (
     AsyncRunContext,
+    AsyncRunStrategy,
     collect_failure_details,
     ConsensusRunStrategy,
     ParallelAllRunStrategy,
@@ -277,6 +278,7 @@ class AsyncRunner:
             sleep_fn=asyncio.sleep,
         )
 
+        strategy: AsyncRunStrategy
         if mode == RunnerMode.SEQUENTIAL:
             strategy = SequentialRunStrategy()
         elif mode == RunnerMode.PARALLEL_ANY:

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -17,7 +17,7 @@ from .parallel_exec import (
     run_parallel_any_sync,
 )
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
-from .runner_config import RunnerConfig
+from .runner_config import RunnerConfig, RunnerMode
 from .runner_shared import (
     estimate_cost,
     log_provider_call,
@@ -239,7 +239,7 @@ class Runner:
             "runner", request.prompt_text, request.options, request.max_tokens
         )
         shadow_used = shadow is not None
-        strategy = get_sync_strategy(self._config.mode)
+        strategy = get_sync_strategy(cast(RunnerMode, self._config.mode))
         context = SyncRunContext(
             runner=self,
             request=request,


### PR DESCRIPTION
## Summary
- ensure the synchronous runner passes a RunnerMode instance to strategy resolution
- annotate the async runner's strategy selection with the shared AsyncRunStrategy protocol

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src

------
https://chatgpt.com/codex/tasks/task_e_68dba4f581708321a5dd14b89b67db6f