### PR TITLE
Add run metric metadata enrichment

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .provider_spi import ProviderSPI
 
 
 class RunnerMode(str, Enum):
@@ -42,6 +46,7 @@ class RunnerConfig:
     max_concurrency: int | None = None
     rpm: int | None = None
     consensus: ConsensusConfig | None = None
+    shadow_provider: ProviderSPI | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.mode, RunnerMode):

--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.runner import Runner, RunnerConfig
+from src.llm_adapter.runner_config import RunnerMode
+
+from .shadow._runner_test_helpers import FakeLogger, _SuccessProvider
+
+
+def _run_and_fetch_event(
+    runner: Runner,
+    request: ProviderRequest,
+    *,
+    metrics_path: Path,
+) -> list[dict[str, object]]:
+    runner.run(request, shadow_metrics_path=metrics_path)
+    logger = runner._logger
+    assert isinstance(logger, FakeLogger)
+    events = logger.of_type("run_metric")
+    assert events, "expected at least one run_metric event"
+    return events
+
+
+def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
+    provider = _SuccessProvider("primary")
+    logger = FakeLogger()
+    runner = Runner([provider], logger=logger)
+    request = ProviderRequest(prompt="hello", model="demo-seq")
+
+    events = _run_and_fetch_event(runner, request, metrics_path=tmp_path / "seq.jsonl")
+    event = events[0]
+
+    assert event["run_id"] == event["request_fingerprint"]
+    assert event["mode"] == RunnerMode.SEQUENTIAL.value
+    assert event["providers"] == ["primary"]
+    assert event["provider_id"] == event["provider"]
+    assert event["cost_estimate"] == pytest.approx(event["cost_usd"])  # type: ignore[arg-type]
+    assert event["retries"] == event["attempts"] - 1  # type: ignore[operator]
+    assert event["outcome"] == "success"
+    assert "shadow_provider_id" in event
+
+
+def test_parallel_run_metric_uses_shadow_default(tmp_path: Path) -> None:
+    primary = _SuccessProvider("primary")
+    secondary = _SuccessProvider("secondary")
+    shadow = _SuccessProvider("shadow")
+    config = RunnerConfig(mode=RunnerMode.PARALLEL_ALL, shadow_provider=shadow)
+    logger = FakeLogger()
+    runner = Runner([primary, secondary], logger=logger, config=config)
+    request = ProviderRequest(prompt="hello", model="demo-parallel")
+
+    events = _run_and_fetch_event(runner, request, metrics_path=tmp_path / "parallel.jsonl")
+
+    for event in events:
+        assert event["run_id"] == event["request_fingerprint"]
+        assert event["mode"] == RunnerMode.PARALLEL_ALL.value
+        assert event["providers"] == ["primary", "secondary"]
+        assert event["provider_id"] == event["provider"]
+        assert event["outcome"] == "success"
+        assert event["shadow_used"] is True
+        assert event["shadow_provider_id"] == "shadow"


### PR DESCRIPTION
## Summary
- enrich provider call and run metric events with normalized identifiers, outcome metadata, and cost aliases
- propagate run-level metadata in the sync runner, including defaulting to the configured shadow provider
- add regression tests that validate run metric schemas for sequential and parallel modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbdc3ef5108321979776f804dbeac6