### PR TITLE
Align consensus configuration with weighted voting semantics

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -3,6 +3,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from .provider_spi import ProviderSPI
+
+
+class ConsensusStrategy(str, Enum):
+    MAJORITY_VOTE = "majority_vote"
+    WEIGHTED_VOTE = "weighted_vote"
+    MAX_SCORE = "max_score"
+
+
+class ConsensusTieBreaker(str, Enum):
+    MIN_LATENCY = "min_latency"
+    MIN_COST = "min_cost"
+    STABLE_ORDER = "stable_order"
 
 
 class RunnerMode(str, Enum):
@@ -14,17 +27,62 @@ class RunnerMode(str, Enum):
     CONSENSUS = "consensus"
 
 
+def _normalize_strategy(value: ConsensusStrategy | str) -> ConsensusStrategy:
+    if isinstance(value, ConsensusStrategy):
+        return value
+    normalized = value.strip().lower()
+    alias = {
+        "majority": ConsensusStrategy.MAJORITY_VOTE,
+        "weighted": ConsensusStrategy.WEIGHTED_VOTE,
+    }
+    try:
+        return ConsensusStrategy(normalized)
+    except ValueError as exc:  # pragma: no cover - config error
+        mapped = alias.get(normalized)
+        if mapped is None:
+            raise ValueError(f"unsupported consensus strategy: {value!r}") from exc
+        return mapped
+
+
+def _normalize_tie_breaker(
+    value: ConsensusTieBreaker | str,
+) -> ConsensusTieBreaker:
+    if isinstance(value, ConsensusTieBreaker):
+        return value
+    normalized = value.strip().lower()
+    alias = {
+        "latency": ConsensusTieBreaker.MIN_LATENCY,
+        "cost": ConsensusTieBreaker.MIN_COST,
+    }
+    try:
+        return ConsensusTieBreaker(normalized)
+    except ValueError as exc:  # pragma: no cover - config error
+        mapped = alias.get(normalized)
+        if mapped is None:
+            raise ValueError(f"unsupported tie_breaker: {value!r}") from exc
+        return mapped
+
+
 @dataclass(frozen=True)
 class ConsensusConfig:
     """Configuration for consensus style orchestrations."""
 
-    strategy: str = "majority"
-    quorum: int | None = None
-    tie_breaker: str | None = None
+    strategy: ConsensusStrategy | str = ConsensusStrategy.MAJORITY_VOTE
+    quorum: int | None = 2
+    tie_breaker: ConsensusTieBreaker | str | None = None
     schema: str | None = None
     judge: str | None = None
     max_rounds: int | None = None
     provider_weights: dict[str, float] | None = None
+    shadow_provider: ProviderSPI | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "strategy", _normalize_strategy(self.strategy))
+        tie_breaker = self.tie_breaker
+        if tie_breaker is not None:
+            object.__setattr__(self, "tie_breaker", _normalize_tie_breaker(tie_breaker))
+        if self.quorum is not None and self.quorum < 1:
+            raise ValueError("quorum must be >= 1")
 
 
 @dataclass(frozen=True)
@@ -42,6 +100,7 @@ class RunnerConfig:
     max_concurrency: int | None = None
     rpm: int | None = None
     consensus: ConsensusConfig | None = None
+    shadow_provider: ProviderSPI | None = None
 
     def __post_init__(self) -> None:
         if isinstance(self.mode, RunnerMode):

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, cast
 
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
 from .provider_spi import ProviderSPI, ProviderResponse
-from .runner_parallel import compute_consensus
+from .runner_parallel import ConsensusInput, compute_consensus
 from .shadow import ShadowMetrics
 from .utils import content_hash
-from .runner_sync_modes import _limited_providers, _raise_no_attempts
+from . import runner_sync_modes
 
 if TYPE_CHECKING:
     from .runner_sync import ProviderInvocationResult
@@ -26,7 +26,9 @@ class ConsensusStrategy:
         total_providers = len(runner.providers)
         results: list["ProviderInvocationResult" | None] = [None] * total_providers
         max_attempts = runner._config.max_attempts
