### PR TITLE
Reorder CLI imports for ruff compliance

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
@@ -8,12 +8,12 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from .parallel_exec import ParallelAllResult
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .providers.factory import create_provider_from_spec, parse_provider_spec, ProviderFactory
 from .runner import AsyncRunner, Runner
 from .runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from .shadow import DEFAULT_METRICS_PATH, MetricsPath
-from .parallel_exec import ParallelAllResult
 
 _AGGREGATE: Mapping[str, str] = {
     "majority_vote": "majority",


### PR DESCRIPTION
## Summary
- reorder standard library and local imports in llm_adapter CLI to satisfy style guidelines

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/cli.py --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dbefefa9d08321af5921d2d10477af