### PR TITLE
Reorder imports in async failure test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from tests.shadow._runner_test_helpers import _ErrorProvider, _SuccessProvider, FakeLogger
 from src.llm_adapter.errors import RetriableError
 from src.llm_adapter.provider_spi import ProviderRequest
 from src.llm_adapter.runner_async import AllFailedError, AsyncRunner
-
+from tests.shadow._runner_test_helpers import _ErrorProvider, _SuccessProvider, FakeLogger
 
 pytestmark = pytest.mark.usefixtures("socket_enabled")
 


### PR DESCRIPTION
## Summary
- reorder the async failure test imports into standard-library, third-party, and first-party sections

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dbe326ddac83218e5757f90285171f