### PR TITLE
Reorder provider SPI imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/provider_spi.py
+++ b/projects/04-llm-adapter/adapter/core/provider_spi.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 


### PR DESCRIPTION
## Summary
- reorder the provider SPI module's standard library imports alphabetically

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/core/provider_spi.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbc6502188321b2f1a3f5347e7125