### PR TITLE
style: reorder imports in parallel async

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Generic, TypeVar, cast
+import inspect
+from typing import Any, cast, Generic, TypeVar
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## Summary
- reorder the standard library imports in parallel_async.py to align with Ruff sorting

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbd9c9c1c48321bf4c4bfd3caab96f