### PR TITLE
Add AllFailedError handling for sequential runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -7,6 +7,7 @@ Runner retry policy:
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import Enum
 
 
@@ -24,6 +25,14 @@ class SkipError(AdapterError):
 
 class FatalError(AdapterError):
     """Base class for unrecoverable issues that should halt the runner."""
+
+
+class AllFailedError(FatalError):
+    """Raised when all providers fail without yielding a usable response."""
+
+    def __init__(self, message: str, *, failures: Sequence[dict[str, str]] | None = None) -> None:
+        super().__init__(message)
+        self.failures: list[dict[str, str]] = list(failures or [])
 
 
 class TimeoutError(RetryableError):
@@ -90,6 +99,7 @@ __all__ = [
     "AuthError",
     "SkipError",
     "FatalError",
+    "AllFailedError",
     "ProviderSkip",
     "SkipReason",
     "ConfigError",

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
@@ -70,12 +70,24 @@ class ConsensusStrategy:
             fatal = runner._extract_fatal_error(results)
             if fatal is not None:
                 raise fatal from None
-            successful: list[tuple["ProviderInvocationResult", ProviderResponse]] = [
-                (res, res.response)
-                for res in invocations
-                if res.response is not None
-            ]
-            if not successful:
+            candidates: list[
+                tuple[str, ProviderResponse, dict[str, object]]
+            ] = []
+            for invocation in invocations:
+                response = invocation.response
+                if response is None:
+                    continue
+                metadata: dict[str, object] = {
+                    "invocation": invocation,
+                    "attempt": invocation.attempt,
+                    "latency_ms": response.latency_ms,
+                    "tokens_in": invocation.tokens_in,
+                    "tokens_out": invocation.tokens_out,
+                }
+                candidates.append(
+                    (invocation.provider.name(), response, metadata)
+                )
+            if not candidates:
                 failure_details: list[dict[str, str]] = []
                 for invocation in invocations:
                     provider_name = invocation.provider.name()
@@ -102,15 +114,19 @@ class ConsensusStrategy:
                     message = f"{message}: {detail_text}"
                 error = ParallelExecutionError(message, failures=failure_details)
                 raise error
-            responses_for_consensus = [response for _, response in successful]
+            responses_for_consensus = [response for _, response, _ in candidates]
             consensus = compute_consensus(
                 responses_for_consensus,
                 config=runner._config.consensus,
             )
-            winner_invocation = next(
-                invocation
-                for invocation, response in successful
-                if response is consensus.response
+            winner_name, _, winner_metadata = next(
+                entry
+                for entry in candidates
+                if entry[1] is consensus.response
+            )
+            winner_invocation = cast(
+                "ProviderInvocationResult",
+                winner_metadata["invocation"],
             )
             votes_against = (
                 consensus.total_voters - consensus.votes - consensus.abstained
@@ -119,12 +135,12 @@ class ConsensusStrategy:
             if event_logger is not None:
                 candidate_summaries = [
                     {
-                        "provider": invocation.provider.name(),
+                        "provider": provider_name,
                         "latency_ms": response.latency_ms,
                         "votes": consensus.tally.get(response.text.strip(), 0),
                         "text_hash": content_hash("consensus", response.text),
                     }
-                    for invocation, response in successful
+                    for provider_name, response, _ in candidates
                 ]
                 event_logger.emit(
                     "consensus_vote",
@@ -138,7 +154,7 @@ class ConsensusStrategy:
                         "votes_for": consensus.votes,
                         "votes_against": votes_against,
                         "abstained": consensus.abstained,
-                        "winner_provider": winner_invocation.provider.name(),
+                        "winner_provider": winner_name,
                         "winner_score": consensus.winner_score,
                         "winner_latency_ms": consensus.response.latency_ms,
                         "tie_break_applied": consensus.tie_break_applied,

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -7,6 +7,7 @@ import time
 from typing import cast, Protocol, TYPE_CHECKING
 
 from .errors import (
+    AllFailedError,
     AuthError,
     ConfigError,
     FatalError,
@@ -84,6 +85,7 @@ def _limited_providers(
 def _raise_no_attempts(context: SyncRunContext) -> None:
     event_logger = context.event_logger
     runner = context.runner
+    error = AllFailedError("no providers were attempted", failures=[])
     if event_logger is not None:
         event_logger.emit(
             "provider_chain_failed",
@@ -107,11 +109,11 @@ def _raise_no_attempts(context: SyncRunContext) -> None:
         tokens_in=None,
         tokens_out=None,
         cost_usd=0.0,
-        error=None,
+        error=error,
         metadata=context.metadata,
         shadow_used=context.shadow_used,
     )
-    raise RuntimeError("No providers succeeded")
+    raise error
 
 
 class SequentialStrategy:
@@ -125,6 +127,7 @@ class SequentialStrategy:
         max_attempts = config.max_attempts
         event_logger = context.event_logger
         last_err: Exception | None = None
+        failure_details: list[dict[str, str]] = []
         attempt_count = 0
 
         for loop_index, provider in enumerate(runner.providers, start=1):
@@ -167,6 +170,15 @@ class SequentialStrategy:
 
             error = result.error
             last_err = error
+            if error is not None:
+                summary = f"{type(error).__name__}: {error}"
+                failure_details.append(
+                    {
+                        "provider": provider.name(),
+                        "attempt": str(attempt_index),
+                        "summary": summary,
+                    }
+                )
             if error is None:
                 continue
             if isinstance(error, FatalError):
@@ -213,6 +225,14 @@ class SequentialStrategy:
                     "last_error_family": error_family(last_err),
                 },
             )
+        detail_text = "; ".join(
+            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
+            for item in failure_details
+        )
+        message = "all providers failed"
+        if detail_text:
+            message = f"{message}: {detail_text}"
+        failure_error = AllFailedError(message, failures=failure_details)
         log_run_metric(
             event_logger,
             request_fingerprint=context.request_fingerprint,
@@ -224,11 +244,13 @@ class SequentialStrategy:
             tokens_in=None,
             tokens_out=None,
             cost_usd=0.0,
-            error=last_err,
+            error=failure_error,
             metadata=context.metadata,
             shadow_used=context.shadow_used,
         )
-        raise last_err if last_err is not None else RuntimeError("No providers succeeded")
+        if last_err is not None:
+            raise failure_error from last_err
+        raise failure_error
 
 
 class ParallelAnyStrategy:

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from src.llm_adapter.errors import AllFailedError, TimeoutError
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.runner_config import RunnerConfig
+from src.llm_adapter.runner_sync import Runner
+
+
+class _FailingProvider:
+    def __init__(self, name: str, error: Exception) -> None:
+        self._name = name
+        self._error = error
+        self.calls = 0
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        self.calls += 1
+        raise self._error
+
+
+def test_sequential_raises_all_failed_error_with_cause() -> None:
+    request = ProviderRequest(model="gpt-test", prompt="hello")
+    first_error = TimeoutError("slow")
+    second_error = TimeoutError("boom")
+    providers = [
+        _FailingProvider("first", first_error),
+        _FailingProvider("second", second_error),
+    ]
+    runner = Runner(providers, config=RunnerConfig())
+
+    with pytest.raises(AllFailedError) as exc_info:
+        runner.run(request)
+
+    error = exc_info.value
+    assert error.__cause__ is second_error
+    assert providers[0].calls == 1
+    assert providers[1].calls == 1


### PR DESCRIPTION
## Summary
- add an AllFailedError fatal exception and expose it for consumers
- raise AllFailedError with failure summaries when sequential fallback exhausts providers and in no-attempt situations
- restructure consensus candidates to include provider metadata and keep event/shadow reporting aligned; add regression coverage for sequential all-failures

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68dbdc3d5e1c8321841f857a83d91053