-        providers = _limited_providers(runner.providers, max_attempts)
+        providers = runner_sync_modes._limited_providers(
+            runner.providers, max_attempts
+        )
 
         def make_worker(
             index: int, provider: ProviderSPI
@@ -61,7 +63,7 @@ class ConsensusStrategy:
             for index, provider in enumerate(providers, start=1)
         ]
         if not workers:
-            _raise_no_attempts(context)
+            runner_sync_modes._raise_no_attempts(context)
 
         try:
             invocations = context.run_parallel_all(
@@ -102,9 +104,16 @@ class ConsensusStrategy:
                     message = f"{message}: {detail_text}"
                 error = ParallelExecutionError(message, failures=failure_details)
                 raise error
-            responses_for_consensus = [response for _, response in successful]
+            consensus_inputs = [
+                ConsensusInput(
+                    provider=invocation.provider,
+                    response=response,
+                    order=index,
+                )
+                for index, (invocation, response) in enumerate(successful)
+            ]
             consensus = compute_consensus(
-                responses_for_consensus,
+                consensus_inputs,
                 config=runner._config.consensus,
             )
             winner_invocation = next(
@@ -116,6 +125,12 @@ class ConsensusStrategy:
                 consensus.total_voters - consensus.votes - consensus.abstained
             )
             event_logger = context.event_logger
+            strategy_value = getattr(consensus.strategy, "value", consensus.strategy)
+            tie_breaker_value = (
+                getattr(consensus.tie_breaker, "value", consensus.tie_breaker)
+                if consensus.tie_breaker is not None
+                else None
+            )
             if event_logger is not None:
                 candidate_summaries = [
                     {
@@ -130,8 +145,8 @@ class ConsensusStrategy:
                     "consensus_vote",
                     {
                         "request_fingerprint": context.request_fingerprint,
-                        "strategy": consensus.strategy,
-                        "tie_breaker": consensus.tie_breaker,
+                        "strategy": strategy_value,
+                        "tie_breaker": tie_breaker_value,
                         "min_votes": consensus.min_votes,
                         "score_threshold": consensus.score_threshold,
                         "voters_total": consensus.total_voters,

--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -7,7 +7,12 @@ import pytest
 
 from src.llm_adapter import cli
 from src.llm_adapter.runner import AsyncRunner, Runner
-from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
+from src.llm_adapter.runner_config import (
+    ConsensusStrategy,
+    ConsensusTieBreaker,
+    RunnerConfig,
+    RunnerMode,
+)
 from src.llm_adapter.shadow import DEFAULT_METRICS_PATH
 
 
@@ -80,9 +85,9 @@ def test_cli_prepare_execution_with_consensus(tmp_path: Path) -> None:
     assert config.mode is RunnerMode.CONSENSUS
     consensus = config.consensus
     assert consensus is not None
-    assert consensus.strategy == "max_score"
+    assert consensus.strategy is ConsensusStrategy.MAX_SCORE
     assert consensus.quorum == 3
-    assert consensus.tie_breaker == "latency"
+    assert consensus.tie_breaker is ConsensusTieBreaker.MIN_LATENCY
     assert consensus.schema == schema_path.read_text(encoding="utf-8")
     assert consensus.judge == "pkg:judge"
     assert consensus.provider_weights == {"mock:fast": 1.0, "mock:slow": 0.5}


### PR DESCRIPTION
## Summary
- add explicit ConsensusStrategy and ConsensusTieBreaker enums with quorum defaults and shadow provider support
- update parallel consensus execution to consume provider metadata, apply weighted tallies, and extend tie-break sequencing
- expose new CLI options and tests covering weighted voting, quorum behaviour, and stable-order fallbacks
- ensure the synchronous consensus strategy resolves helper functions via the shared runner_sync_modes module to avoid NameError during failure reporting

## Testing
- python -c "import pytest, sys; sys.exit(pytest.main(['-vv','-s','--maxfail=1','--durations=20','--disable-socket','projects/04-llm-adapter-shadow/tests']))"


------
https://chatgpt.com/codex/tasks/task_e_68dbdc3e49a4832196ba0ac6c6e8d07a