### PR TITLE
chore: tidy aggregation selector imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+import json
 from pathlib import Path
-from typing import Any, Protocol, TYPE_CHECKING, cast
+from typing import Any, cast, Protocol, TYPE_CHECKING
 
 from . import aggregation as aggregation_module
 from .aggregation import (
@@ -97,7 +97,7 @@ class AggregationSelector:
     def select(
         self,
         mode: str,
-        config: "RunnerConfig",
+        config: RunnerConfig,
         batch: Sequence[tuple[int, SingleRunResult]],
         *,
         default_judge_config: ProviderConfig | None,
@@ -151,7 +151,7 @@ class AggregationSelector:
     def _resolve_aggregation_strategy(
         self,
         mode: str,
-        config: "RunnerConfig",
+        config: RunnerConfig,
         *,
         default_judge_config: ProviderConfig | None,
     ) -> AggregationStrategy | None:
@@ -182,7 +182,7 @@ class AggregationSelector:
 
     @staticmethod
     def _resolve_tie_breaker(
-        config: "RunnerConfig",
+        config: RunnerConfig,
         lookup: Mapping[int, SingleRunResult],
     ) -> TieBreaker | None:
         tie_name = (config.tie_breaker or "").strip().lower()


### PR DESCRIPTION
## Summary
- reorder the aggregation selector imports and tidy the TYPE_CHECKING block
- reference RunnerConfig directly in aggregation selector type hints

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation_selector.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbd9f1aa808321a52f8ff01434b227