### PR TITLE
Fix SingleRunResult type annotation

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover - 型補完用
 _single_run_result_cls: type[Any] | None = None
 
 
-def _get_single_run_result_cls() -> type["SingleRunResult"]:
+def _get_single_run_result_cls() -> type[SingleRunResult]:
     global _single_run_result_cls
     if _single_run_result_cls is None:
         from .runner_execution import SingleRunResult as _SingleRunResult


### PR DESCRIPTION
## Summary
- update the helper to return the concrete SingleRunResult type

## Testing
- ruff check --select UP037 projects/04-llm-adapter/adapter/core/runner_execution_attempts.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbc6854588321906c6f76475710c8