### PR TITLE
Sort imports and update annotations in compare_runner_finalizer

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import RunMetrics, compute_diff_rate
+from .metrics import compute_diff_rate, RunMetrics
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -94,7 +94,7 @@ class TaskFinalizer:
         self,
         task: GoldenTask,
         providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        histories: Sequence[Sequence["SingleRunResult"]],
+        histories: Sequence[Sequence[SingleRunResult]],
         results: list[RunMetrics],
     ) -> None:
         for index, (provider_config, _) in enumerate(providers):


### PR DESCRIPTION
## Summary
- sort the standard library and local import blocks in `compare_runner_finalizer`
- remove the unnecessary string literal wrapper from `SingleRunResult` type annotations

## Testing
- ruff check --select I001,UP037 projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py

------
https://chatgpt.com/codex/tasks/task_e_68dbce78ed10832185507d6f556f3277