### PR TITLE
Adjust provider SPI imports for collections.abc

### DIFF
--- a/projects/04-llm-adapter/adapter/core/provider_spi.py
+++ b/projects/04-llm-adapter/adapter/core/provider_spi.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- import Mapping and Sequence from collections.abc in the provider SPI module to follow modern typing guidance

## Testing
- ruff check --select UP035 projects/04-llm-adapter/adapter/core/provider_spi.py

------
https://chatgpt.com/codex/tasks/task_e_68dbba0737b883219530066d730b5037