### PR TITLE
refactor: extract rate limiter module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/rate_limiter.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/rate_limiter.py
@@ -1,0 +1,82 @@
+"""Rate limiting utilities shared across runner modules."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import threading
+import time
+
+
+class RateLimiter:
+    """Simple monotonic-rate limiter supporting sync/async acquisition."""
+
+    def __init__(
+        self,
+        rpm: int,
+        *,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], None] | None = None,
+        async_sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        if rpm <= 0:
+            raise ValueError("rpm must be greater than zero")
+        self._rate_per_second = float(rpm) / 60.0
+        self._clock = clock or time.monotonic
+        self._sleep = sleep or time.sleep
+        self._async_sleep = async_sleep or asyncio.sleep
+        self._capacity = 1.0
+        self._tokens = self._capacity
+        self._updated_at = self._clock()
+        self._lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
+
+    def _refill(self, now: float) -> None:
+        elapsed = now - self._updated_at
+        if elapsed > 0.0:
+            self._tokens = min(
+                self._capacity, self._tokens + elapsed * self._rate_per_second
+            )
+            self._updated_at = now
+
+    def _reserve(self, now: float) -> float:
+        self._refill(now)
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return 0.0
+        deficit = 1.0 - self._tokens
+        wait = deficit / self._rate_per_second
+        self._tokens = 0.0
+        self._updated_at = now
+        return wait
+
+    def acquire(self) -> None:
+        while True:
+            with self._lock:
+                wait = self._reserve(self._clock())
+            if wait <= 0.0:
+                return
+            self._sleep(wait)
+
+    async def acquire_async(self) -> None:
+        while True:
+            async with self._async_lock:
+                wait = self._reserve(self._clock())
+            if wait <= 0.0:
+                return
+            await self._async_sleep(wait)
+
+
+def resolve_rate_limiter(
+    rpm: int | None,
+    *,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    async_sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> RateLimiter | None:
+    if rpm is None:
+        return None
+    return RateLimiter(rpm, clock=clock, sleep=sleep, async_sleep=async_sleep)
+
+
+__all__ = ["RateLimiter", "resolve_rate_limiter", "time", "asyncio", "threading"]
+

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -1,15 +1,13 @@
 """Shared helpers for runner modules."""
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
-import threading
-import time
 from typing import Any, TYPE_CHECKING
 
 from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger
+from . import rate_limiter as _rate_limiter
 from .utils import content_hash
 
 if TYPE_CHECKING:
@@ -17,77 +15,11 @@ if TYPE_CHECKING:
 
 MetricsPath = str | Path | None
 
-
-class RateLimiter:
-    """Simple monotonic-rate limiter supporting sync/async acquisition."""
-
-    def __init__(
-        self,
-        rpm: int,
-        *,
-        clock: Callable[[], float] | None = None,
-        sleep: Callable[[float], None] | None = None,
-        async_sleep: Callable[[float], Awaitable[None]] | None = None,
-    ) -> None:
-        if rpm <= 0:
-            raise ValueError("rpm must be greater than zero")
-        self._rate_per_second = float(rpm) / 60.0
-        self._clock = clock or time.monotonic
-        self._sleep = sleep or time.sleep
-        self._async_sleep = async_sleep or asyncio.sleep
-        self._capacity = 1.0
-        self._tokens = self._capacity
-        self._updated_at = self._clock()
-        self._lock = threading.Lock()
-        self._async_lock = asyncio.Lock()
-
-    def _refill(self, now: float) -> None:
-        elapsed = now - self._updated_at
-        if elapsed > 0.0:
-            self._tokens = min(
-                self._capacity, self._tokens + elapsed * self._rate_per_second
-            )
-            self._updated_at = now
-
-    def _reserve(self, now: float) -> float:
-        self._refill(now)
-        if self._tokens >= 1.0:
-            self._tokens -= 1.0
-            return 0.0
-        deficit = 1.0 - self._tokens
-        wait = deficit / self._rate_per_second
-        self._tokens = 0.0
-        self._updated_at = now
-        return wait
-
-    def acquire(self) -> None:
-        while True:
-            with self._lock:
-                wait = self._reserve(self._clock())
-            if wait <= 0.0:
-                return
-            self._sleep(wait)
-
-    async def acquire_async(self) -> None:
-        while True:
-            async with self._async_lock:
-                wait = self._reserve(self._clock())
-            if wait <= 0.0:
-                return
-            await self._async_sleep(wait)
-
-
-def resolve_rate_limiter(
-    rpm: int | None,
-    *,
-    clock: Callable[[], float] | None = None,
-    sleep: Callable[[float], None] | None = None,
-    async_sleep: Callable[[float], Awaitable[None]] | None = None,
-) -> RateLimiter | None:
-    if rpm is None:
-        return None
-    return RateLimiter(rpm, clock=clock, sleep=sleep, async_sleep=async_sleep)
-
+RateLimiter = _rate_limiter.RateLimiter
+resolve_rate_limiter = _rate_limiter.resolve_rate_limiter
+time = _rate_limiter.time
+asyncio = _rate_limiter.asyncio
+threading = _rate_limiter.threading
 
 def resolve_event_logger(
     logger: EventLogger | None,


### PR DESCRIPTION
## Summary
- extract the shared rate-limiting helpers into a dedicated `llm_adapter.rate_limiter` module
- re-export rate limiting APIs and dependency modules from `runner_shared` to preserve backwards compatibility

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async.py projects/04-llm-adapter-shadow/tests/test_runner_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68dbe61341948321a423e775f9066250