### PR TITLE
Fix import order and annotations in compare runner finalizer

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import RunMetrics, compute_diff_rate
+from .metrics import compute_diff_rate, RunMetrics
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -94,7 +94,7 @@ class TaskFinalizer:
         self,
         task: GoldenTask,
         providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        histories: Sequence[Sequence["SingleRunResult"]],
+        histories: Sequence[Sequence[SingleRunResult]],
         results: list[RunMetrics],
     ) -> None:
         for index, (provider_config, _) in enumerate(providers):


### PR DESCRIPTION
## Summary
- reorder the standard library imports in `compare_runner_finalizer.py`
- drop unnecessary string forward references for `SingleRunResult`

## Testing
- `ruff check --select I001,UP037 projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68dbcedb3d2083218f85bc20eec858e8