### PR TITLE
Add shadow provider hook and metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -95,6 +95,9 @@ class RunMetrics:
     error_message: str | None
     output_text: str | None
     output_hash: str | None
+    shadow_provider_id: str | None = None
+    shadow_latency_ms: int | None = None
+    shadow_outcome: str | None = None
     eval: EvalMetrics = field(default_factory=EvalMetrics)
     budget: BudgetSnapshot = field(default_factory=lambda: BudgetSnapshot(0.0, False))
     ci_meta: Mapping[str, Any] = field(default_factory=dict)

--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -44,6 +44,7 @@ class RunnerConfig:
     schema: Path | None = None
     judge: Path | None = None
     judge_provider: ProviderConfig | None = None
+    shadow_provider: ProviderConfig | None = None
     max_concurrency: int | None = None
     rpm: int | None = None
 

--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -1,4 +1,5 @@
 """Attempt executor helpers for :mod:`adapter.core.runner_execution`."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
@@ -25,7 +26,7 @@ class _ParallelRunner(Protocol):
 
 _RunSingle = Callable[
     [ProviderConfig, BaseProvider, GoldenTask, int, str],
-    SingleRunResult,
+    "SingleRunResult",
 ]
 
 
@@ -41,8 +42,8 @@ class SequentialAttemptExecutor:
         task: GoldenTask,
         attempt_index: int,
         mode: str,
-    ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
-        batch: list[tuple[int, SingleRunResult]] = []
+    ) -> tuple[list[tuple[int, "SingleRunResult"]], str | None]:
+        batch: list[tuple[int, "SingleRunResult"]] = []
         stop_reason: str | None = None
         for index, (provider_config, provider) in enumerate(providers):
             result = self._run_single(provider_config, provider, task, attempt_index, mode)
@@ -76,7 +77,7 @@ class ParallelAttemptExecutor:
         task: GoldenTask,
         attempt_index: int,
         config: RunnerConfig,
-    ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+    ) -> tuple[list[tuple[int, "SingleRunResult"]], str | None]:
         if not providers:
             return [], None
 
@@ -84,7 +85,7 @@ class ParallelAttemptExecutor:
         max_workers = self._normalize_concurrency(len(providers), max_concurrency)
 
         stop_reason: str | None = None
-        results: list[SingleRunResult | None] = [None] * len(providers)
+        results: list["SingleRunResult | None"] = [None] * len(providers)
 
         def build_worker(
             index: int, provider_config: ProviderConfig, provider: BaseProvider

--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -143,12 +143,22 @@ class CompareRunner:
         if config.judge_provider is not None:
             self._judge_provider_config = config.judge_provider
 
+        shadow_config = getattr(config, "shadow_provider", None)
+        shadow_factory: Callable[[], BaseProvider] | None = None
+        if shadow_config is not None:
+            def _create_shadow_provider() -> BaseProvider:
+                return ProviderFactory.create(shadow_config)
+
+            shadow_factory = _create_shadow_provider
+
         execution = RunnerExecution(
             token_bucket=self._token_bucket,
             schema_validator=self._schema_validator,
             evaluate_budget=self._evaluate_budget,
             build_metrics=self._build_metrics,
             normalize_concurrency=self._normalize_concurrency,
+            shadow_provider_factory=shadow_factory,
+            shadow_config=shadow_config,
         )
 
         providers: list[tuple[ProviderConfig, BaseProvider]] = []


### PR DESCRIPTION
## Summary
- add optional shadow_provider to RunnerConfig and record shadow telemetry fields on RunMetrics
- invoke configured shadow provider in RunnerExecution without affecting primary selection and propagate metrics through CompareRunner
- cover the shadow execution behaviour with unit tests ensuring metrics capture and selection stability

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py -k shadow

------
https://chatgpt.com/codex/tasks/task_e_68dbb45e464c8321becf244c90ef55a3