### PR TITLE
Fix mypy issues in shadow adapter components

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -55,7 +55,7 @@ def _make_shadow_payload(
 
 
 def _make_timeout_payload(provider_name: str | None, duration_ms: int | None) -> dict[str, Any]:
-    payload = {
+    payload: dict[str, Any] = {
         "provider": provider_name,
         "ok": False,
         "error": "ShadowTimeout",

--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -38,8 +38,15 @@ def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
     assert event["mode"] == RunnerMode.SEQUENTIAL.value
     assert event["providers"] == ["primary"]
     assert event["provider_id"] == event["provider"]
-    assert event["cost_estimate"] == pytest.approx(event["cost_usd"])  # type: ignore[arg-type]
-    assert event["retries"] == event["attempts"] - 1  # type: ignore[operator]
+    cost_usd = event["cost_usd"]
+    assert isinstance(cost_usd, (int, float))
+    assert event["cost_estimate"] == pytest.approx(float(cost_usd))
+
+    attempts = event["attempts"]
+    assert isinstance(attempts, int)
+    retries = event["retries"]
+    assert isinstance(retries, int)
+    assert retries == attempts - 1
     assert event["outcome"] == "success"
     assert "shadow_provider_id" in event
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,7 +13,7 @@ __path__ = [str(_current_dir)]
 if _legacy_tools.exists():
     __path__.append(str(_legacy_tools))
 
-__all__ = []
+__all__: list[str] = []
 
 
 def _ensure_namespace(package: str, location: Path) -> ModuleType:


### PR DESCRIPTION
## Summary
- tighten the run metric schema test assertions to avoid unused type ignore comments
- annotate shadow timeout payload and CLI response handling so unions satisfy mypy
- add a type annotation for tools.__all__ to keep namespace package compatible with mypy

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools

------
https://chatgpt.com/codex/tasks/task_e_68dbed2b79d88321b9233bf9a851552b