### PR TITLE
Fix import order and type hints in consensus runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import cast, TYPE_CHECKING
 
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
-from .provider_spi import ProviderSPI, ProviderResponse
+from .provider_spi import ProviderResponse, ProviderSPI
 from .runner_parallel import compute_consensus
+from .runner_sync_modes import _limited_providers, _raise_no_attempts
 from .shadow import ShadowMetrics
 from .utils import content_hash
-from .runner_sync_modes import _limited_providers, _raise_no_attempts
 
 if TYPE_CHECKING:
     from .runner_sync import ProviderInvocationResult
@@ -18,20 +18,20 @@ if TYPE_CHECKING:
 
 class ConsensusStrategy:
     def execute(
-        self, context: "SyncRunContext"
+        self, context: SyncRunContext
     ) -> ProviderResponse | ParallelAllResult[
-        "ProviderInvocationResult", ProviderResponse
+        ProviderInvocationResult, ProviderResponse
     ]:
         runner = context.runner
         total_providers = len(runner.providers)
-        results: list["ProviderInvocationResult" | None] = [None] * total_providers
+        results: list[ProviderInvocationResult | None] = [None] * total_providers
         max_attempts = runner._config.max_attempts
         providers = _limited_providers(runner.providers, max_attempts)
 
         def make_worker(
             index: int, provider: ProviderSPI
-        ) -> Callable[[], "ProviderInvocationResult"]:
-            def worker() -> "ProviderInvocationResult":
+        ) -> Callable[[], ProviderInvocationResult]:
+            def worker() -> ProviderInvocationResult:
                 result = runner._invoke_provider_sync(
                     provider,
                     context.request,
@@ -70,7 +70,7 @@ class ConsensusStrategy:
             fatal = runner._extract_fatal_error(results)
             if fatal is not None:
                 raise fatal from None
-            successful: list[tuple["ProviderInvocationResult", ProviderResponse]] = [
+            successful: list[tuple[ProviderInvocationResult, ProviderResponse]] = [
                 (res, res.response)
                 for res in invocations
                 if res.response is not None


### PR DESCRIPTION
## Summary
- reorder the consensus runner imports to follow ruff rules
- replace string-based annotations with native references for consensus execution helpers

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbdc9c955c832183057ef0a5bbae24