### PR TITLE
Refactor imports in parallel_exec

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
@@ -10,7 +10,9 @@ from concurrent.futures import (
     wait,
 )
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, TypeVar
+
+from . import parallel_async as _parallel_async
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -144,9 +146,6 @@ def run_parallel_all_sync(
                 pending.cancel()
             raise
     return responses
-
-
-from . import parallel_async as _parallel_async
 
 AsyncWorker = _parallel_async.AsyncWorker
 RetryDirective = _parallel_async.RetryDirective


### PR DESCRIPTION
## Summary
- reorder imports in `parallel_exec.py` to follow style guidelines and remove the unused `cast`
- move the `parallel_async` import to the standard import section while preserving public re-exports

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbd9ca44548321b8878fb0a9afa4af