### PR TITLE
Reorder imports in test_cli_runner_config

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -8,10 +8,10 @@ import pytest
 from src.llm_adapter import cli
 from src.llm_adapter.runner import AsyncRunner, Runner
 from src.llm_adapter.runner_config import (
+    ConsensusConfig,
     DEFAULT_MAX_CONCURRENCY,
     RunnerConfig,
     RunnerMode,
-    ConsensusConfig,
 )
 from src.llm_adapter.shadow import DEFAULT_METRICS_PATH
 


### PR DESCRIPTION
## Summary
- reorder the local imports in the CLI runner config tests to follow standard grouping and alphabetical order

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py --select I001 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dc6b9a451483218a9a399be0483f8d