### PR TITLE
Fix formatting in aggregation selector builder test

### DIFF
--- a/projects/04-llm-adapter/tests/test_aggregation_selector.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector.py
@@ -68,7 +68,8 @@ def test_max_score_selects_highest_quality() -> None:
     builder_calls: list[ProviderConfig] = []
 
     def builder(config: ProviderConfig) -> _DummyFactory:
-        builder_calls.append(config); return factory
+        builder_calls.append(config)
+        return factory
 
     selector = AggregationSelector(judge_factory_builder=builder)
     config = RunnerConfig(mode="consensus", aggregate="max")


### PR DESCRIPTION
## Summary
- separate the builder test helper statements onto individual lines to satisfy PEP 8 formatting

## Testing
- ruff check projects/04-llm-adapter/tests/test_aggregation_selector.py --select E702 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbe8e306888321aa11910d08e008ab