### PR TITLE
feat: enforce runner config concurrency defaults

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -72,8 +72,13 @@ class AsyncRunner:
         shadow: ProviderSPI | AsyncProviderSPI | None = None,
         shadow_metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
     ) -> ProviderResponse | ParallelAllResult[WorkerResult, ProviderResponse]:
+        metrics_path = (
+            self._config.metrics_path
+            if shadow_metrics_path == DEFAULT_METRICS_PATH
+            else shadow_metrics_path
+        )
         event_logger, metrics_path_str = resolve_event_logger(
-            self._logger, shadow_metrics_path
+            self._logger, metrics_path
         )
         metadata: dict[str, Any] = dict(request.metadata or {})
         run_started = time.time()

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from .shadow import DEFAULT_METRICS_PATH, MetricsPath
+
 if TYPE_CHECKING:
     from .provider_spi import ProviderSPI
 
@@ -22,8 +24,8 @@ class RunnerMode(str, Enum):
 class ConsensusConfig:
     """Configuration for consensus style orchestrations."""
 
-    strategy: str = "majority"
-    quorum: int | None = None
+    strategy: str = "majority_vote"
+    quorum: int = 2
     tie_breaker: str | None = None
     schema: str | None = None
     judge: str | None = None
@@ -38,15 +40,19 @@ class BackoffPolicy:
     retryable_next_provider: bool = True
 
 
+DEFAULT_MAX_CONCURRENCY = 4
+
+
 @dataclass(frozen=True)
 class RunnerConfig:
     backoff: BackoffPolicy = field(default_factory=BackoffPolicy)
     max_attempts: int | None = None
     mode: RunnerMode | str | Enum = RunnerMode.SEQUENTIAL
-    max_concurrency: int | None = None
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY
     rpm: int | None = None
     consensus: ConsensusConfig | None = None
     shadow_provider: ProviderSPI | None = None
+    metrics_path: MetricsPath = DEFAULT_METRICS_PATH
 
     def __post_init__(self) -> None:
         if isinstance(self.mode, RunnerMode):
@@ -56,3 +62,9 @@ class RunnerConfig:
             normalized = RunnerMode(mode_value)
 
         object.__setattr__(self, "mode", normalized)
+
+        max_concurrency = self.max_concurrency
+        if isinstance(max_concurrency, bool) or not isinstance(max_concurrency, int):
+            raise TypeError("max_concurrency must be an int")
+        if max_concurrency <= 0:
+            raise ValueError("max_concurrency must be a positive integer")

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -230,8 +230,13 @@ class Runner:
     ]:
         """Execute ``request`` with fallback semantics."""
 
+        metrics_path = (
+            self._config.metrics_path
+            if shadow_metrics_path == DEFAULT_METRICS_PATH
+            else shadow_metrics_path
+        )
         event_logger, metrics_path_str = resolve_event_logger(
-            self._logger, shadow_metrics_path
+            self._logger, metrics_path
         )
         metadata = dict(request.metadata or {})
         run_started = time.time()

--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -7,7 +7,12 @@ import pytest
 
 from src.llm_adapter import cli
 from src.llm_adapter.runner import AsyncRunner, Runner
-from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
+from src.llm_adapter.runner_config import (
+    DEFAULT_MAX_CONCURRENCY,
+    RunnerConfig,
+    RunnerMode,
+    ConsensusConfig,
+)
 from src.llm_adapter.shadow import DEFAULT_METRICS_PATH
 
 
@@ -32,6 +37,21 @@ def test_runner_config_accepts_enum_members() -> None:
     mutated = replace(config, mode=RunnerMode.SEQUENTIAL)
     assert mutated.mode is RunnerMode.SEQUENTIAL
     assert config.mode is RunnerMode.CONSENSUS
+
+
+def test_runner_config_validates_max_concurrency_and_metrics_path(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "custom.jsonl"
+    config = RunnerConfig(metrics_path=metrics_path)
+    assert config.max_concurrency == DEFAULT_MAX_CONCURRENCY
+    assert config.metrics_path == metrics_path
+    with pytest.raises(ValueError):
+        RunnerConfig(max_concurrency=0)
+
+
+def test_consensus_config_defaults() -> None:
+    config = ConsensusConfig()
+    assert config.strategy == "majority_vote"
+    assert config.quorum == 2
 
 
 def test_cli_prepare_execution_with_consensus(tmp_path: Path) -> None:
@@ -82,11 +102,12 @@ def test_cli_prepare_execution_with_consensus(tmp_path: Path) -> None:
     assert consensus is not None
     assert consensus.strategy == "max_score"
     assert consensus.quorum == 3
-    assert consensus.tie_breaker == "latency"
+    assert consensus.tie_breaker == "min_latency"
     assert consensus.schema == schema_path.read_text(encoding="utf-8")
     assert consensus.judge == "pkg:judge"
     assert consensus.provider_weights == {"mock:fast": 1.0, "mock:slow": 0.5}
     assert metrics == str(metrics_path)
+    assert config.metrics_path == metrics_path
     assert request.prompt_text == "hello world"
     assert request.model == "fast"
 
@@ -113,3 +134,24 @@ def test_cli_prepare_execution_async(tmp_path: Path) -> None:
     assert runner._config.mode is RunnerMode.PARALLEL_ANY
     assert metrics == DEFAULT_METRICS_PATH
     assert request.model == "one"
+
+
+def test_cli_prepare_execution_uses_defaults(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("ping", encoding="utf-8")
+
+    args = cli.parse_args(
+        [
+            "--mode",
+            "sequential",
+            "--providers",
+            "mock:primary",
+            "--input",
+            str(prompt_path),
+        ]
+    )
+
+    runner, _request, metrics = cli.prepare_execution(args)
+    assert runner._config.max_concurrency == DEFAULT_MAX_CONCURRENCY
+    assert runner._config.metrics_path == DEFAULT_METRICS_PATH
+    assert metrics == DEFAULT_METRICS_PATH


### PR DESCRIPTION
## Summary
- enforce the SRS defaults in `RunnerConfig`, including a positive `max_concurrency`, consensus defaults, and configurable metrics path
- simplify CLI consensus option handling while persisting metrics targets on the config and honoring them in sync/async runners
- expand the CLI configuration tests to cover the new defaults and validation

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dc65365d30832187fee91557e9e68b