### PR TITLE
Fix typing import order in runner_execution_attempts

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_attempts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any, TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask


### PR DESCRIPTION
## Summary
- sort the typing imports alphabetically in `runner_execution_attempts`

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runner_execution_attempts.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc66de1590832197b86cb4933def8b