### PR TITLE
feat: expose runner backoff policy configuration

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 import inspect
 import logging
 from pathlib import Path
-from typing import cast, Literal
+from typing import cast, Literal, Protocol, TYPE_CHECKING
 
 from .budgets import BudgetManager
 from .config import (
@@ -17,6 +17,22 @@ from .config import (
 )
 from .datasets import load_golden_tasks
 from .runners import CompareRunner
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.provider_spi import ProviderSPI
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.provider_spi import ProviderSPI  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+        class ProviderSPI(Protocol):
+            """プロバイダ SPI フォールバック."""
+
+
+@dataclass(frozen=True)
+class BackoffPolicy:
+    rate_limit_sleep_s: float | None = None
+    timeout_next_provider: bool = False
+    retryable_next_provider: bool = False
 
 Mode = Literal["sequential", "parallel-any", "parallel-all", "consensus"]
 
@@ -46,6 +62,10 @@ class RunnerConfig:
     judge_provider: ProviderConfig | None = None
     max_concurrency: int | None = None
     rpm: int | None = None
+    backoff: BackoffPolicy = field(default_factory=BackoffPolicy)
+    shadow_provider: ProviderSPI | None = None
+    metrics_path: Path | None = None
+    provider_weights: dict[str, float] | None = None
 
 
 def default_budgets_path() -> Path:
@@ -103,28 +123,65 @@ def run_compare(
     max_concurrency: int | None = None,
     rpm: int | None = None,
     runner_config: RunnerConfig | None = None,
+    backoff: BackoffPolicy | None = None,
+    shadow_provider: ProviderSPI | None = None,
+    provider_weights: dict[str, float] | None = None,
 ) -> int:
     logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
 
     resolved_mode = _normalize_mode(mode)
     judge_path = _resolve_optional_path(judge)
     judge_provider = load_provider_config(judge_path) if judge_path else None
+    sanitized_quorum = _sanitize_positive_int(quorum)
+    sanitized_max_concurrency = _sanitize_positive_int(max_concurrency)
+    sanitized_rpm = _sanitize_positive_int(rpm)
+
     if runner_config is None:
         config = RunnerConfig(
             mode=resolved_mode,
             aggregate=aggregate,
-            quorum=_sanitize_positive_int(quorum),
+            quorum=sanitized_quorum,
             tie_breaker=tie_breaker,
             schema=_resolve_optional_path(schema),
             judge=judge_path,
             judge_provider=judge_provider,
-            max_concurrency=_sanitize_positive_int(max_concurrency),
-            rpm=_sanitize_positive_int(rpm),
+            max_concurrency=sanitized_max_concurrency,
+            rpm=sanitized_rpm,
+            backoff=backoff or BackoffPolicy(),
+            shadow_provider=shadow_provider,
+            metrics_path=metrics_path,
+            provider_weights=provider_weights,
         )
     else:
         config = runner_config
+        updates: dict[str, object] = {}
         if config.judge_provider is None and judge_provider is not None:
-            config = replace(config, judge=judge_path, judge_provider=judge_provider)
+            updates["judge"] = judge_path
+            updates["judge_provider"] = judge_provider
+        if backoff is not None:
+            updates["backoff"] = backoff
+        if shadow_provider is not None:
+            updates["shadow_provider"] = shadow_provider
+        if provider_weights is not None:
+            updates["provider_weights"] = provider_weights
+        if config.metrics_path is None:
+            updates["metrics_path"] = metrics_path
+        if updates:
+            try:
+                config = replace(config, **updates)
+            except (TypeError, AttributeError):
+                for key, value in updates.items():
+                    setattr(config, key, value)
+
+    current_metrics_path = getattr(config, "metrics_path", None)
+    if current_metrics_path is None:
+        try:
+            config = replace(config, metrics_path=metrics_path)
+        except (TypeError, AttributeError):
+            setattr(config, "metrics_path", metrics_path)
+        resolved_metrics_path = metrics_path
+    else:
+        resolved_metrics_path = current_metrics_path
 
     provider_configs = load_provider_configs(list(provider_paths))
     tasks = load_golden_tasks(prompt_path)
@@ -135,7 +192,7 @@ def run_compare(
         provider_configs,
         tasks,
         budget_manager,
-        metrics_path,
+        resolved_metrics_path,
         allow_overrun=allow_overrun,
         runner_config=config,
     )
@@ -174,6 +231,7 @@ def run_batch(provider_specs: Iterable[str], prompts_path: str) -> int:
 
 
 __all__ = [
+    "BackoffPolicy",
     "Mode",
     "RunnerConfig",
     "default_budgets_path",

--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from threading import Lock
 from time import perf_counter, sleep
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, Protocol
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.parallel_exec import (
@@ -47,17 +47,19 @@ else:  # pragma: no cover - 実行時フォールバック
                 raise ParallelExecutionError(str(last_error)) from last_error
             raise ParallelExecutionError("no worker executed successfully")
 
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.provider_spi import ProviderSPI
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.provider_spi import ProviderSPI  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+        class ProviderSPI(Protocol):
+            """プロバイダ SPI フォールバック."""
+
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .providers import BaseProvider, ProviderResponse
-from .runner_execution_attempts import (
-    ParallelAttemptExecutor,
-    SequentialAttemptExecutor,
-)
-
-if TYPE_CHECKING:  # pragma: no cover - 型補完用
-    from .runner_api import RunnerConfig
 
 
 class _TokenBucket:
@@ -115,6 +117,15 @@ class SingleRunResult:
     aggregate_output: str | None = None
 
 
+from .runner_execution_attempts import (
+    ParallelAttemptExecutor,
+    SequentialAttemptExecutor,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .runner_api import BackoffPolicy, RunnerConfig
+
+
 _EvaluateBudget = Callable[
     [ProviderConfig, float, str, str | None, str | None],
     tuple[BudgetSnapshot, str | None, str, str | None, str | None],
@@ -147,12 +158,20 @@ class RunnerExecution:
         evaluate_budget: _EvaluateBudget,
         build_metrics: _BuildMetrics,
         normalize_concurrency: _NormalizeConcurrency,
+        backoff: BackoffPolicy | None,
+        shadow_provider: ProviderSPI | None,
+        metrics_path: Path | None,
+        provider_weights: dict[str, float] | None,
     ) -> None:
         self._token_bucket = token_bucket
         self._schema_validator = schema_validator
         self._evaluate_budget = evaluate_budget
         self._build_metrics = build_metrics
         self._normalize_concurrency = normalize_concurrency
+        self._backoff = backoff
+        self._shadow_provider = shadow_provider
+        self._metrics_path = metrics_path
+        self._provider_weights = provider_weights
         self._sequential_executor = SequentialAttemptExecutor(self._run_single)
         self._parallel_executor = ParallelAttemptExecutor(
             self._run_single,

--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import Protocol, TYPE_CHECKING
 
+from .runner_execution import SingleRunResult
+
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import RunnerConfig
-    from .runner_execution import SingleRunResult
 
 
 class _ParallelRunner(Protocol):

--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -109,6 +109,11 @@ def test_run_compare_sanitizes_runner_config(
     assert captured["quorum"] == 5
     assert captured["max_concurrency"] is None
     assert captured["rpm"] is None
+    assert isinstance(captured["backoff"], runner_api.BackoffPolicy)
+    assert captured["backoff"].rate_limit_sleep_s is None
+    assert captured["shadow_provider"] is None
+    assert captured["provider_weights"] is None
+    assert captured["metrics_path"].name == "metrics.jsonl"
     assert captured["repeat"] == 1
 
 


### PR DESCRIPTION
## Summary
- add a BackoffPolicy dataclass and extend RunnerConfig with new backoff and provider fields
- update run_compare to construct the extended RunnerConfig while keeping legacy call sites working
- propagate the new config attributes through CompareRunner/RunnerExecution and refresh the CLI runner config expectation

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb455671c8321b2759ddf16548d97