### PR TITLE
chore: sort imports in aggregation selector

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+import json
 from pathlib import Path
-from typing import Any, Protocol, TYPE_CHECKING, cast
+from typing import Any, cast, Protocol, TYPE_CHECKING
 
 from . import aggregation as aggregation_module
 from .aggregation import (


### PR DESCRIPTION
## Summary
- reorder standard library imports in `aggregation_selector.py` to satisfy Ruff import sorting

## Testing
- ruff check --select I001 projects/04-llm-adapter/adapter/core/aggregation_selector.py
- ruff check --select I001 projects/04-llm-adapter/adapter/core/aggregation_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd57d5df48321b0e441da9da9952f