### PR TITLE
Add outcome fields to shadow metrics schema

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_shadow_metrics_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow_metrics_schema.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.providers.mock import MockProvider
+from src.llm_adapter.runner import Runner
+
+
+def _load_shadow_diff(metrics_path: Path) -> dict[str, object]:
+    payloads = [
+        json.loads(line)
+        for line in metrics_path.read_text().splitlines()
+        if line.strip()
+    ]
+    return next(item for item in payloads if item["event"] == "shadow_diff")
+
+
+def test_shadow_metrics_include_provider_id_and_outcome_success(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    request = ProviderRequest(prompt="hello", model="primary-model")
+    runner.run(request, shadow=shadow, shadow_metrics_path=metrics_path)
+
+    event = _load_shadow_diff(metrics_path)
+    assert event["shadow_provider"] == "shadow"
+    assert event["shadow_provider_id"] == "shadow"
+    assert event["shadow_outcome"] == "success"
+
+
+def test_shadow_metrics_include_provider_id_and_outcome_error(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    request = ProviderRequest(prompt="[TIMEOUT] boom", model="primary-model")
+    runner.run(request, shadow=shadow, shadow_metrics_path=metrics_path)
+
+    event = _load_shadow_diff(metrics_path)
+    assert event["shadow_provider"] == "shadow"
+    assert event["shadow_provider_id"] == "shadow"
+    assert event["shadow_outcome"] == "error"


### PR DESCRIPTION
## Summary
- add outcome resolution helper to include `shadow_provider_id` and `shadow_outcome` in shadow metrics
- populate shadow payloads with explicit outcomes for success, failure, and timeout cases
- cover new schema expectations with success and error pytest cases

## Testing
- pytest tests/test_shadow_metrics_schema.py


------
https://chatgpt.com/codex/tasks/task_e_68dbdc44ef188321bad61eaff1f6435b