### PR TITLE
Fix consensus quorum metadata default

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_controller.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_controller.py
@@ -76,11 +76,8 @@ class AggregationController:
         if selection.votes is not None:
             meta["aggregate_votes"] = selection.votes
         if mode == "consensus":
-            quorum_value = (
-                config.quorum
-                if config.quorum is not None
-                else len(selection.decision.candidates)
-            )
+            quorum_value = config.quorum if config.quorum is not None else 2
+            meta["aggregate_quorum"] = quorum_value
             consensus_meta: dict[str, object] = {
                 "strategy": selection.decision.strategy,
                 "quorum": quorum_value,

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -372,6 +372,7 @@ def test_consensus_majority_and_judge_tiebreak(
     assert consensus_meta["chosen_provider"] == "consensus"
     assert consensus_meta.get("metadata", {}) == {"bucket_size": 2}
 
+
     class JudgeProvider(BaseProvider):
         calls = 0
 
@@ -407,6 +408,47 @@ def test_consensus_majority_and_judge_tiebreak(
     )
     assert judge_winner.model == "B"
     assert JudgeProvider.calls == 1
+
+
+def test_consensus_default_quorum_meta_uses_two(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class ThreeWayConsensusProvider(BaseProvider):
+        def generate(self, prompt: str) -> ProviderResponse:
+            return ProviderResponse(
+                output_text="YES",
+                input_tokens=1,
+                output_tokens=1,
+                latency_ms=5,
+            )
+
+    monkeypatch.setitem(
+        ProviderFactory._registry, "three-way-consensus", ThreeWayConsensusProvider
+    )
+
+    runner = CompareRunner(
+        [
+            _make_provider_config(
+                tmp_path, name="p1", provider="three-way-consensus", model="YES"
+            ),
+            _make_provider_config(
+                tmp_path, name="p2", provider="three-way-consensus", model="YES"
+            ),
+            _make_provider_config(
+                tmp_path, name="p3", provider="three-way-consensus", model="YES"
+            ),
+        ],
+        [_make_task()],
+        _make_budget_manager(),
+        tmp_path / "metrics_consensus_quorum_default.jsonl",
+    )
+
+    results = runner.run(repeat=1, config=RunnerConfig(mode="consensus"))
+    winner = next(metric for metric in results if metric.ci_meta.get("consensus"))
+
+    consensus_meta = winner.ci_meta["consensus"]
+    assert consensus_meta["quorum"] == 2
+    assert winner.ci_meta["aggregate_quorum"] == 2
 
 
 def test_consensus_quorum_failure_marks_metrics(


### PR DESCRIPTION
## Summary
- add a regression test covering three-provider consensus runs with the default quorum
- update the aggregation controller so consensus metadata always reports a quorum of two when unset

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5dba02288321be5de1332140f13a