### PR TITLE
Fix import ordering in runner_execution metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -59,7 +59,7 @@ else:  # pragma: no cover - 実行時フォールバック
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .execution.guards import _SchemaValidator, _TokenBucket
-from .metrics import BudgetSnapshot, RunMetrics, estimate_cost
+from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .provider_spi import ProviderRequest
 from .providers import BaseProvider, ProviderResponse
 


### PR DESCRIPTION
## Summary
- reorder adapter metrics import to follow alphabetical order

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/core/runner_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcdd57914832198cd33683611a409