### PR TITLE
Organize runner execution imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -58,7 +58,6 @@ else:  # pragma: no cover - 実行時フォールバック
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .execution.guards import _SchemaValidator, _TokenBucket
 from .errors import (
     AuthError,
     ConfigError,
@@ -67,6 +66,7 @@ from .errors import (
     RetriableError,
     TimeoutError,
 )
+from .execution.guards import _SchemaValidator, _TokenBucket
 from .metrics import BudgetSnapshot, estimate_cost, RunMetrics
 from .provider_spi import ProviderRequest
 from .providers import BaseProvider, ProviderResponse
@@ -350,7 +350,7 @@ class RunnerExecution:
         provider_config: ProviderConfig,
         provider: BaseProvider,
         prompt: str,
-    ) -> "_ProviderCallResult":
+    ) -> _ProviderCallResult:
         result = self._invoke_provider(provider, prompt)
         status, failure_kind = self._check_timeout(
             provider_config, result.latency_ms, result.status, result.failure_kind


### PR DESCRIPTION
## Summary
- reorder imports in runner_execution to group standard library, third-party, and local modules
- update _run_provider_call return annotation to reference _ProviderCallResult directly

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runner_execution.py --fix --select I001,UP037

------
https://chatgpt.com/codex/tasks/task_e_68dbe62126d8832193018868374bff15