### PR TITLE
chore: tidy runner execution imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -7,8 +7,7 @@ import json
 from pathlib import Path
 from threading import Lock
 from time import perf_counter, sleep
-from typing import TYPE_CHECKING, Literal, TypeVar, Protocol
-
+from typing import Literal, Protocol, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.parallel_exec import (
@@ -61,6 +60,10 @@ from .config import ProviderConfig
 from .datasets import GoldenTask
 from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .providers import BaseProvider, ProviderResponse
+from .runner_execution_attempts import (
+    ParallelAttemptExecutor,
+    SequentialAttemptExecutor,
+)
 
 
 class _TokenBucket:
@@ -116,13 +119,6 @@ class SingleRunResult:
     raw_output: str
     stop_reason: str | None = None
     aggregate_output: str | None = None
-
-
-from .runner_execution_attempts import (
-    ParallelAttemptExecutor,
-    SequentialAttemptExecutor,
-)
-
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import BackoffPolicy, RunnerConfig
 


### PR DESCRIPTION
## Summary
- reorder standard library and local imports in runner_execution to follow preferred grouping
- move runner_execution_attempts import into the primary local import block

## Testing
- ruff check --select I001,E402 projects/04-llm-adapter/adapter/core/runner_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68dbba09cb9c8321a3f9ceb02cfd2d8f