### PR TITLE
chore: sort runner_shared imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -5,9 +5,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
+from . import rate_limiter as _rate_limiter
 from .errors import FatalError, ProviderSkip, RateLimitError, RetryableError, SkipError
 from .observability import EventLogger, JsonlLogger
-from . import rate_limiter as _rate_limiter
 from .utils import content_hash
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- sort the runner_shared imports alphabetically to satisfy import linting

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbe8e14b6883219dcd8e6249b0be68