### PR TITLE
Organize metrics imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, UTC
 import hashlib
 from statistics import median
-from typing import Any, TYPE_CHECKING, Literal
+from typing import Any, Literal, TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
## Summary
- reorder imports in `adapter/core/metrics.py` to group standard library, third-party, and local modules

## Testing
- `ruff check --select I001 projects/04-llm-adapter/adapter/core/metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68dbba077e308321a416150a6d047a02