### PR TITLE
Add cancellation regression test for parallel runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
@@ -130,13 +130,13 @@ def run_parallel_any_sync(
                     continue
                 cancelled: tuple[int, ...] = ()
                 if on_cancelled is not None:
-                    pending = list(future_map.values())
+                    pending_indices = list(future_map.values())
                     if next_index < total_workers:
-                        pending.extend(range(next_index, total_workers))
-                    if pending:
-                        cancelled = tuple(sorted(pending))
-                for pending in list(future_map):
-                    pending.cancel()
+                        pending_indices.extend(range(next_index, total_workers))
+                    if pending_indices:
+                        cancelled = tuple(sorted(pending_indices))
+                for pending_future in list(future_map):
+                    pending_future.cancel()
                 if on_cancelled is not None and cancelled:
                     on_cancelled(cancelled)
                 return result


### PR DESCRIPTION
## Summary
- add regression coverage ensuring `run_parallel_any_sync` invokes `cancel()` on every pending future when cancelling the remainder of the pool
- refactor the pending-future loop variable in `run_parallel_any_sync` so it no longer collides with the cancellation bookkeeping list

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py::test_run_parallel_any_sync_cancels_pending_futures
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src *(fails: pre-existing arg-type errors in runner_async_modes/parallel_any.py and cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6e578a40832180e61e610c2b38da