### PR TITLE
chore: tidy cli imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections.abc import Mapping, Sequence
 import json
-import sys
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+import sys
+from typing import Any
 
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .providers.factory import create_provider_from_spec, parse_provider_spec, ProviderFactory


### PR DESCRIPTION
## Summary
- reorder the CLI module imports to follow standard library, third-party, and local grouping
- import `Mapping` and `Sequence` from `collections.abc` while limiting `typing` imports to the symbols in use

## Testing
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/cli.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68dbd9c880688321b2854ddc947d6727