### PR TITLE
feat(adapter): add weighted vote weights option

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -41,6 +41,7 @@ class RunnerConfig:
     aggregate: str | None = None
     quorum: int | None = None
     tie_breaker: str | None = None
+    provider_weights: dict[str, float] | None = None
     schema: Path | None = None
     judge: Path | None = None
     judge_provider: ProviderConfig | None = None
@@ -98,6 +99,7 @@ def run_compare(
     aggregate: str | None = None,
     quorum: int | None = None,
     tie_breaker: str | None = None,
+    provider_weights: dict[str, float] | None = None,
     schema: Path | str | None = None,
     judge: str | None = None,
     max_concurrency: int | None = None,
@@ -115,6 +117,7 @@ def run_compare(
             aggregate=aggregate,
             quorum=_sanitize_positive_int(quorum),
             tie_breaker=tie_breaker,
+            provider_weights=provider_weights,
             schema=_resolve_optional_path(schema),
             judge=judge_path,
             judge_provider=judge_provider,

--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -24,13 +24,14 @@ def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_pat
         metrics=None,
         log_level="DEBUG",
         allow_overrun=True,
-        aggregate=None,
+        aggregate="weighted_vote",
         quorum=3,
-        tie_breaker=None,
+        tie_breaker="min_cost",
         schema=None,
         judge=None,
         max_concurrency=4,
         rpm=90,
+        weights="openai=1.5,anthropic=0.5",
     )
     monkeypatch.setattr(run_compare_module, "_parse_args", lambda: args)
     captured: dict[str, object] = {}
@@ -49,6 +50,9 @@ def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert forwarded["max_concurrency"] == 4
     assert forwarded["quorum"] == 3
     assert forwarded["rpm"] == 90
+    assert forwarded["aggregate"] == "weighted_vote"
+    assert forwarded["tie_breaker"] == "min_cost"
+    assert forwarded["provider_weights"] == {"openai": 1.5, "anthropic": 0.5}
 
 
 def test_run_compare_sanitizes_runner_config(
@@ -104,11 +108,13 @@ def test_run_compare_sanitizes_runner_config(
         quorum=5,
         max_concurrency=-1,
         rpm=0,
+        provider_weights={"openai": 1.0},
     )
     assert captured["mode"] == "parallel-any"
     assert captured["quorum"] == 5
     assert captured["max_concurrency"] is None
     assert captured["rpm"] is None
+    assert captured["provider_weights"] == {"openai": 1.0}
     assert captured["repeat"] == 1
 
 


### PR DESCRIPTION
## Summary
- restrict compare CLI aggregate and tie-breaker choices
- add a --weights option and forward provider weights to RunnerConfig
- extend the CLI runner config tests to cover provider weight propagation

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py *(fails: ImportError -> NameError: SingleRunResult is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb4609ccc8321a6cdec8ac0181bd2