### PR TITLE
Adjust Gemini provider test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/conftest.py
@@ -9,6 +9,10 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+CORE_ROOT = PROJECT_ROOT.parent / "04-llm-adapter"
+if str(CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CORE_ROOT))
+
 
 @pytest.fixture(autouse=True)
 def _fast_mock_provider_sleep(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py
@@ -3,18 +3,11 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any, cast, NoReturn
-import pathlib
-import sys
 
 import pytest
 
-PROJECTS_ROOT = pathlib.Path(__file__).resolve().parents[3]
-CORE_ROOT = PROJECTS_ROOT / "04-llm-adapter"
-if str(CORE_ROOT) not in sys.path:
-    sys.path.insert(0, str(CORE_ROOT))
-
-from adapter.core.providers import gemini_support
 from adapter.core.errors import RateLimitError as CoreRateLimitError
+from adapter.core.providers import gemini_support
 from src.llm_adapter.errors import (
     AuthError,
     ProviderSkip,


### PR DESCRIPTION
## Summary
- add the core adapter project directory to the tests' import path setup
- reorder the Gemini provider test imports now that sys.path manipulation is centralized

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_gemini_provider.py --fix --select I001,E402

------
https://chatgpt.com/codex/tasks/task_e_68dc5c4c829c832199799932894b222e