### PR TITLE
chore: reorder aggregation imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation.py
@@ -1,11 +1,11 @@
 """応答集約ストラテジ。"""
 from __future__ import annotations
 
-import json
-import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+import json
 from pathlib import Path
+import re
 from typing import Any, cast, Protocol, runtime_checkable, TYPE_CHECKING
 
 __path__ = [str(Path(__file__).with_name("aggregation"))]


### PR DESCRIPTION
## Summary
- reorder the standard library imports in the aggregation module to satisfy linting

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/core/aggregation.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd57b9fac8321839795817559183e