### PR TITLE
Reorder imports in runner_async_support

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
@@ -1,8 +1,8 @@
 """Support utilities for :mod:`llm_adapter.runner_async`."""
 from __future__ import annotations
 
-import time
 from collections.abc import Mapping
+import time
 from typing import Any, cast
 
 from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
@@ -14,9 +14,9 @@ from .provider_spi import (
     ProviderResponse,
     ProviderSPI,
 )
-from .runner_async_modes import AsyncRunContext, WorkerResult, collect_failure_details
-from .runner_shared import RateLimiter, log_provider_call, log_provider_skipped
-from .shadow import ShadowMetrics, run_with_shadow_async
+from .runner_async_modes import AsyncRunContext, collect_failure_details, WorkerResult
+from .runner_shared import log_provider_call, log_provider_skipped, RateLimiter
+from .shadow import run_with_shadow_async, ShadowMetrics
 from .utils import elapsed_ms
 
 


### PR DESCRIPTION
## Summary
- reorder the standard-library imports at the top of runner_async_support to satisfy linting order
- accept Ruff's standard import sorting for the adjacent local imports

## Testing
- ruff check --select I001 projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd57b13108321842bd2be5d603727