### PR TITLE
Refactor runner shadow execution

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/shadow_runner.py
+++ b/projects/04-llm-adapter/adapter/core/execution/shadow_runner.py
@@ -1,0 +1,115 @@
+"""シャドウプロバイダ実行のヘルパー。"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from threading import Thread
+from time import perf_counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.provider_spi import ProviderSPI
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.provider_spi import ProviderSPI  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+        from typing import Protocol
+
+        class ProviderSPI(Protocol):
+            """プロバイダ SPI フォールバック."""
+
+from ..config import ProviderConfig
+from ..provider_spi import ProviderRequest
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ShadowRunnerResult:
+    provider_id: str | None
+    latency_ms: int | None = None
+    status: str | None = None
+    error_message: str | None = None
+
+
+class ShadowRunner:
+    """シャドウプロバイダ呼び出しを管理する。"""
+
+    def __init__(self, provider: ProviderSPI | None) -> None:
+        self._provider = provider
+        self._thread: Thread | None = None
+        self._result: ShadowRunnerResult | None = None
+        self._provider_id: str | None = None
+
+    def start(self, provider_config: ProviderConfig, prompt: str) -> None:
+        if self._provider is None:
+            return
+        provider = self._provider
+        try:
+            provider_id = provider.name()
+        except Exception:  # pragma: no cover - name() 実装の防御
+            provider_id = None
+        self._provider_id = provider_id
+        request = ProviderRequest(
+            model=provider_config.model,
+            prompt=prompt,
+            max_tokens=provider_config.max_tokens,
+            temperature=provider_config.temperature,
+            top_p=provider_config.top_p,
+            timeout_s=(
+                float(provider_config.timeout_s)
+                if provider_config.timeout_s > 0
+                else None
+            ),
+        )
+        result = ShadowRunnerResult(provider_id=provider_id)
+
+        def _run() -> None:
+            start = perf_counter()
+            try:
+                response = provider.invoke(request)
+            except Exception as exc:  # pragma: no cover - 影響範囲縮小のため
+                latency_ms = int((perf_counter() - start) * 1000)
+                LOGGER.exception(
+                    "Shadow provider %s failed", provider_id, exc_info=exc
+                )
+                result.status = "error"
+                result.error_message = str(exc)
+                result.latency_ms = latency_ms
+            else:
+                latency_ms = int(getattr(response, "latency_ms", 0))
+                LOGGER.info(
+                    "Shadow provider %s completed in %sms", provider_id, latency_ms
+                )
+                result.status = "ok"
+                result.latency_ms = latency_ms
+            finally:
+                if result.latency_ms is None:
+                    result.latency_ms = int((perf_counter() - start) * 1000)
+
+        thread = Thread(
+            target=_run,
+            name=f"shadow-{provider_id or 'unknown'}",
+            daemon=True,
+        )
+        thread.start()
+        self._thread = thread
+        self._result = result
+
+    def finalize(self) -> ShadowRunnerResult | None:
+        if self._thread is None:
+            return None
+        self._thread.join()
+        result = self._result
+        if result is None:
+            return ShadowRunnerResult(provider_id=self._provider_id)
+        if result.provider_id is None:
+            result.provider_id = self._provider_id
+        return result
+
+    @property
+    def provider_id(self) -> str | None:
+        return self._provider_id
+
+
+__all__ = ["ShadowRunner", "ShadowRunnerResult"]

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,7 +22,7 @@ from adapter.core.aggregation_controller import AggregationController  # noqa: E
 from adapter.core.budgets import BudgetManager  # noqa: E402
 from adapter.core.datasets import GoldenTask  # noqa: E402
 from adapter.core.errors import ProviderSkip, TimeoutError  # noqa: E402
-from adapter.core.metrics import RunMetrics  # noqa: E402
+from adapter.core.metrics import BudgetSnapshot, RunMetrics  # noqa: E402
 from adapter.core.models import (  # noqa: E402
     BudgetBook,
     BudgetRule,
@@ -39,6 +40,7 @@ from adapter.core.providers import (  # noqa: E402
 from adapter.core.runner_api import RunnerConfig  # noqa: E402
 from adapter.core.runner_execution import (  # noqa: E402
     ParallelExecutionError,
+    RunnerExecution,
     SingleRunResult,
 )
 from adapter.core.runners import CompareRunner  # noqa: E402
@@ -143,6 +145,115 @@ def test_majority_vote_normalizes_text_variants() -> None:
     assert result.chosen.index == 0
     assert result.metadata == {"bucket_size": 2}
     assert result.tie_breaker_used == "first"
+
+
+def test_runner_execution_records_shadow_budget_and_schema(
+    tmp_path: Path,
+) -> None:
+    provider_config = _make_provider_config(
+        tmp_path, name="p-main", provider="p-main", model="m1"
+    )
+    task = _make_task()
+    response = ProviderResponse(
+        output_text="primary",
+        input_tokens=7,
+        output_tokens=5,
+        latency_ms=27,
+        token_usage=SimpleNamespace(prompt=7, completion=5, total=12),
+    )
+    provider = SimpleNamespace(generate=lambda _prompt: response)
+    shadow_latency = 11
+    shadow_provider = SimpleNamespace(
+        name=lambda: "shadow-mock",
+        capabilities=lambda: set(),
+        invoke=lambda request: SimpleNamespace(latency_ms=shadow_latency),
+    )
+
+    class Validator:
+        def validate(self, _text: str) -> None:
+            raise ValueError("schema mismatch")
+
+    evaluate_calls: list[tuple[ProviderConfig, float, str, str | None, str | None]] = []
+
+    def evaluate_budget(
+        cfg: ProviderConfig,
+        cost: float,
+        status: str,
+        failure_kind: str | None,
+        error_message: str | None,
+    ) -> tuple[BudgetSnapshot, str | None, str, str | None, str | None]:
+        evaluate_calls.append((cfg, cost, status, failure_kind, error_message))
+        return (
+            BudgetSnapshot(run_budget_usd=0.0, hit_stop=False),
+            "budget-stop",
+            status,
+            failure_kind,
+            error_message,
+        )
+
+    def build_metrics(
+        cfg: ProviderConfig,
+        golden_task: GoldenTask,
+        attempt_index: int,
+        mode: str,
+        provider_response: ProviderResponse,
+        status: str,
+        failure_kind: str | None,
+        error_message: str | None,
+        latency_ms: int,
+        budget_snapshot: BudgetSnapshot,
+        cost_usd: float,
+    ) -> tuple[RunMetrics, str]:
+        metrics = _make_run_metrics(
+            provider=cfg.provider,
+            model=cfg.model,
+            latency_ms=latency_ms,
+            cost_usd=cost_usd,
+        )
+        metrics.status = status
+        metrics.failure_kind = failure_kind
+        metrics.error_message = error_message
+        metrics.output_text = provider_response.output_text or ""
+        return metrics, provider_response.output_text or ""
+
+    execution = RunnerExecution(
+        token_bucket=None,
+        schema_validator=Validator(),
+        evaluate_budget=evaluate_budget,
+        build_metrics=build_metrics,
+        normalize_concurrency=lambda count, limit: count,
+        backoff=None,
+        shadow_provider=shadow_provider,
+        metrics_path=None,
+        provider_weights=None,
+    )
+
+    result = execution._run_single(
+        provider_config,
+        provider,
+        task,
+        attempt_index=0,
+        mode="consensus",
+    )
+
+    assert len(evaluate_calls) == 1
+    cfg, cost, status, failure_kind, error_message = evaluate_calls[0]
+    assert cfg == provider_config
+    assert cost == pytest.approx(0.0)
+    assert status == "ok"
+    assert failure_kind is None
+    assert error_message is None
+    assert result.stop_reason == "budget-stop"
+
+    metrics = result.metrics
+    assert metrics.shadow_provider_id == "shadow-mock"
+    assert metrics.shadow_latency_ms == shadow_latency
+    assert metrics.shadow_status == "ok"
+    assert metrics.shadow_outcome == "success"
+    assert metrics.shadow_error_message is None
+    assert metrics.status == "error"
+    assert metrics.failure_kind == "schema_violation"
+    assert metrics.error_message and "schema mismatch" in metrics.error_message
 
 
 def test_majority_vote_uses_json_equality_when_schema_present() -> None:


### PR DESCRIPTION
## Summary
- add a regression test ensuring RunnerExecution records shadow provider metrics, budget evaluation, and schema validation errors when using a mock provider
- extract shadow provider execution into a dedicated helper and delegate metrics assembly from RunnerExecution to keep orchestration focused

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py -k runner_execution

------
https://chatgpt.com/codex/tasks/task_e_68dc6391346883219ef7904da9bdc4f0