### PR TITLE
Fix duplicate keys in run metric logging

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -303,9 +303,6 @@ def log_run_metric(
             "providers": providers,
             "trace_id": metadata.get("trace_id"),
             "project_id": metadata.get("project_id"),
-            "run_id": metadata.get("run_id"),
-            "mode": metadata.get("mode"),
-            "providers": metadata.get("providers"),
         },
     )
 


### PR DESCRIPTION
## Summary
- remove duplicate key assignments in `log_run_metric` to avoid overwriting metadata values

## Testing
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py --select F601`


------
https://chatgpt.com/codex/tasks/task_e_68dbe324a1e48321982b60677408a6b4