### PR TITLE
chore: sort runner execution attempt imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -1,4 +1,5 @@
 """Attempt executor helpers for :mod:`adapter.core.runner_execution`."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
@@ -8,9 +9,9 @@ from threading import Event, Lock
 from typing import Any, Protocol, TYPE_CHECKING
 import uuid
 
-from .errors import AllFailedError
 from .config import ProviderConfig
 from .datasets import GoldenTask
+from .errors import AllFailedError
 from .metrics import BudgetSnapshot, EvalMetrics, now_ts, RunMetrics
 from .providers import BaseProvider
 


### PR DESCRIPTION
## Summary
- reorder imports in `runner_execution_attempts.py` to follow standard, third-party, and local grouping

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runner_execution_attempts.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dbe62236588321bb4eba273c188875