### PR TITLE
Fix zip strictness in async parallel helper

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py
@@ -176,7 +176,7 @@ async def run_parallel_any_async(
         if on_cancelled is not None:
             cancelled = [
                 index
-                for (index, _), outcome in zip(task_pairs, results)
+                for (index, _), outcome in zip(task_pairs, results, strict=False)
                 if isinstance(outcome, asyncio.CancelledError)
             ]
             if cancelled:


### PR DESCRIPTION
## Summary
- ensure zip in run_parallel_any_async uses non-strict iteration to handle mismatched results length

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/parallel_async.py --select B905 --fix

------
https://chatgpt.com/codex/tasks/task_e_68dc6b99f9e883218419bd0621063d06