### PR TITLE
Reorder imports in consensus runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,6 +1,5 @@
 import pytest
 
-import src.llm_adapter.runner_parallel as runner_parallel
 from src.llm_adapter.errors import RetriableError, TimeoutError
 from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import (
@@ -10,6 +9,7 @@ from src.llm_adapter.provider_spi import (
 )
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
+import src.llm_adapter.runner_parallel as runner_parallel
 from src.llm_adapter.runner_parallel import (
     compute_consensus,
     ConsensusResult,


### PR DESCRIPTION
## Summary
- reorder the imports in `test_runner_consensus.py` to follow standard grouping

## Testing
- `ruff check projects/04-llm-adapter-shadow/tests/test_runner_consensus.py --select I001 --fix`


------
https://chatgpt.com/codex/tasks/task_e_68dc6b9bd2b08321aa54744f0a96eff6