### PR TITLE
Sort provider import order

### DIFF
--- a/projects/04-llm-adapter/adapter/core/providers/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/providers/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-import warnings
 from typing import Any
+import warnings
 
 from ..config import ProviderConfig
 from ..provider_spi import ProviderRequest, ProviderResponse as _ProviderResponse, TokenUsage


### PR DESCRIPTION
## Summary
- reorder the provider module's standard library imports to satisfy Ruff's I001 rule

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/core/providers/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd57d59c08321bb576caa5f4ee5ba