### PR TITLE
Add CLI for configuring runners

### DIFF
--- a/projects/04-llm-adapter-shadow/pyproject.toml
+++ b/projects/04-llm-adapter-shadow/pyproject.toml
@@ -5,6 +5,9 @@ description = "Minimal shadow-execution + error-cases PoC for portfolio"
 requires-python = ">=3.10"
 dependencies = ["PyYAML>=6.0"]
 
+[project.scripts]
+llm-adapter = "src.llm_adapter.cli:main"
+
 [tool.pytest.ini_options]
 pythonpath = ["projects/04-llm-adapter-shadow"]
 addopts = "-q"

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from .providers.factory import create_provider_from_spec, parse_provider_spec, ProviderFactory
+from .runner import AsyncRunner, Runner
+from .runner_config import ConsensusConfig, RunnerConfig, RunnerMode
+from .shadow import DEFAULT_METRICS_PATH, MetricsPath
+
+_AGGREGATE: Mapping[str, str] = {
+    "majority_vote": "majority",
+    "max_score": "max_score",
+    "weighted_vote": "weighted",
+}
+_TIE: Mapping[str, str | None] = {
+    "min_latency": "latency",
+    "min_cost": "cost",
+    "stable_order": None,
+}
+
+
+def _parse_csv(value: str) -> tuple[str, ...]:
+    parts = tuple(entry.strip() for entry in value.split(",") if entry.strip())
+    if not parts:
+        raise argparse.ArgumentTypeError("expected at least one item")
+    return parts
+
+
+def _parse_weights(value: str) -> dict[str, float]:
+    weights: dict[str, float] = {}
+    for item in _parse_csv(value):
+        key, sep, raw = item.partition("=")
+        if not sep:
+            raise argparse.ArgumentTypeError("weights must use key=value")
+        try:
+            weights[key.strip()] = float(raw.strip())
+        except ValueError as exc:  # pragma: no cover - argparse reports error
+            raise argparse.ArgumentTypeError("weight must be numeric") from exc
+    if not weights:
+        raise argparse.ArgumentTypeError("weights must not be empty")
+    return weights
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="llm-adapter")
+    parser.add_argument("--mode", required=True, choices=("sequential", "parallel-any", "parallel-all", "consensus"))
+    parser.add_argument("--providers", required=True, type=_parse_csv)
+    parser.add_argument("--max-concurrency", dest="max_concurrency", type=int)
+    parser.add_argument("--rpm", type=int)
+    parser.add_argument("--aggregate", choices=tuple(_AGGREGATE))
+    parser.add_argument("--quorum", type=int)
+    parser.add_argument("--tie-breaker", choices=tuple(_TIE), dest="tie_breaker")
+    parser.add_argument("--schema")
+    parser.add_argument("--judge")
+    parser.add_argument("--weights", type=_parse_weights)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--out-format", dest="out_format", default="text", choices=("text", "json", "jsonl"))
+    parser.add_argument("--metrics")
+    parser.add_argument("--async-runner", action="store_true", dest="async_runner")
+    return parser.parse_args(argv)
+
+
+def _load_optional_text(path_text: str | None) -> str | None:
+    if not path_text:
+        return None
+    return Path(path_text).read_text(encoding="utf-8")
+
+
+def _build_consensus_config(args: argparse.Namespace) -> ConsensusConfig | None:
+    schema_text = _load_optional_text(args.schema)
+    if not any((args.aggregate, args.quorum, args.tie_breaker, schema_text, args.judge, args.weights)):
+        return None
+    payload: dict[str, Any] = {}
+    if args.aggregate:
+        payload["strategy"] = _AGGREGATE[args.aggregate]
+    if args.quorum is not None:
+        payload["quorum"] = args.quorum
+    if args.tie_breaker is not None:
+        payload["tie_breaker"] = _TIE[args.tie_breaker]
+    if schema_text is not None:
+        payload["schema"] = schema_text
+    if args.judge is not None:
+        payload["judge"] = args.judge
+    if args.weights is not None:
+        payload["provider_weights"] = dict(args.weights)
+    return ConsensusConfig(**payload)
+
+
+def build_runner_config(args: argparse.Namespace) -> RunnerConfig:
+    return RunnerConfig(
+        mode=RunnerMode(args.mode.replace("-", "_")),
+        max_concurrency=args.max_concurrency,
+        rpm=args.rpm,
+        consensus=_build_consensus_config(args),
+    )
+
+
+def _resolve_model_name(spec: str, provider: ProviderSPI) -> str:
+    _, remainder = parse_provider_spec(spec)
+    if remainder:
+        return remainder
+    name = provider.name()
+    if ":" in name:
+        return name.split(":", 1)[1]
+    model_attr = getattr(provider, "model", None)
+    if isinstance(model_attr, str) and model_attr.strip():
+        return model_attr
+    return "primary-model"
+
+
+def prepare_execution(
+    args: argparse.Namespace,
+    *,
+    async_mode: bool | None = None,
+    factories: Mapping[str, ProviderFactory] | None = None,
+) -> tuple[Runner | AsyncRunner, ProviderRequest, MetricsPath]:
+    providers = [create_provider_from_spec(spec, factories=factories) for spec in args.providers]
+    if not providers:
+        raise ValueError("at least one provider is required")
+    request = ProviderRequest(
+        prompt=Path(args.input).read_text(encoding="utf-8") if args.input != "-" else sys.stdin.read(),
+        model=_resolve_model_name(args.providers[0], providers[0]),
+    )
+    config = build_runner_config(args)
+    metrics_path: MetricsPath = args.metrics or DEFAULT_METRICS_PATH
+    use_async = async_mode if async_mode is not None else args.async_runner
+    runner: Runner | AsyncRunner = AsyncRunner(providers, config=config) if use_async else Runner(providers, config=config)
+    return runner, request, metrics_path
+
+
+def _format_output(response: ProviderResponse, fmt: str) -> str:
+    if fmt == "text":
+        return response.text
+    payload = {"text": response.text, "model": response.model, "latency_ms": response.latency_ms}
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        runner, request, metrics_path = prepare_execution(args)
+        if isinstance(runner, AsyncRunner):
+            response = asyncio.run(runner.run_async(request, shadow=None, shadow_metrics_path=metrics_path))
+        else:
+            response = runner.run(request, shadow=None, shadow_metrics_path=metrics_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Execution failed: {exc}", file=sys.stderr)
+        return 1
+    print(_format_output(response, args.out_format))
+    return 0
+
+
+__all__ = ["parse_args", "build_runner_config", "prepare_execution", "main"]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -24,6 +24,7 @@ class ConsensusConfig:
     schema: str | None = None
     judge: str | None = None
     max_rounds: int | None = None
+    provider_weights: dict[str, float] | None = None
 
 
 @dataclass(frozen=True)

--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
+from src.llm_adapter import cli
+from src.llm_adapter.runner import AsyncRunner, Runner
 from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
+from src.llm_adapter.shadow import DEFAULT_METRICS_PATH
 
 
 @pytest.mark.parametrize(
@@ -28,3 +32,84 @@ def test_runner_config_accepts_enum_members() -> None:
     mutated = replace(config, mode=RunnerMode.SEQUENTIAL)
     assert mutated.mode is RunnerMode.SEQUENTIAL
     assert config.mode is RunnerMode.CONSENSUS
+
+
+def test_cli_prepare_execution_with_consensus(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("hello world\n", encoding="utf-8")
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{\"type\":\"object\"}", encoding="utf-8")
+    metrics_path = tmp_path / "metrics.jsonl"
+
+    args = cli.parse_args(
+        [
+            "--mode",
+            "consensus",
+            "--providers",
+            "mock:fast,mock:slow",
+            "--max-concurrency",
+            "3",
+            "--rpm",
+            "120",
+            "--aggregate",
+            "max_score",
+            "--quorum",
+            "3",
+            "--tie-breaker",
+            "min_latency",
+            "--schema",
+            str(schema_path),
+            "--judge",
+            "pkg:judge",
+            "--weights",
+            "mock:fast=1.0,mock:slow=0.5",
+            "--input",
+            str(prompt_path),
+            "--metrics",
+            str(metrics_path),
+        ]
+    )
+
+    assert args.providers == ("mock:fast", "mock:slow")
+    assert args.weights == {"mock:fast": 1.0, "mock:slow": 0.5}
+
+    runner, request, metrics = cli.prepare_execution(args)
+
+    assert isinstance(runner, Runner)
+    config = runner._config
+    assert config.mode is RunnerMode.CONSENSUS
+    consensus = config.consensus
+    assert consensus is not None
+    assert consensus.strategy == "max_score"
+    assert consensus.quorum == 3
+    assert consensus.tie_breaker == "latency"
+    assert consensus.schema == schema_path.read_text(encoding="utf-8")
+    assert consensus.judge == "pkg:judge"
+    assert consensus.provider_weights == {"mock:fast": 1.0, "mock:slow": 0.5}
+    assert metrics == str(metrics_path)
+    assert request.prompt_text == "hello world"
+    assert request.model == "fast"
+
+
+def test_cli_prepare_execution_async(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("ping", encoding="utf-8")
+
+    args = cli.parse_args(
+        [
+            "--mode",
+            "parallel-any",
+            "--providers",
+            "mock:one",
+            "--input",
+            str(prompt_path),
+            "--async-runner",
+        ]
+    )
+
+    runner, request, metrics = cli.prepare_execution(args)
+
+    assert isinstance(runner, AsyncRunner)
+    assert runner._config.mode is RunnerMode.PARALLEL_ANY
+    assert metrics == DEFAULT_METRICS_PATH
+    assert request.model == "one"


### PR DESCRIPTION
## Summary
- add an llm-adapter CLI that normalises arguments into Runner/AsyncRunner configurations and request payloads
- extend consensus configuration with provider weight support and register the CLI as a project entry point
- cover CLI argument propagation and async selection in tests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd07ae8ec83218e86125a220f308a