### PR TITLE
Reorder imports in test_runner_parallel

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -27,9 +27,9 @@ from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
+    _normalize_candidate_text,
     compute_consensus,
     ConsensusConfig,
-    _normalize_candidate_text,
 )
 from src.llm_adapter.runner_sync import Runner
 from src.llm_adapter.shadow import run_with_shadow


### PR DESCRIPTION
## Summary
- reorder imports in the parallel test module to follow standard/third-party/local grouping and alphabetical order
- run ruff with autofix to resolve the I001 violation

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_parallel.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbd9caa9d8832193cae07bd8f0dd80