### PR TITLE
Refactor runner execution guards into dedicated module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/guards.py
+++ b/projects/04-llm-adapter/adapter/core/execution/guards.py
@@ -1,0 +1,57 @@
+"""Execution guard utilities for runner execution."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from time import perf_counter, sleep
+
+
+class _TokenBucket:
+    def __init__(self, rpm: int | None) -> None:
+        self.capacity = rpm or 0
+        self.tokens = float(self.capacity)
+        self.updated = perf_counter()
+        self.lock = Lock()
+
+    def acquire(self) -> None:
+        if self.capacity <= 0:
+            return
+        refill_rate = self.capacity / 60.0
+        while True:
+            with self.lock:
+                now = perf_counter()
+                elapsed = now - self.updated
+                if elapsed > 0:
+                    self.tokens = min(
+                        float(self.capacity), self.tokens + elapsed * refill_rate
+                    )
+                    self.updated = now
+                if self.tokens >= 1.0:
+                    self.tokens -= 1.0
+                    return
+            sleep(max(1.0 / max(self.capacity, 1), 0.01))
+
+
+class _SchemaValidator:
+    def __init__(self, schema_path: Path | None) -> None:
+        self.schema: dict[str, object] | None = None
+        if schema_path and schema_path.exists():
+            with schema_path.open("r", encoding="utf-8") as fp:
+                self.schema = json.load(fp)
+
+    def validate(self, payload: str) -> None:
+        if self.schema is None or not payload.strip():
+            return
+        data = json.loads(payload)
+        required = self.schema.get("required") if isinstance(self.schema, dict) else None
+        if isinstance(required, list):
+            missing = [field for field in required if field not in data]
+            if missing:
+                raise ValueError(f"missing required fields: {', '.join(missing)}")
+        expected_type = self.schema.get("type") if isinstance(self.schema, dict) else None
+        if expected_type == "object" and not isinstance(data, dict):
+            raise ValueError("schema type mismatch: expected object")
+
+
+__all__ = ["_TokenBucket", "_SchemaValidator"]

--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-import json
 from pathlib import Path
-from threading import Lock
-from time import perf_counter, sleep
+from time import perf_counter
 from typing import Literal, Protocol, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -58,60 +56,9 @@ else:  # pragma: no cover - 実行時フォールバック
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
+from .execution.guards import _SchemaValidator, _TokenBucket
+from .metrics import BudgetSnapshot, RunMetrics, estimate_cost
 from .providers import BaseProvider, ProviderResponse
-from .runner_execution_attempts import (
-    ParallelAttemptExecutor,
-    SequentialAttemptExecutor,
-)
-
-
-class _TokenBucket:
-    def __init__(self, rpm: int | None) -> None:
-        self.capacity = rpm or 0
-        self.tokens = float(self.capacity)
-        self.updated = perf_counter()
-        self.lock = Lock()
-
-    def acquire(self) -> None:
-        if self.capacity <= 0:
-            return
-        refill_rate = self.capacity / 60.0
-        while True:
-            with self.lock:
-                now = perf_counter()
-                elapsed = now - self.updated
-                if elapsed > 0:
-                    self.tokens = min(
-                        float(self.capacity), self.tokens + elapsed * refill_rate
-                    )
-                    self.updated = now
-                if self.tokens >= 1.0:
-                    self.tokens -= 1.0
-                    return
-            sleep(max(1.0 / max(self.capacity, 1), 0.01))
-
-
-class _SchemaValidator:
-    def __init__(self, schema_path: Path | None) -> None:
-        self.schema: dict[str, object] | None = None
-        if schema_path and schema_path.exists():
-            with schema_path.open("r", encoding="utf-8") as fp:
-                self.schema = json.load(fp)
-
-    def validate(self, payload: str) -> None:
-        if self.schema is None or not payload.strip():
-            return
-        data = json.loads(payload)
-        required = self.schema.get("required") if isinstance(self.schema, dict) else None
-        if isinstance(required, list):
-            missing = [field for field in required if field not in data]
-            if missing:
-                raise ValueError(f"missing required fields: {', '.join(missing)}")
-        expected_type = self.schema.get("type") if isinstance(self.schema, dict) else None
-        if expected_type == "object" and not isinstance(data, dict):
-            raise ValueError("schema type mismatch: expected object")
-
 
 @dataclass(slots=True)
 class SingleRunResult:
@@ -121,6 +68,12 @@ class SingleRunResult:
     aggregate_output: str | None = None
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import BackoffPolicy, RunnerConfig
+
+
+from .runner_execution_attempts import (  # noqa: E402  # isort: skip
+    ParallelAttemptExecutor,
+    SequentialAttemptExecutor,
+)
 
 
 _EvaluateBudget = Callable[

--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -16,6 +16,13 @@ if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import RunnerConfig
     from .runner_execution import SingleRunResult
 
+    _RunSingle = Callable[
+        [ProviderConfig, BaseProvider, GoldenTask, int, str],
+        SingleRunResult,
+    ]
+else:
+    _RunSingle = Callable[[ProviderConfig, BaseProvider, GoldenTask, int, str], object]
+
 
 _single_run_result_cls: type[Any] | None = None
 
@@ -37,12 +44,6 @@ class _ParallelRunner(Protocol):
         max_concurrency: int | None = None,
     ) -> object:
         ...
-
-
-_RunSingle = Callable[
-    [ProviderConfig, BaseProvider, GoldenTask, int, str],
-    SingleRunResult,
-]
 
 
 class SequentialAttemptExecutor:


### PR DESCRIPTION
## Summary
- extract the token bucket and schema validation helpers into `adapter.core.execution.guards`
- update `runner_execution` to use the shared guard helpers while preserving its public API
- adjust `runner_execution_attempts` type hints to avoid runtime `SingleRunResult` lookups during import

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc241210c83219bc0380a6ea57769