### PR TITLE
feat: handle provider backoff and failure propagation in runner executors

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from pathlib import Path
 from threading import Thread
-from time import perf_counter
+from time import perf_counter, sleep
 from typing import Literal, Protocol, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -59,6 +59,14 @@ else:  # pragma: no cover - 実行時フォールバック
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .execution.guards import _SchemaValidator, _TokenBucket
+from .errors import (
+    AuthError,
+    ConfigError,
+    ProviderSkip,
+    RateLimitError,
+    RetriableError,
+    TimeoutError,
+)
 from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .provider_spi import ProviderRequest
 from .providers import BaseProvider, ProviderResponse
@@ -71,6 +79,8 @@ class SingleRunResult:
     raw_output: str
     stop_reason: str | None = None
     aggregate_output: str | None = None
+    error: Exception | None = None
+    backoff_next_provider: bool = False
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import BackoffPolicy, RunnerConfig
 
@@ -235,11 +245,16 @@ class RunnerExecution:
             )
             shadow_thread.start()
             shadow_result = shadow_data
-        response, status, failure_kind, error_message, latency_ms = self._run_provider_call(
+        provider_result = self._run_provider_call(
             provider_config,
             provider,
             prompt,
         )
+        response = provider_result.response
+        status = provider_result.status
+        failure_kind = provider_result.failure_kind
+        error_message = provider_result.error_message
+        latency_ms = provider_result.latency_ms
         cost_usd = estimate_cost(
             provider_config, response.input_tokens, response.output_tokens
         )
@@ -293,7 +308,9 @@ class RunnerExecution:
             "completion": completion_tokens,
             "total": total_tokens,
         }
-        run_metrics.retries = max(self._current_attempt_index, 0)
+        run_metrics.retries = max(self._current_attempt_index, 0) + max(
+            provider_result.retries - 1, 0
+        )
         if schema_error:
             run_metrics.status = status
             run_metrics.failure_kind = failure_kind
@@ -324,6 +341,8 @@ class RunnerExecution:
             metrics=run_metrics,
             raw_output=raw_output,
             stop_reason=stop_reason,
+            error=provider_result.error,
+            backoff_next_provider=provider_result.backoff_next_provider,
         )
 
     def _run_provider_call(
@@ -331,17 +350,87 @@ class RunnerExecution:
         provider_config: ProviderConfig,
         provider: BaseProvider,
         prompt: str,
-    ) -> tuple[ProviderResponse, str, str | None, str | None, int]:
-        response, status, failure_kind, error_message, latency_ms = self._invoke_provider(
-            provider, prompt
-        )
+    ) -> "_ProviderCallResult":
+        result = self._invoke_provider(provider, prompt)
         status, failure_kind = self._check_timeout(
-            provider_config, latency_ms, status, failure_kind
+            provider_config, result.latency_ms, result.status, result.failure_kind
         )
         status, failure_kind = self._enforce_output_guard(
-            response.output_text, status, failure_kind
+            result.response.output_text, status, failure_kind
         )
