### PR TITLE
Add provider usage metadata to adapter run metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_controller.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_controller.py
@@ -120,6 +120,33 @@ class AggregationController:
         meta["aggregate_hash"] = hash_text(aggregate_output)
         if selection.votes is not None:
             meta["aggregate_votes"] = selection.votes
+        if mode == "consensus":
+            quorum_value = (
+                config.quorum
+                if config.quorum is not None
+                else len(selection.decision.candidates)
+            )
+            consensus_meta: dict[str, object] = {
+                "strategy": selection.decision.strategy,
+                "quorum": quorum_value,
+                "chosen_provider": selection.decision.chosen.provider,
+            }
+            if selection.votes is not None:
+                consensus_meta["votes"] = selection.votes
+            if selection.decision.tie_breaker_used:
+                consensus_meta["tie_breaker"] = selection.decision.tie_breaker_used
+            if selection.decision.reason:
+                consensus_meta["reason"] = selection.decision.reason
+            score_map = {
+                candidate.provider: candidate.score
+                for candidate in selection.decision.candidates
+                if candidate.score is not None
+            }
+            if score_map:
+                consensus_meta["scores"] = score_map
+            if selection.decision.metadata:
+                consensus_meta["metadata"] = selection.decision.metadata
+            meta["consensus"] = consensus_meta
         winner.metrics.ci_meta = meta
 
     def _select_aggregation(

--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, UTC
 import hashlib
 from statistics import median
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -95,6 +95,10 @@ class RunMetrics:
     error_message: str | None
     output_text: str | None
     output_hash: str | None
+    providers: list[str] = field(default_factory=list)
+    token_usage: dict[str, int] = field(default_factory=dict)
+    retries: int = 0
+    outcome: Literal["success", "skip", "error"] = "success"
     eval: EvalMetrics = field(default_factory=EvalMetrics)
     budget: BudgetSnapshot = field(default_factory=lambda: BudgetSnapshot(0.0, False))
     ci_meta: Mapping[str, Any] = field(default_factory=dict)

--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from threading import Lock
 from time import perf_counter, sleep
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.parallel_exec import (
@@ -161,6 +161,8 @@ class RunnerExecution:
             run_parallel_any_sync=run_parallel_any_sync,
             parallel_execution_error=ParallelExecutionError,
         )
+        self._active_provider_ids: tuple[str, ...] = ()
+        self._current_attempt_index = 0
 
     def run_sequential_attempt(
         self,
@@ -169,6 +171,8 @@ class RunnerExecution:
         attempt_index: int,
         mode: str,
     ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        self._active_provider_ids = tuple(cfg.provider for cfg, _ in providers)
+        self._current_attempt_index = attempt_index
         return self._sequential_executor.run(
             providers,
             task,
@@ -183,6 +187,8 @@ class RunnerExecution:
         attempt_index: int,
         config: RunnerConfig,
     ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        self._active_provider_ids = tuple(cfg.provider for cfg, _ in providers)
+        self._current_attempt_index = attempt_index
         return self._parallel_executor.run(
             providers,
             task,
@@ -245,10 +251,26 @@ class RunnerExecution:
             budget_snapshot,
             cost_usd,
         )
+        provider_ids: list[str] = []
+        for provider_id in self._active_provider_ids:
+            if provider_id not in provider_ids:
+                provider_ids.append(provider_id)
+        run_metrics.providers = provider_ids
+        usage = response.token_usage
+        prompt_tokens = int(getattr(usage, "prompt", response.input_tokens))
+        completion_tokens = int(getattr(usage, "completion", response.output_tokens))
+        total_tokens = int(getattr(usage, "total", prompt_tokens + completion_tokens))
+        run_metrics.token_usage = {
+            "prompt": prompt_tokens,
+            "completion": completion_tokens,
+            "total": total_tokens,
+        }
+        run_metrics.retries = max(self._current_attempt_index, 0)
         if schema_error:
             run_metrics.status = status
             run_metrics.failure_kind = failure_kind
             run_metrics.error_message = error_message
+        run_metrics.outcome = self._resolve_outcome(run_metrics.status)
         return SingleRunResult(
             metrics=run_metrics,
             raw_output=raw_output,
@@ -318,6 +340,14 @@ class RunnerExecution:
             )
             return response, status, failure_kind, error_message, latency_ms
         return response, status, failure_kind, error_message, response.latency_ms
+
+    @staticmethod
+    def _resolve_outcome(status: str) -> Literal["success", "skip", "error"]:
+        if status == "ok":
+            return "success"
+        if status == "skip":
+            return "skip"
+        return "error"
 
 
 __all__ = [

--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Protocol, TYPE_CHECKING
+from typing import Any, Protocol, TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
@@ -11,6 +11,8 @@ from .providers import BaseProvider
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import RunnerConfig
     from .runner_execution import SingleRunResult
+else:  # pragma: no cover - 実行時評価回避
+    SingleRunResult = Any
 
 
 class _ParallelRunner(Protocol):

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -145,9 +145,19 @@ def test_consensus_majority_and_judge_tiebreak(
     )
     results = runner.run(repeat=1, config=RunnerConfig(mode="consensus", quorum=2))
     winner = next(metric for metric in results if metric.ci_meta.get("aggregate_strategy"))
+    assert winner.providers == ["consensus"]
+    assert winner.token_usage == {"prompt": 1, "completion": 1, "total": 2}
+    assert winner.retries == 0
+    assert winner.outcome == "success"
     assert winner.ci_meta["aggregate_strategy"] == "majority"
     assert winner.ci_meta["aggregate_votes"] == 2
     assert winner.ci_meta["aggregate_mode"] == "consensus"
+    consensus_meta = winner.ci_meta["consensus"]
+    assert consensus_meta["strategy"] == "majority"
+    assert consensus_meta["quorum"] == 2
+    assert consensus_meta["votes"] == 2
+    assert consensus_meta["chosen_provider"] == "consensus"
+    assert consensus_meta.get("metadata", {}) == {"bucket_size": 2}
 
     class JudgeProvider(BaseProvider):
         calls = 0


### PR DESCRIPTION
## Summary
- extend RunMetrics with provider participation, token usage, retry count, and outcome fields while keeping JSON output compatible
- populate the new fields from RunnerExecution and expose consensus aggregation metadata in ci_meta
- document the expected metrics output through updated consensus runner tests

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb45d1bb8832197fe5dd48578c28f