### PR TITLE
feat: add AllFailedError handling for async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -192,6 +192,8 @@ class AsyncRunner:
             shadow_used=shadow is not None,
         )
         if last_err is not None:
+            if mode == RunnerMode.CONSENSUS or total_providers <= 1:
+                raise last_err
             raise failure_error from last_err
         raise failure_error
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -270,6 +270,9 @@ def log_run_metric(
             "shadow_used": shadow_used,
             "trace_id": metadata.get("trace_id"),
             "project_id": metadata.get("project_id"),
+            "run_id": metadata.get("run_id"),
+            "mode": metadata.get("mode"),
+            "providers": metadata.get("providers"),
         },
     )
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.shadow._runner_test_helpers import _ErrorProvider, _SuccessProvider, FakeLogger
+from src.llm_adapter.errors import RetriableError
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.runner_async import AllFailedError, AsyncRunner
+
+
+pytestmark = pytest.mark.usefixtures("socket_enabled")
+
+
+@pytest.mark.asyncio
+async def test_all_failed_error_is_raised_and_wrapped() -> None:
+    logger = FakeLogger()
+    first_error = RetriableError("nope")
+    runner = AsyncRunner(
+        [
+            _ErrorProvider("first", first_error),
+            _ErrorProvider("second", RetriableError("still nope")),
+        ],
+        logger=logger,
+    )
+    request = ProviderRequest(prompt="hello", model="demo-model")
+
+    with pytest.raises(AllFailedError) as excinfo:
+        await runner.run_async(request, shadow_metrics_path="unused.jsonl")
+
+    assert isinstance(excinfo.value.__cause__, RetriableError)
+    run_event = logger.of_type("run_metric")[0]
+    assert run_event["status"] == "error"
+    assert run_event["run_id"] == run_event["request_fingerprint"]
+    assert run_event["mode"] == "sequential"
+    assert run_event["providers"] == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_run_metric_success_includes_extended_metadata() -> None:
+    logger = FakeLogger()
+    runner = AsyncRunner([_SuccessProvider("primary")], logger=logger)
+    request = ProviderRequest(prompt="hello", model="demo-model")
+
+    await runner.run_async(request, shadow_metrics_path="unused.jsonl")
+
+    run_event = logger.of_type("run_metric")[0]
+    assert run_event["status"] == "ok"
+    assert run_event["run_id"] == run_event["request_fingerprint"]
+    assert run_event["mode"] == "sequential"
+    assert run_event["providers"] == ["primary"]


### PR DESCRIPTION
## Summary
- add AllFailedError type to the async runner and use RunnerConfig defaults for shadow providers
- enrich run metadata with run_id, mode, and provider list for success and failure metrics
- cover AllFailedError propagation and extended run_metric fields with new async tests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py

------
https://chatgpt.com/codex/tasks/task_e_68dbdc41d39c8321b0986d580f2f4a57