-        return response, status, failure_kind, error_message, latency_ms
+        result.status = status
+        result.failure_kind = failure_kind
+        return result
+
+    def _build_error_result(
+        self,
+        prompt: str,
+        started_at: float,
+        error: Exception,
+        *,
+        status: str,
+        failure_kind: str,
+        advance: bool,
+    ) -> _ProviderCallResult:
+        latency_ms = int((perf_counter() - started_at) * 1000)
+        response = self._build_error_response(prompt, latency_ms)
+        return _ProviderCallResult(
+            response=response,
+            status=status,
+            failure_kind=failure_kind,
+            error_message=str(error),
+            latency_ms=latency_ms,
+            retries=1,
+            error=error,
+            backoff_next_provider=advance,
+        )
+
+    def _handle_backoff_error(
+        self,
+        prompt: str,
+        started_at: float,
+        error: Exception,
+        *,
+        status: str,
+        failure_kind: str,
+        default_advance: bool,
+    ) -> _ProviderCallResult:
+        advance = self._apply_backoff(error)
+        if not advance:
+            advance = default_advance
+        return self._build_error_result(
+            prompt,
+            started_at,
+            error,
+            status=status,
+            failure_kind=failure_kind,
+            advance=advance,
+        )
+
+    def _build_error_response(self, prompt: str, latency_ms: int) -> ProviderResponse:
+        return ProviderResponse(
+            output_text="",
+            input_tokens=len(prompt.split()),
+            output_tokens=0,
+            latency_ms=latency_ms,
+        )
+
+    def _apply_backoff(self, error: Exception) -> bool:
+        policy = self._backoff
+        if policy is None:
+            return False
+        should_advance = False
+        delay = 0.0
+        if isinstance(error, RateLimitError):
+            delay = float(policy.rate_limit_sleep_s or 0.0)
+            should_advance = True
+        elif isinstance(error, TimeoutError):
+            should_advance = bool(policy.timeout_next_provider)
+        elif isinstance(error, RetriableError):
+            should_advance = bool(policy.retryable_next_provider)
+        if delay > 0.0:
+            sleep(delay)
+        return should_advance
 
     @staticmethod
     def _check_timeout(
@@ -366,29 +455,88 @@ class RunnerExecution:
             return "error", failure_kind or "guard_violation"
         return status, failure_kind
 
-    @staticmethod
     def _invoke_provider(
-        provider: BaseProvider, prompt: str
-    ) -> tuple[ProviderResponse, str, str | None, str | None, int]:
+        self, provider: BaseProvider, prompt: str
+    ) -> _ProviderCallResult:
         start = perf_counter()
-        status = "ok"
-        failure_kind: str | None = None
-        error_message: str | None = None
         try:
             response = provider.generate(prompt)
-        except Exception as exc:  # pragma: no cover - 実プロバイダ利用時の防御
-            status = "error"
-            failure_kind = "provider_error"
-            error_message = str(exc)
+        except ProviderSkip as exc:
             latency_ms = int((perf_counter() - start) * 1000)
-            response = ProviderResponse(
-                output_text="",
-                input_tokens=len(prompt.split()),
-                output_tokens=0,
+            response = self._build_error_response(prompt, latency_ms)
+            return _ProviderCallResult(
+                response=response,
+                status="skip",
+                failure_kind="skip",
+                error_message=str(exc),
                 latency_ms=latency_ms,
+                retries=1,
+                error=exc,
+                backoff_next_provider=True,
             )
-            return response, status, failure_kind, error_message, latency_ms
-        return response, status, failure_kind, error_message, response.latency_ms
+        except AuthError as exc:
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="auth",
+                advance=True,
+            )
+        except ConfigError as exc:
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="config",
+                advance=True,
+            )
+        except RateLimitError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="rate_limit",
+                default_advance=True,
+            )
+        except TimeoutError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="timeout",
+                default_advance=False,
+            )
+        except RetriableError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="retryable",
+                default_advance=False,
+            )
+        except Exception as exc:  # pragma: no cover - 実プロバイダ利用時の防御
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="provider_error",
+                advance=False,
+            )
+        latency_ms = response.latency_ms
+        return _ProviderCallResult(
+            response=response,
+            status="ok",
+            failure_kind=None,
+            error_message=None,
+            latency_ms=latency_ms,
+            retries=1,
+        )
 
     @staticmethod
     def _resolve_outcome(status: str) -> Literal["success", "skip", "error"]:
@@ -407,3 +555,13 @@ __all__ = [
     "_SchemaValidator",
     "_TokenBucket",
 ]
+@dataclass(slots=True)
+class _ProviderCallResult:
+    response: ProviderResponse
+    status: str
+    failure_kind: str | None
+    error_message: str | None
+    latency_ms: int
+    retries: int
+    error: Exception | None = None
+    backoff_next_provider: bool = False


### PR DESCRIPTION
## Summary
- add structured provider call handling with backoff policies and error metadata in `RunnerExecution`
- augment sequential and parallel attempt executors to surface detailed failure summaries via `AllFailedError` and `ParallelExecutionError`
- ensure `CompareRunner` logs and records batches when all providers fail in sequential or parallel modes

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dbde1f11008321a800f2476f4d3bae