### PR TITLE
style: sort imports in shadow metrics test

### DIFF
--- a/tests/test_runner_shadow_metrics.py
+++ b/tests/test_runner_shadow_metrics.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import contextlib
-import logging
-import sys
 from dataclasses import replace
+import logging
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -14,7 +14,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "projects" / "04-ll
 
 from adapter.core.metrics import RunMetrics
 from adapter.core.runner_execution import RunnerExecution
-
 
 BASE_METRICS = RunMetrics(
     ts="2024-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
- reorder the standard library imports in `tests/test_runner_shadow_metrics.py` to match the expected grouping

## Testing
- ruff check --select I001 tests/test_runner_shadow_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd57e95dc83219e2b49b39017f18f