### PR TITLE
Refactor parallel attempt executor into dedicated module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -1,0 +1,342 @@
+"""Parallel attempt executor helpers for :mod:`adapter.core.runner_execution`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from concurrent.futures import CancelledError
+from dataclasses import dataclass
+from threading import Event, Lock
+from typing import TYPE_CHECKING, Any, Protocol
+import uuid
+
+from .config import ProviderConfig
+from .datasets import GoldenTask
+from .metrics import BudgetSnapshot, EvalMetrics, RunMetrics, now_ts
+from .providers import BaseProvider
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .runner_api import RunnerConfig
+    from .runner_execution import SingleRunResult
+
+    _RunSingle = Callable[
+        [ProviderConfig, BaseProvider, GoldenTask, int, str],
+        SingleRunResult,
+    ]
+else:
+    _RunSingle = Callable[[ProviderConfig, BaseProvider, GoldenTask, int, str], object]
+
+
+class _ParallelRunner(Protocol):
+    def __call__(
+        self,
+        workers: Sequence[Callable[[], int]],
+        *,
+        max_concurrency: int | None = None,
+    ) -> object:
+        ...
+
+
+_single_run_result_cls: type[Any] | None = None
+
+
+def _get_single_run_result_cls() -> type[SingleRunResult]:
+    global _single_run_result_cls
+    if _single_run_result_cls is None:
+        from .runner_execution import SingleRunResult as _SingleRunResult
+
+        _single_run_result_cls = _SingleRunResult
+    return _single_run_result_cls
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderFailureSummary:
+    index: int
+    provider: str
+    status: str
+    failure_kind: str | None
+    error_message: str | None
+    backoff_next_provider: bool
+    retries: int
+    error_type: str | None
+
+
+class _ParallelCoordinatorBase:
+    CANCEL_MESSAGE = "parallel-any cancelled after winner"
+
+    def __init__(
+        self,
+        executor: "ParallelAttemptExecutor",
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+    ) -> None:
+        self._executor = executor
+        self._providers = providers
+        self._task = task
+        self._attempt_index = attempt_index
+        self._config = config
+        max_concurrency = getattr(config, "max_concurrency", None)
+        self._max_workers = executor._normalize_concurrency(
+            len(providers), max_concurrency
+        )
+        self._results: list[SingleRunResult | None] = [None] * len(providers)
+        self._stop_reason: str | None = None
+        self._cancel_event = Event()
+
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        raise NotImplementedError
+
+    def _mark_cancelled(self, index: int) -> None:
+        result = self._results[index]
+        if result is not None:
+            metrics = result.metrics
+            metrics.status = "skip"
+            if not metrics.failure_kind:
+                metrics.failure_kind = "cancelled"
+            metrics.error_message = self.CANCEL_MESSAGE
+            result.stop_reason = result.stop_reason or "cancelled"
+            return
+        provider_config, _ = self._providers[index]
+        metrics = RunMetrics(
+            ts=now_ts(),
+            run_id=f"run_{self._task.task_id}_{self._attempt_index}_{uuid.uuid4().hex}",
+            provider=provider_config.provider,
+            model=provider_config.model,
+            mode=self._config.mode,
+            prompt_id=self._task.task_id,
+            prompt_name=self._task.name,
+            seed=provider_config.seed,
+            temperature=provider_config.temperature,
+            top_p=provider_config.top_p,
+            max_tokens=provider_config.max_tokens,
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=0,
+            cost_usd=0.0,
+            status="skip",
+            failure_kind="cancelled",
+            error_message=self.CANCEL_MESSAGE,
+            output_text=None,
+            output_hash=None,
+            eval=EvalMetrics(),
+            budget=BudgetSnapshot(0.0, False),
+            ci_meta={},
+        )
+        single_run_result_cls = _get_single_run_result_cls()
+        self._results[index] = single_run_result_cls(
+            metrics=metrics,
+            raw_output="",
+            stop_reason="cancelled",
+        )
+
+    def _update_stop_reason(self, result: SingleRunResult) -> None:
+        if result.stop_reason and not self._stop_reason:
+            self._stop_reason = result.stop_reason
+
+    def _build_batch(self) -> list[tuple[int, SingleRunResult]]:
+        return [
+            (index, result)
+            for index, result in enumerate(self._results)
+            if result is not None
+        ]
+
+
+class _ParallelAllCoordinator(_ParallelCoordinatorBase):
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        workers = [
+            self._build_worker(index, provider_config, provider)
+            for index, (provider_config, provider) in enumerate(self._providers)
+        ]
+        self._executor._run_parallel_all_sync(
+            workers, max_concurrency=self._max_workers
+        )
+        return self._build_batch(), self._stop_reason
+
+    def _build_worker(
+        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
+    ) -> Callable[[], int]:
+        def worker() -> int:
+            if self._cancel_event.is_set():
+                raise CancelledError()
+            try:
+                result = self._executor._run_single(
+                    provider_config,
+                    provider,
+                    self._task,
+                    self._attempt_index,
+                    self._config.mode,
+                )
+                self._results[index] = result
+                self._update_stop_reason(result)
+                return index
+            except CancelledError:
+                self._mark_cancelled(index)
+                raise
+
+        return worker
+
+
+class _ParallelAnyCoordinator(_ParallelCoordinatorBase):
+    def __init__(
+        self,
+        executor: "ParallelAttemptExecutor",
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+    ) -> None:
+        super().__init__(executor, providers, task, attempt_index, config)
+        self._failure_lock = Lock()
+        self._winner_lock = Lock()
+        self._failure_indices: set[int] = set()
+        self._failure_summaries: list[ProviderFailureSummary] = []
+        self._winner_index: int | None = None
+        self._caught_error: Exception | None = None
+
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        workers = [
+            self._build_worker(index, provider_config, provider)
+            for index, (provider_config, provider) in enumerate(self._providers)
+        ]
+        try:
+            self._executor._run_parallel_any_sync(
+                workers, max_concurrency=self._max_workers
+            )
+        except self._executor._parallel_execution_error as exc:  # type: ignore[misc]
+            self._caught_error = exc
+        except RuntimeError as exc:
+            self._caught_error = exc
+        self._finalize()
+        return self._build_batch(), self._stop_reason
+
+    def _build_worker(
+        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
+    ) -> Callable[[], int]:
+        def worker() -> int:
+            if self._cancel_event.is_set():
+                raise CancelledError()
+            try:
+                result = self._executor._run_single(
+                    provider_config,
+                    provider,
+                    self._task,
+                    self._attempt_index,
+                    self._config.mode,
+                )
+                should_cancel = self._cancel_event.is_set()
+                if result.metrics.status != "ok":
+                    self._results[index] = result
+                    summary = self._build_failure_summary(index, provider_config, result)
+                    with self._failure_lock:
+                        self._failure_summaries.append(summary)
+                        self._failure_indices.add(index)
+                    raise RuntimeError("parallel-any failure")
+                with self._winner_lock:
+                    if self._winner_index is None:
+                        self._winner_index = index
+                        self._cancel_event.set()
+                        should_cancel = False
+                    else:
+                        should_cancel = self._winner_index != index
+                self._results[index] = result
+                if should_cancel:
+                    raise CancelledError()
+                self._update_stop_reason(result)
+                return index
+            except CancelledError:
+                self._mark_cancelled(index)
+                raise
+
+        return worker
+
+    def _finalize(self) -> None:
+        for index, result in enumerate(self._results):
+            if result is None:
+                self._mark_cancelled(index)
+        success_found = any(
+            result is not None and result.metrics.status == "ok"
+            for result in self._results
+        )
+        if success_found:
+            return
+        for index, result in enumerate(self._results):
+            if result is None or index in self._failure_indices:
+                continue
+            provider_config, _ = self._providers[index]
+            summary = self._build_failure_summary(index, provider_config, result)
+            self._failure_summaries.append(summary)
+            self._failure_indices.add(index)
+        error = self._executor._parallel_execution_error("parallel-any failed")
+        error.failures = self._failure_summaries  # type: ignore[attr-defined]
+        error.batch = [
+            (index, result)
+            for index, result in enumerate(self._results)
+            if result is not None
+        ]  # type: ignore[attr-defined]
+        if self._caught_error is not None:
+            raise error from self._caught_error
+        raise error
+
+    def _build_failure_summary(
+        self,
+        index: int,
+        provider_config: ProviderConfig,
+        result: SingleRunResult,
+    ) -> ProviderFailureSummary:
+        metrics = result.metrics
+        return ProviderFailureSummary(
+            index=index,
+            provider=provider_config.provider,
+            status=metrics.status,
+            failure_kind=metrics.failure_kind,
+            error_message=metrics.error_message,
+            backoff_next_provider=result.backoff_next_provider,
+            retries=metrics.retries,
+            error_type=type(result.error).__name__ if result.error else None,
+        )
+
+
+class ParallelAttemptExecutor:
+    """Executor to handle parallel provider attempts."""
+
+    def __init__(
+        self,
+        run_single: _RunSingle,
+        normalize_concurrency: Callable[[int, int | None], int],
+        *,
+        run_parallel_all_sync: _ParallelRunner,
+        run_parallel_any_sync: _ParallelRunner,
+        parallel_execution_error: type[Exception],
+    ) -> None:
+        self._run_single = run_single
+        self._normalize_concurrency = normalize_concurrency
+        self._run_parallel_all_sync = run_parallel_all_sync
+        self._run_parallel_any_sync = run_parallel_any_sync
+        self._parallel_execution_error = parallel_execution_error
+
+    def run(
+        self,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+    ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        if not providers:
+            return [], None
+        if config.mode == "parallel-any":
+            coordinator: _ParallelCoordinatorBase = _ParallelAnyCoordinator(
+                self, providers, task, attempt_index, config
+            )
+        else:
+            coordinator = _ParallelAllCoordinator(
+                self, providers, task, attempt_index, config
+            )
+        return coordinator.execute()
+
+
+__all__ = [
+    "ParallelAttemptExecutor",
+    "ProviderFailureSummary",
+]
+

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -20,6 +20,7 @@ from adapter.core.aggregation import (  # noqa: E402
 from adapter.core.aggregation_controller import AggregationController  # noqa: E402
 from adapter.core.budgets import BudgetManager  # noqa: E402
 from adapter.core.datasets import GoldenTask  # noqa: E402
+from adapter.core.errors import ProviderSkip, TimeoutError  # noqa: E402
 from adapter.core.metrics import RunMetrics  # noqa: E402
 from adapter.core.models import (  # noqa: E402
     BudgetBook,
@@ -36,7 +37,10 @@ from adapter.core.providers import (  # noqa: E402
     ProviderResponse,
 )
 from adapter.core.runner_api import RunnerConfig  # noqa: E402
-from adapter.core.runner_execution import SingleRunResult  # noqa: E402
+from adapter.core.runner_execution import (  # noqa: E402
+    ParallelExecutionError,
+    SingleRunResult,
+)
 from adapter.core.runners import CompareRunner  # noqa: E402
 
 
@@ -328,6 +332,119 @@ def test_parallel_any_cancels_pending_workers(
     slow_metric = next(metric for metric in results if metric.model == "slow")
     assert slow_metric.failure_kind == "cancelled"
     assert slow_metric.error_message == "parallel-any cancelled after winner"
+
+
+def test_parallel_any_populates_metrics_for_unscheduled_workers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class WinnerProvider(BaseProvider):
+        calls = 0
+
+        def generate(self, prompt: str) -> ProviderResponse:
+            WinnerProvider.calls += 1
+            return ProviderResponse(
+                output_text="winner",
+                input_tokens=1,
+                output_tokens=1,
+                latency_ms=5,
+            )
+
+    class IdleProvider(BaseProvider):
+        called = False
+
+        def generate(self, prompt: str) -> ProviderResponse:  # pragma: no cover - 防御ライン
+            IdleProvider.called = True
+            raise AssertionError("idle provider should not run")
+
+    monkeypatch.setitem(ProviderFactory._registry, "winner", WinnerProvider)
+    monkeypatch.setitem(ProviderFactory._registry, "idle", IdleProvider)
+
+    winner_config = _make_provider_config(
+        tmp_path, name="winner", provider="winner", model="winner"
+    )
+    idle_config = _make_provider_config(
+        tmp_path, name="idle", provider="idle", model="idle"
+    )
+
+    from adapter.core import runners as runners_module
+
+    def fake_run_parallel_any(workers, *, max_concurrency=None):  # type: ignore[override]
+        return workers[0]()
+
+    monkeypatch.setattr(runners_module, "run_parallel_any_sync", fake_run_parallel_any)
+
+    runner = CompareRunner(
+        [winner_config, idle_config],
+        [_make_task()],
+        _make_budget_manager(),
+        tmp_path / "metrics_unscheduled.jsonl",
+    )
+    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2))
+
+    metrics_by_model = {metric.model: metric for metric in results}
+    assert WinnerProvider.calls == 1
+    assert IdleProvider.called is False
+
+    idle_metrics = metrics_by_model["idle"]
+    assert idle_metrics.status == "skip"
+    assert idle_metrics.failure_kind == "cancelled"
+    assert idle_metrics.error_message == "parallel-any cancelled after winner"
+    assert idle_metrics.input_tokens == 0
+    assert idle_metrics.output_tokens == 0
+    assert idle_metrics.latency_ms == 0
+    assert idle_metrics.cost_usd == 0.0
+
+
+def test_parallel_any_failure_summary_includes_all_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class SkipProvider(BaseProvider):
+        def generate(self, prompt: str) -> ProviderResponse:
+            raise ProviderSkip("skip me")
+
+    class TimeoutProvider(BaseProvider):
+        def generate(self, prompt: str) -> ProviderResponse:
+            raise TimeoutError("deadline")
+
+    monkeypatch.setitem(ProviderFactory._registry, "skip", SkipProvider)
+    monkeypatch.setitem(ProviderFactory._registry, "timeout", TimeoutProvider)
+
+    skip_config = _make_provider_config(
+        tmp_path, name="skip", provider="skip", model="skip-model"
+    )
+    timeout_config = _make_provider_config(
+        tmp_path, name="timeout", provider="timeout", model="timeout-model"
+    )
+
+    runner = CompareRunner(
+        [skip_config, timeout_config],
+        [_make_task()],
+        _make_budget_manager(),
+        tmp_path / "metrics_failure_summary.jsonl",
+    )
+
+    with pytest.raises(ParallelExecutionError) as exc_info:
+        runner.run(repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2))
+
+    failures = getattr(exc_info.value, "failures", ())
+    assert len(failures) == 2
+    summary_by_provider = {failure.provider: failure for failure in failures}
+
+    skip_summary = summary_by_provider["skip"]
+    assert skip_summary.status == "skip"
+    assert skip_summary.failure_kind == "skip"
+    assert skip_summary.error_message == "skip me"
+    assert skip_summary.backoff_next_provider is True
+    assert skip_summary.retries == 0
+    assert skip_summary.error_type == "ProviderSkip"
+
+    timeout_summary = summary_by_provider["timeout"]
+    assert timeout_summary.status == "error"
+    assert timeout_summary.failure_kind == "timeout"
+    assert timeout_summary.error_message == "deadline"
+    assert timeout_summary.backoff_next_provider is False
+    assert timeout_summary.retries == 0
+    assert timeout_summary.error_type == "TimeoutError"
 
 
 def test_consensus_majority_and_judge_tiebreak(


### PR DESCRIPTION
## Summary
- add regression tests capturing cancellation metrics population and failure summaries for parallel-any runs
- extract ProviderFailureSummary and ParallelAttemptExecutor into a new runner_execution_parallel module and streamline orchestration helpers
- trim runner_execution_attempts to sequential logic while re-exporting parallel helpers

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5c55e08883218f1ca5ee3c48167d