### PR TITLE
chore: reorder runner_parallel imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -6,16 +6,16 @@ from dataclasses import dataclass
 import importlib
 from typing import Any, cast
 
-from .parallel_exec import ParallelExecutionError
-from .provider_spi import ProviderResponse
-from .runner_config import ConsensusConfig
 from .consensus_candidates import (
-    CandidateSet,
     _apply_tie_breaker,
     _Candidate,
     _normalize_candidate_text,
+    CandidateSet,
     validate_consensus_schema,
 )
+from .parallel_exec import ParallelExecutionError
+from .provider_spi import ProviderResponse
+from .runner_config import ConsensusConfig
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- reorder standard library and local imports in runner_parallel.py to match linting conventions
- apply Ruff import sorting fix to ensure clean lint status

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbeff0e7908321971b4ce0b73cca6d