### PR TITLE
Refactor async runner support helpers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
@@ -1,0 +1,212 @@
+"""Support utilities for :mod:`llm_adapter.runner_async`."""
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any, cast
+
+from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
+from .observability import EventLogger
+from .parallel_exec import ParallelExecutionError
+from .provider_spi import (
+    AsyncProviderSPI,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderSPI,
+)
+from .runner_async_modes import AsyncRunContext, WorkerResult, collect_failure_details
+from .runner_shared import RateLimiter, log_provider_call, log_provider_skipped
+from .shadow import ShadowMetrics, run_with_shadow_async
+from .utils import elapsed_ms
+
+
+class AsyncProviderInvoker:
+    """Encapsulates provider invocation with logging and rate limiting."""
+
+    def __init__(self, *, rate_limiter: RateLimiter | None) -> None:
+        self._rate_limiter = rate_limiter
+
+    async def invoke(
+        self,
+        provider: ProviderSPI | AsyncProviderSPI,
+        async_provider: AsyncProviderSPI,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        event_logger: EventLogger | None,
+        request_fingerprint: str,
+        metadata: Mapping[str, Any],
+        shadow: ProviderSPI | AsyncProviderSPI | None,
+        shadow_async: AsyncProviderSPI | None,
+        metrics_path: str | None,
+        capture_shadow_metrics: bool,
+    ) -> tuple[ProviderResponse, ShadowMetrics | None]:
+        if self._rate_limiter is not None:
+            await self._rate_limiter.acquire_async()
+        attempt_started = time.time()
+        shadow_metrics: ShadowMetrics | None = None
+        response: ProviderResponse
+        try:
+            if capture_shadow_metrics:
+                response_with_metrics = await run_with_shadow_async(
+                    async_provider,
+                    shadow_async,
+                    request,
+                    metrics_path=metrics_path,
+                    logger=event_logger,
+                    capture_metrics=True,
+                )
+                response, shadow_metrics = cast(
+                    tuple[ProviderResponse, ShadowMetrics | None],
+                    response_with_metrics,
+                )
+            else:
+                response_only = await run_with_shadow_async(
+                    async_provider,
+                    shadow_async,
+                    request,
+                    metrics_path=metrics_path,
+                    logger=event_logger,
+                    capture_metrics=False,
+                )
+                response = cast(ProviderResponse, response_only)
+        except RateLimitError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except RetryableError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except SkipError as err:
+            if isinstance(err, ProviderSkip):
+                log_provider_skipped(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=provider,
+                    request=request,
+                    attempt=attempt,
+                    total_providers=total_providers,
+                    error=err,
+                )
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        except FatalError as err:
+            log_provider_call(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                provider=provider,
+                request=request,
+                attempt=attempt,
+                total_providers=total_providers,
+                status="error",
+                latency_ms=elapsed_ms(attempt_started),
+                tokens_in=None,
+                tokens_out=None,
+                error=err,
+                metadata=metadata,
+                shadow_used=shadow is not None,
+                allow_private_model=True,
+            )
+            raise
+        token_usage = response.token_usage
+        log_provider_call(
+            event_logger,
+            request_fingerprint=request_fingerprint,
+            provider=provider,
+            request=request,
+            attempt=attempt,
+            total_providers=total_providers,
+            status="ok",
+            latency_ms=response.latency_ms,
+            tokens_in=token_usage.prompt,
+            tokens_out=token_usage.completion,
+            error=None,
+            metadata=metadata,
+            shadow_used=shadow is not None,
+            allow_private_model=True,
+        )
+        return response, shadow_metrics
+
+
+def emit_consensus_failure(
+    *,
+    context: AsyncRunContext,
+    results: list[WorkerResult] | None,
+    failure_details: list[dict[str, str]] | None,
+    last_error: Exception | None,
+) -> tuple[list[dict[str, str]] | None, Exception | None]:
+    """Aggregate consensus failures and emit metrics/errors."""
+
+    updated_details = failure_details
+    if results is not None:
+        for _, _, _, metrics in results:
+            if metrics is not None:
+                metrics.emit()
+        no_success = not any(len(entry) >= 3 and entry[2] is not None for entry in results)
+        if no_success and not updated_details:
+            updated_details = collect_failure_details(context)
+    elif not updated_details:
+        updated_details = collect_failure_details(context)
+
+    updated_error = last_error
+    if updated_details and (
+        updated_error is None or not isinstance(updated_error, ParallelExecutionError)
+    ):
+        detail_text = "; ".join(
+            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
+            for item in updated_details
+        )
+        message = "all workers failed"
+        if detail_text:
+            message = f"{message}: {detail_text}"
+        updated_error = ParallelExecutionError(message, failures=updated_details)
+
+    return updated_details, updated_error
+
+
+__all__ = ["AsyncProviderInvoker", "emit_consensus_failure"]


### PR DESCRIPTION
## Summary
- extract provider invocation and consensus failure handling into a dedicated support module for the async runner
- simplify AsyncRunner to delegate provider calls and failure aggregation to the shared helpers while preserving the public interface

## Testing
- `pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py`


------
https://chatgpt.com/codex/tasks/task_e_68dbcda22dd48321b314f112560a7ea5