### PR TITLE
Reorder type-checking imports in runners

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING
 import uuid
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
-    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse
     from src.llm_adapter.parallel_exec import ParallelExecutionError
+    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse
 else:  # pragma: no cover - 実行時フォールバック
     try:
         from src.llm_adapter.provider_spi import (  # type: ignore[import-not-found]


### PR DESCRIPTION
## Summary
- reorder the type-checking imports in `projects/04-llm-adapter/adapter/core/runners.py` to satisfy Ruff's import order rule

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runners.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dbe622fd888321becf1d0e5a3c3be8