### PR TITLE
Handle auth/config errors during sequential fallback

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -7,6 +7,8 @@ import time
 from typing import cast, Protocol, TYPE_CHECKING
 
 from .errors import (
+    AuthError,
+    ConfigError,
     FatalError,
     ProviderSkip,
     RateLimitError,
@@ -170,6 +172,19 @@ class SequentialStrategy:
             if error is None:
                 continue
             if isinstance(error, FatalError):
+                if isinstance(error, (AuthError, ConfigError)):
+                    if event_logger is not None:
+                        event_logger.emit(
+                            "provider_fallback",
+                            {
+                                "request_fingerprint": context.request_fingerprint,
+                                "provider": provider.name(),
+                                "attempt": attempt_index,
+                                "error_type": type(error).__name__,
+                                "error_message": str(error),
+                            },
+                        )
+                    continue
                 raise error
             if isinstance(error, RateLimitError):
                 sleep_duration = config.backoff.rate_limit_sleep_s

--- a/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
+++ b/projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
@@ -4,7 +4,13 @@ from collections.abc import Sequence
 
 import pytest
 
-from src.llm_adapter.errors import AuthError, RateLimitError, RetriableError, TimeoutError
+from src.llm_adapter.errors import (
+    AuthError,
+    ConfigError,
+    RateLimitError,
+    RetriableError,
+    TimeoutError,
+)
 from src.llm_adapter.provider_spi import ProviderSPI
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig
 
@@ -247,3 +253,39 @@ def test_run_metric_contains_tokens_and_cost() -> None:
     assert run_event["tokens_out"] == 9
     assert run_event["cost_usd"] == pytest.approx(0.456)
     assert succeeding.cost_calls == [(21, 9)]
+
+
+def test_auth_error_falls_back_and_logs() -> None:
+    response, logger = _run_and_collect(
+        [
+            _ErrorProvider("auth", AuthError("invalid")),
+            _SuccessProvider("fallback"),
+        ]
+    )
+
+    assert response is not None
+    fallback_events = logger.of_type("provider_fallback")
+    assert len(fallback_events) == 1
+    event = fallback_events[0]
+    assert event["provider"] == "auth"
+    assert event["attempt"] == 1
+    assert event["error_type"] == "AuthError"
+    assert event["error_message"] == "invalid"
+
+
+def test_config_error_falls_back_and_logs() -> None:
+    response, logger = _run_and_collect(
+        [
+            _ErrorProvider("config", ConfigError("bad setup")),
+            _SuccessProvider("fallback"),
+        ]
+    )
+
+    assert response is not None
+    fallback_events = logger.of_type("provider_fallback")
+    assert len(fallback_events) == 1
+    event = fallback_events[0]
+    assert event["provider"] == "config"
+    assert event["attempt"] == 1
+    assert event["error_type"] == "ConfigError"
+    assert event["error_message"] == "bad setup"


### PR DESCRIPTION
## Summary
- allow the sequential runner strategy to continue past AuthError/ConfigError while logging a provider_fallback event
- add regression tests covering sequential fallback for AuthError and ConfigError in the shadow runner suite

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd07371808321ae27f34234fd855b