### PR TITLE
Fix mypy assignments for shadow CLI responses

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -55,7 +55,7 @@ def _make_shadow_payload(
 
 
 def _make_timeout_payload(provider_name: str | None, duration_ms: int | None) -> dict[str, Any]:
-    payload = {
+    payload: dict[str, Any] = {
         "provider": provider_name,
         "ok": False,
         "error": "ShadowTimeout",


### PR DESCRIPTION
## Summary
- annotate shadow timeout payload as a typed dictionary to satisfy mypy
- normalize CLI runner outputs into ProviderResponse instances before formatting output

## Testing
- pytest projects/04-llm-adapter-shadow/tests/shadow/test_runner_sync.py
- mypy src/llm_adapter/cli.py src/llm_adapter/shadow.py

------
https://chatgpt.com/codex/tasks/task_e_68dbed198a148321a17d4f4834202e40