### PR TITLE
Add provider-weighted consensus support

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
@@ -55,7 +55,10 @@ class ConsensusRunStrategy(ParallelStrategyBase):
 
         try:
             consensus = compute_consensus(
-                [response for _, _, response, _ in successful_entries],
+                [
+                    (provider.name(), response)
+                    for _, provider, response, _ in successful_entries
+                ],
                 config=context.config.consensus,
             )
         except ParallelExecutionError as err:
@@ -87,7 +90,7 @@ class ConsensusRunStrategy(ParallelStrategyBase):
                 results=results,
             )
         attempt_index, provider, response, shadow_metrics = winner_entry
-        votes_against = consensus.total_voters - consensus.votes - consensus.abstained
+        votes_against = sum(consensus.tally.values()) - consensus.votes
         if context.event_logger is not None:
             candidate_summaries = [
                 {

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -24,6 +24,7 @@ class ConsensusConfig:
     schema: str | None = None
     judge: str | None = None
     max_rounds: int | None = None
+    provider_weights: dict[str, float] | None = None
 
 
 @dataclass(frozen=True)

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -88,6 +88,24 @@ def test_weighted_strategy_records_scores() -> None:
     assert tie_breaker_selected == "cost"
 
 
+def test_weighted_vote_uses_provider_weights() -> None:
+    responses = [
+        ("p1", _response("A", 10)),
+        ("p2", _response("B", 12)),
+        ("p3", _response("B", 8)),
+    ]
+    config = ConsensusConfig(
+        strategy="weighted_vote",
+        quorum=1,
+        provider_weights={"p1": 5.0, "p2": 1.0, "p3": 0.5},
+    )
+    result = compute_consensus(responses, config=config)
+    assert result.response.text == "A"
+    assert result.tally == pytest.approx({"A": 5.0, "B": 1.5})
+    assert result.votes == pytest.approx(5.0)
+    assert result.scores == pytest.approx({"A": 5.0, "B": 1.5})
+
+
 def test_max_score_strategy_prefers_best_latency() -> None:
     responses = [
         _response("A", 18, score=0.6),


### PR DESCRIPTION
## Summary
- add provider weight configuration to consensus runner settings
- propagate provider identifiers and weights when computing consensus results
- extend consensus tests to cover provider-weighted voting

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py


------
https://chatgpt.com/codex/tasks/task_e_68dbd0763c348321825780b429f5785a