### PR TITLE
Add adapter error hierarchy

### DIFF
--- a/projects/04-llm-adapter/adapter/core/errors.py
+++ b/projects/04-llm-adapter/adapter/core/errors.py
@@ -1,0 +1,92 @@
+"""Normalized exception hierarchy for adapter core."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class AdapterError(Exception):
+    """Base class for adapter-originated errors."""
+
+
+class RetryableError(AdapterError):
+    """Base class for errors where retrying may succeed."""
+
+
+class SkipError(AdapterError):
+    """Base class for skip events."""
+
+
+class FatalError(AdapterError):
+    """Base class for unrecoverable errors."""
+
+
+class TimeoutError(RetryableError):
+    """Raised when a provider call exceeds the timeout."""
+
+
+class RateLimitError(RetryableError):
+    """Raised when a provider signals rate limiting."""
+
+
+class AuthError(FatalError):
+    """Raised when authentication fails."""
+
+
+class RetriableError(RetryableError):
+    """Raised for transient provider issues."""
+
+
+class SkipReason(str, Enum):
+    """Enumerates structured skip reasons."""
+
+    UNKNOWN = "unknown"
+    MISSING_GEMINI_API_KEY = "missing_gemini_api_key"
+
+
+class ProviderSkip(SkipError):
+    """Raised when a provider should be skipped without counting as failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: SkipReason | str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self._message = message
+        if reason is None:
+            self.reason: SkipReason | None = None
+        elif isinstance(reason, SkipReason):
+            self.reason = reason
+        else:
+            try:
+                self.reason = SkipReason(reason)
+            except ValueError:
+                self.reason = SkipReason.UNKNOWN
+
+    def __str__(self) -> str:
+        return self._message
+
+
+class ConfigError(FatalError):
+    """Raised when provider configuration is invalid."""
+
+
+class AllFailedError(FatalError):
+    """Raised when all providers fail to produce a result."""
+
+
+__all__ = [
+    "AdapterError",
+    "RetryableError",
+    "SkipError",
+    "FatalError",
+    "TimeoutError",
+    "RateLimitError",
+    "AuthError",
+    "RetriableError",
+    "ProviderSkip",
+    "SkipReason",
+    "ConfigError",
+    "AllFailedError",
+]

--- a/projects/04-llm-adapter/adapter/core/loader.py
+++ b/projects/04-llm-adapter/adapter/core/loader.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from pydantic import ValidationError
 
+from .errors import ConfigError as _ConfigErrorBase
 from .models import (
     BudgetBook,
     BudgetRule,
@@ -36,7 +37,7 @@ __all__ = [
 ]
 
 
-class ConfigError(ValueError):
+class ConfigError(_ConfigErrorBase):
     """設定ファイルの検証エラー。"""
 
 


### PR DESCRIPTION
## Summary
- introduce adapter.core.errors with the normalized exception hierarchy
- update loader ConfigError to reuse the shared FatalError base class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb457942c83218196563d6b28a674