### PR TITLE
Organize imports in shadow metrics module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow_metrics.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow_metrics.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+import time
 from typing import Any
 
 from .observability import EventLogger, JsonlLogger


### PR DESCRIPTION
## Summary
- reorder standard library imports in shadow metrics module to follow the expected grouping

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/shadow_metrics.py --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbe8e3e08083218b850dfd78f7ac90