### PR TITLE
Refactor compare runner metrics helpers

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -1,0 +1,274 @@
+"""CompareRunner 用の補助クラス。"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+import logging
+import os
+import re
+from typing import TYPE_CHECKING
+import uuid
+
+from .budgets import BudgetManager
+from .config import ProviderConfig
+from .datasets import GoldenTask
+from .metrics import (
+    BudgetSnapshot,
+    compute_diff_rate,
+    EvalMetrics,
+    hash_text,
+    now_ts,
+    RunMetrics,
+)
+from .providers import BaseProvider, ProviderFactory, ProviderResponse
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.provider_spi import (  # type: ignore[import-not-found]
+            ProviderResponse as JudgeProviderResponse,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+        from dataclasses import dataclass
+        from types import SimpleNamespace
+        from typing import Any
+
+        @dataclass(slots=True)
+        class JudgeProviderResponse:  # type: ignore[too-many-ancestors]
+            text: str
+            latency_ms: int
+            tokens_in: int = 0
+            tokens_out: int = 0
+            raw: Any | None = None
+
+            @property
+            def token_usage(self) -> SimpleNamespace:
+                return SimpleNamespace(
+                    prompt=self.tokens_in,
+                    completion=self.tokens_out,
+                    total=self.tokens_in + self.tokens_out,
+                )
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "RunMetricsBuilder",
+    "BudgetEvaluator",
+    "_JudgeInvoker",
+    "_JudgeProviderFactoryAdapter",
+]
+
+
+class RunMetricsBuilder:
+    """ランメトリクス生成ロジック。"""
+
+    def build(
+        self,
+        provider_config: ProviderConfig,
+        task: GoldenTask,
+        attempt_index: int,
+        mode: str,
+        response: ProviderResponse,
+        status: str,
+        failure_kind: str | None,
+        error_message: str | None,
+        latency_ms: int,
+        budget_snapshot: BudgetSnapshot,
+        cost_usd: float,
+    ) -> tuple[RunMetrics, str]:
+        output_text = response.output_text
+        eval_metrics, eval_failure_kind = self._evaluate(task, output_text)
+        eval_metrics.len_tokens = response.output_tokens
+        status, failure_kind = self._merge_eval_failure(status, failure_kind, eval_failure_kind)
+        output_text_record = output_text if provider_config.persist_output else None
+        output_hash = self._compute_output_hash(output_text)
+        run_metrics = RunMetrics(
+            ts=now_ts(),
+            run_id=f"run_{task.task_id}_{attempt_index}_{uuid.uuid4().hex}",
+            provider=provider_config.provider,
+            model=provider_config.model,
+            mode=mode,
+            prompt_id=task.task_id,
+            prompt_name=task.name,
+            seed=provider_config.seed,
+            temperature=provider_config.temperature,
+            top_p=provider_config.top_p,
+            max_tokens=provider_config.max_tokens,
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            latency_ms=latency_ms,
+            cost_usd=cost_usd,
+            status=status,
+            failure_kind=failure_kind,
+            error_message=error_message,
+            output_text=output_text_record,
+            output_hash=output_hash,
+            eval=eval_metrics,
+            budget=budget_snapshot,
+            ci_meta=self._ci_metadata(),
+        )
+        return run_metrics, output_text or ""
+
+    def _merge_eval_failure(
+        self,
+        status: str,
+        failure_kind: str | None,
+        eval_failure_kind: str | None,
+    ) -> tuple[str, str | None]:
+        if not eval_failure_kind:
+            return status, failure_kind
+        failure_kind = failure_kind or eval_failure_kind
+        if status == "ok":
+            status = "error"
+        return status, failure_kind
+
+    def _evaluate(
+        self,
+        task: GoldenTask,
+        output_text: str | None,
+    ) -> tuple[EvalMetrics, str | None]:
+        expected_type = str(task.expected.get("type", "regex"))
+        expected_value = task.expected.get("value")
+        eval_metrics = EvalMetrics()
+        failure_kind: str | None = None
+        if output_text is None:
+            return eval_metrics, failure_kind
+        if expected_type == "regex" and isinstance(expected_value, str):
+            match = re.search(expected_value, output_text)
+            eval_metrics.exact_match = bool(match)
+            eval_metrics.diff_rate = 0.0 if match else 1.0
+        elif expected_type == "literal" and isinstance(expected_value, str):
+            eval_metrics.exact_match = output_text.strip() == expected_value.strip()
+            eval_metrics.diff_rate = (
+                0.0
+                if eval_metrics.exact_match
+                else compute_diff_rate(output_text, expected_value)
+            )
+        elif expected_type == "json_equal" and expected_value is not None:
+            try:
+                import json as _json
+
+                actual = _json.loads(output_text)
+                eval_metrics.exact_match = actual == expected_value
+                eval_metrics.diff_rate = 0.0 if eval_metrics.exact_match else 1.0
+            except Exception:
+                eval_metrics.exact_match = False
+                eval_metrics.diff_rate = 1.0
+                failure_kind = "parsing"
+        else:
+            eval_metrics.diff_rate = 1.0
+        return eval_metrics, failure_kind
+
+    @staticmethod
+    def _compute_output_hash(output_text: str | None) -> str | None:
+        return hash_text(output_text) if output_text else None
+
+    @staticmethod
+    def _ci_metadata() -> Mapping[str, str]:
+        meta: dict[str, str] = {}
+        branch = os.getenv("GITHUB_REF_NAME") or os.getenv("GITHUB_HEAD_REF")
+        commit = os.getenv("GITHUB_SHA")
+        if branch:
+            meta["branch"] = branch
+        if commit:
+            meta["commit"] = commit
+        return meta
+
+
+class BudgetEvaluator:
+    """予算評価ロジック。"""
+
+    def __init__(
+        self,
+        *,
+        budget_manager: BudgetManager,
+        allow_overrun: bool,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._budget_manager = budget_manager
+        self.allow_overrun = allow_overrun
+        self._logger = logger or LOGGER
+
+    def evaluate(
+        self,
+        provider_config: ProviderConfig,
+        cost_usd: float,
+        status: str,
+        failure_kind: str | None,
+        error_message: str | None,
+    ) -> tuple[BudgetSnapshot, str | None, str, str | None, str | None]:
+        provider_name = provider_config.provider
+        run_budget_limit = self._budget_manager.run_budget(provider_name)
+        run_budget_hit = run_budget_limit > 0 and cost_usd > run_budget_limit
+        daily_stop_required = not self._budget_manager.notify_cost(provider_name, cost_usd)
+        budget_snapshot = BudgetSnapshot(
+            run_budget_usd=run_budget_limit,
+            hit_stop=run_budget_hit or daily_stop_required,
+        )
+        run_reason: str | None = None
+        if run_budget_hit:
+            run_reason = (
+                f"provider={provider_name} run budget {run_budget_limit:.4f} USD exceeded "
+                f"(cost={cost_usd:.4f} USD)"
+            )
+        daily_reason: str | None = None
+        if daily_stop_required:
+            spent = self._budget_manager.spent_today(provider_name)
+            daily_limit = self._budget_manager.daily_budget(provider_name)
+            daily_reason = (
+                f"provider={provider_name} daily budget {daily_limit:.4f} USD exceeded "
+                f"(spent={spent:.4f} USD)"
+            )
+        stop_reason: str | None = None
+        if not self.allow_overrun:
+            if daily_reason:
+                stop_reason = daily_reason
+            elif self._budget_manager.should_stop_run(provider_name, cost_usd):
+                stop_reason = run_reason
+        budget_messages = [msg for msg in (run_reason, daily_reason) if msg]
+        if budget_messages:
+            if status == "ok":
+                status = "error"
+            if failure_kind is None:
+                failure_kind = "guard_violation"
+            joined = " | ".join(budget_messages)
+            if error_message:
+                error_message = f"{error_message} | {joined}"
+            else:
+                error_message = joined
+            if self.allow_overrun and stop_reason is None:
+                self._logger.warning("予算超過を許容 (--allow-overrun): %s", joined)
+        return budget_snapshot, stop_reason, status, failure_kind, error_message
+
+
+class _JudgeInvoker:
+    def __init__(self, provider: BaseProvider, config: ProviderConfig) -> None:
+        self._provider = provider
+        self._config = config
+
+    def invoke(self, request: object) -> JudgeProviderResponse:
+        if hasattr(request, "prompt_text"):
+            prompt = request.prompt_text or ""
+        elif hasattr(request, "prompt"):
+            prompt = request.prompt or ""
+        else:
+            prompt = ""
+        response = self._provider.generate(prompt)
+        return JudgeProviderResponse(
+            text=response.output_text,
+            latency_ms=response.latency_ms,
+            tokens_in=response.input_tokens,
+            tokens_out=response.output_tokens,
+            raw={"provider": self._config.provider},
+        )
+
+
+class _JudgeProviderFactoryAdapter:
+    def __init__(self, config: ProviderConfig) -> None:
+        self._config = config
+
+    def create(self, *, model: str) -> _JudgeInvoker:
+        provider_config = replace(self._config, model=model)
+        provider = ProviderFactory.create(provider_config)
+        return _JudgeInvoker(provider, provider_config)

--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -1,44 +1,14 @@
 """比較ランナーの実装。"""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
-from dataclasses import replace
+from collections.abc import Callable, Sequence
 import logging
-import os
 from pathlib import Path
-import re
 from typing import TYPE_CHECKING
-import uuid
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.parallel_exec import ParallelExecutionError
-    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse
 else:  # pragma: no cover - 実行時フォールバック
-    try:
-        from src.llm_adapter.provider_spi import (  # type: ignore[import-not-found]
-            ProviderResponse as JudgeProviderResponse,
-        )
-    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
-        from dataclasses import dataclass
-        from types import SimpleNamespace
-        from typing import Any
-
-        @dataclass(slots=True)
-        class JudgeProviderResponse:
-            text: str
-            latency_ms: int
-            tokens_in: int = 0
-            tokens_out: int = 0
-            raw: Any | None = None
-
-            @property
-            def token_usage(self) -> SimpleNamespace:
-                return SimpleNamespace(
-                    prompt=self.tokens_in,
-                    completion=self.tokens_out,
-                    total=self.tokens_in + self.tokens_out,
-                )
-
     try:
         from src.llm_adapter.parallel_exec import (  # type: ignore[import-not-found]
             ParallelExecutionError,
@@ -47,14 +17,20 @@ else:  # pragma: no cover - 実行時フォールバック
         class ParallelExecutionError(RuntimeError):
             """並列実行失敗のフォールバック."""
 
+
 from .aggregation_controller import AggregationController
 from .budgets import BudgetManager
 from .compare_runner_finalizer import TaskFinalizer
+from .compare_runner_support import (
+    _JudgeProviderFactoryAdapter,
+    BudgetEvaluator,
+    RunMetricsBuilder,
+)
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .execution.compare_task_runner import run_tasks
-from .metrics import BudgetSnapshot, compute_diff_rate, EvalMetrics, hash_text, now_ts, RunMetrics
-from .providers import BaseProvider, ProviderFactory, ProviderResponse
+from .metrics import RunMetrics
+from .providers import BaseProvider, ProviderResponse
 from .runner_execution import (
     _SchemaValidator,
     _TokenBucket,
@@ -69,38 +45,6 @@ if TYPE_CHECKING:  # pragma: no cover - 型補完用
 LOGGER = logging.getLogger(__name__)
 
 __all__ = ["CompareRunner", "run_parallel_any_sync"]
-
-
-class _JudgeInvoker:
-    def __init__(self, provider: BaseProvider, config: ProviderConfig) -> None:
-        self._provider = provider
-        self._config = config
-
-    def invoke(self, request: object) -> JudgeProviderResponse:
-        if hasattr(request, "prompt_text"):
-            prompt = request.prompt_text or ""
-        elif hasattr(request, "prompt"):
-            prompt = request.prompt or ""
-        else:
-            prompt = ""
-        response = self._provider.generate(prompt)
-        return JudgeProviderResponse(
-            text=response.output_text,
-            latency_ms=response.latency_ms,
-            tokens_in=response.input_tokens,
-            tokens_out=response.output_tokens,
-            raw={"provider": self._config.provider},
-        )
-
-
-class _JudgeProviderFactoryAdapter:
-    def __init__(self, config: ProviderConfig) -> None:
-        self._config = config
-
-    def create(self, *, model: str) -> _JudgeInvoker:
-        provider_config = replace(self._config, model=model)
-        provider = ProviderFactory.create(provider_config)
-        return _JudgeInvoker(provider, provider_config)
 
 
 class CompareRunner:
@@ -146,6 +90,12 @@ class CompareRunner:
             judge_factory_builder=lambda cfg: _JudgeProviderFactoryAdapter(cfg)
         )
         self._task_finalizer = TaskFinalizer(self.metrics_path)
+        self._metrics_builder = RunMetricsBuilder()
+        self._budget_evaluator = BudgetEvaluator(
+            budget_manager=self.budget_manager,
+            allow_overrun=self.allow_overrun,
+            logger=LOGGER,
+        )
 
     def run(self, repeat: int, config: RunnerConfig) -> list[RunMetrics]:
         repeat = max(repeat, 1)
@@ -169,11 +119,12 @@ class CompareRunner:
         if config.judge_provider is not None:
             self._judge_provider_config = config.judge_provider
 
+        self._budget_evaluator.allow_overrun = self.allow_overrun
         execution = RunnerExecution(
             token_bucket=self._token_bucket,
             schema_validator=self._schema_validator,
-            evaluate_budget=self._evaluate_budget,
-            build_metrics=self._build_metrics,
+            evaluate_budget=self._budget_evaluator.evaluate,
+            build_metrics=self._metrics_builder.build,
             normalize_concurrency=self._normalize_concurrency,
             backoff=self._backoff,
             shadow_provider=self._shadow_provider,
@@ -236,8 +187,8 @@ class CompareRunner:
         execution = RunnerExecution(
             token_bucket=self._token_bucket,
             schema_validator=self._schema_validator,
-            evaluate_budget=self._evaluate_budget,
-            build_metrics=self._build_metrics,
+            evaluate_budget=self._budget_evaluator.evaluate,
+            build_metrics=self._metrics_builder.build,
             normalize_concurrency=self._normalize_concurrency,
         )
         return execution._run_provider_call(provider_config, provider, prompt)
@@ -250,164 +201,5 @@ class CompareRunner:
             return total
         return max(1, min(total, limit))
 
-    def _build_metrics(
-        self,
-        provider_config: ProviderConfig,
-        task: GoldenTask,
-        attempt_index: int,
-        mode: str,
-        response: ProviderResponse,
-        status: str,
-        failure_kind: str | None,
-        error_message: str | None,
-        latency_ms: int,
-        budget_snapshot: BudgetSnapshot,
-        cost_usd: float,
-    ) -> tuple[RunMetrics, str]:
-        output_text = response.output_text
-        eval_metrics, eval_failure_kind = self._evaluate(task, output_text)
-        eval_metrics.len_tokens = response.output_tokens
-        status, failure_kind = self._merge_eval_failure(
-            status, failure_kind, eval_failure_kind
-        )
-        output_text_record = output_text if provider_config.persist_output else None
-        output_hash = self._compute_output_hash(output_text)
-        run_metrics = RunMetrics(
-            ts=now_ts(),
-            run_id=f"run_{task.task_id}_{attempt_index}_{uuid.uuid4().hex}",
-            provider=provider_config.provider,
-            model=provider_config.model,
-            mode=mode,
-            prompt_id=task.task_id,
-            prompt_name=task.name,
-            seed=provider_config.seed,
-            temperature=provider_config.temperature,
-            top_p=provider_config.top_p,
-            max_tokens=provider_config.max_tokens,
-            input_tokens=response.input_tokens,
-            output_tokens=response.output_tokens,
-            latency_ms=latency_ms,
-            cost_usd=cost_usd,
-            status=status,
-            failure_kind=failure_kind,
-            error_message=error_message,
-            output_text=output_text_record,
-            output_hash=output_hash,
-            eval=eval_metrics,
-            budget=budget_snapshot,
-            ci_meta=self._ci_metadata(),
-        )
-        return run_metrics, output_text or ""
 
-    def _merge_eval_failure(
-        self,
-        status: str,
-        failure_kind: str | None,
-        eval_failure_kind: str | None,
-    ) -> tuple[str, str | None]:
-        if not eval_failure_kind:
-            return status, failure_kind
-        failure_kind = failure_kind or eval_failure_kind
-        if status == "ok":
-            status = "error"
-        return status, failure_kind
 
-    def _compute_output_hash(self, output_text: str | None) -> str | None:
-        return hash_text(output_text) if output_text else None
-
-    def _evaluate_budget(
-        self,
-        provider_config: ProviderConfig,
-        cost_usd: float,
-        status: str,
-        failure_kind: str | None,
-        error_message: str | None,
-    ) -> tuple[BudgetSnapshot, str | None, str, str | None, str | None]:
-        run_budget_limit = self.budget_manager.run_budget(provider_config.provider)
-        run_budget_hit = run_budget_limit > 0 and cost_usd > run_budget_limit
-        daily_stop_required = not self.budget_manager.notify_cost(
-            provider_config.provider, cost_usd
-        )
-        budget_snapshot = BudgetSnapshot(
-            run_budget_usd=run_budget_limit,
-            hit_stop=run_budget_hit or daily_stop_required,
-        )
-        run_reason: str | None = None
-        if run_budget_hit:
-            run_reason = (
-                f"provider={provider_config.provider} run budget "
-                f"{run_budget_limit:.4f} USD exceeded "
-                f"(cost={cost_usd:.4f} USD)"
-            )
-        daily_reason: str | None = None
-        if daily_stop_required:
-            spent = self.budget_manager.spent_today(provider_config.provider)
-            daily_limit = self.budget_manager.daily_budget(provider_config.provider)
-            daily_reason = (
-                f"provider={provider_config.provider} daily budget "
-                f"{daily_limit:.4f} USD exceeded "
-                f"(spent={spent:.4f} USD)"
-            )
-        stop_reason: str | None = None
-        if not self.allow_overrun:
-            if daily_reason:
-                stop_reason = daily_reason
-            elif self.budget_manager.should_stop_run(provider_config.provider, cost_usd):
-                stop_reason = run_reason
-        budget_messages = [msg for msg in (run_reason, daily_reason) if msg]
-        if budget_messages:
-            if status == "ok":
-                status = "error"
-            if failure_kind is None:
-                failure_kind = "guard_violation"
-            joined = " | ".join(budget_messages)
-            if error_message:
-                error_message = f"{error_message} | {joined}"
-            else:
-                error_message = joined
-            if self.allow_overrun and stop_reason is None:
-                LOGGER.warning("予算超過を許容 (--allow-overrun): %s", joined)
-        return budget_snapshot, stop_reason, status, failure_kind, error_message
-
-    def _evaluate(
-        self, task: GoldenTask, output_text: str | None
-    ) -> tuple[EvalMetrics, str | None]:
-        expected_type = str(task.expected.get("type", "regex"))
-        expected_value = task.expected.get("value")
-        eval_metrics = EvalMetrics()
-        failure_kind: str | None = None
-        if output_text is None:
-            return eval_metrics, failure_kind
-        if expected_type == "regex" and isinstance(expected_value, str):
-            match = re.search(expected_value, output_text)
-            eval_metrics.exact_match = bool(match)
-            eval_metrics.diff_rate = 0.0 if match else 1.0
-        elif expected_type == "literal" and isinstance(expected_value, str):
-            eval_metrics.exact_match = output_text.strip() == expected_value.strip()
-            eval_metrics.diff_rate = 0.0 if eval_metrics.exact_match else compute_diff_rate(
-                output_text, expected_value
-            )
-        elif expected_type == "json_equal" and expected_value is not None:
-            try:
-                import json as _json
-
-                actual = _json.loads(output_text)
-                eval_metrics.exact_match = actual == expected_value
-                eval_metrics.diff_rate = 0.0 if eval_metrics.exact_match else 1.0
-            except Exception:
-                eval_metrics.exact_match = False
-                eval_metrics.diff_rate = 1.0
-                failure_kind = "parsing"
-        else:
-            eval_metrics.diff_rate = 1.0
-        return eval_metrics, failure_kind
-
-    def _ci_metadata(self) -> Mapping[str, str]:
-        meta: dict[str, str] = {}
-        branch = os.getenv("GITHUB_REF_NAME") or os.getenv("GITHUB_HEAD_REF")
-        commit = os.getenv("GITHUB_SHA")
-        if branch:
-            meta["branch"] = branch
-        if commit:
-            meta["commit"] = commit
-        return meta

--- a/projects/04-llm-adapter/tests/test_compare_runner_metrics.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_metrics.py
@@ -1,0 +1,123 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from adapter.core.budgets import BudgetBook, BudgetManager, BudgetRule
+from adapter.core.compare_runner_support import BudgetEvaluator, RunMetricsBuilder
+from adapter.core.config import ProviderConfig
+from adapter.core.datasets import GoldenTask
+from adapter.core.metrics import BudgetSnapshot, hash_text
+from adapter.core.models import (
+    PricingConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from adapter.core.providers import ProviderResponse
+
+
+@pytest.fixture(name="provider_config")
+def _provider_config(tmp_path: Path) -> ProviderConfig:
+    config_path = tmp_path / "provider.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    return ProviderConfig(
+        path=config_path,
+        schema_version=1,
+        provider="mock",
+        endpoint=None,
+        model="test-model",
+        auth_env=None,
+        seed=42,
+        temperature=0.1,
+        top_p=0.9,
+        max_tokens=16,
+        timeout_s=30,
+        retries=RetryConfig(max=0, backoff_s=0.0),
+        persist_output=True,
+        pricing=PricingConfig(),
+        rate_limit=RateLimitConfig(),
+        quality_gates=QualityGatesConfig(),
+        raw={},
+    )
+
+
+@pytest.fixture(name="golden_task")
+def _golden_task() -> GoldenTask:
+    return GoldenTask(
+        task_id="task-1",
+        name="sample",
+        input={},
+        prompt_template="",
+        expected={"type": "json_equal", "value": {"answer": 1}},
+    )
+
+
+@pytest.fixture(name="provider_response")
+def _provider_response() -> ProviderResponse:
+    return ProviderResponse(
+        output_text="not-json",
+        latency_ms=123,
+        input_tokens=5,
+        output_tokens=7,
+    )
+
+
+@pytest.fixture(name="budget_manager")
+def _budget_manager() -> BudgetManager:
+    rule = BudgetRule(run_budget_usd=1.0, daily_budget_usd=1.0, stop_on_budget_exceed=True)
+    book = BudgetBook(default=rule, overrides={})
+    return BudgetManager(book)
+
+
+def test_run_metrics_builder_merges_eval_failures(
+    provider_config: ProviderConfig,
+    golden_task: GoldenTask,
+    provider_response: ProviderResponse,
+) -> None:
+    builder = RunMetricsBuilder()
+    snapshot = BudgetSnapshot(run_budget_usd=1.0, hit_stop=False)
+
+    run_metrics, output_text = builder.build(
+        provider_config=provider_config,
+        task=golden_task,
+        attempt_index=2,
+        mode="parallel-any",
+        response=provider_response,
+        status="ok",
+        failure_kind=None,
+        error_message=None,
+        latency_ms=provider_response.latency_ms,
+        budget_snapshot=snapshot,
+        cost_usd=0.5,
+    )
+
+    assert run_metrics.status == "error"
+    assert run_metrics.failure_kind == "parsing"
+    assert run_metrics.output_text == provider_response.output_text
+    assert run_metrics.output_hash == hash_text(provider_response.output_text)
+    assert run_metrics.eval.len_tokens == provider_response.output_tokens
+    assert output_text == provider_response.output_text
+
+
+def test_budget_evaluator_flags_budget_exceed(
+    provider_config: ProviderConfig,
+    budget_manager: BudgetManager,
+) -> None:
+    evaluator = BudgetEvaluator(budget_manager=budget_manager, allow_overrun=False, logger=logging.getLogger(__name__))
+
+    snapshot, stop_reason, status, failure_kind, error_message = evaluator.evaluate(
+        provider_config=provider_config,
+        cost_usd=2.0,
+        status="ok",
+        failure_kind=None,
+        error_message="preexisting",
+    )
+
+    assert snapshot.hit_stop is True
+    assert status == "error"
+    assert failure_kind == "guard_violation"
+    assert "run budget" in error_message
+    assert "daily budget" in error_message
+    assert error_message.startswith("preexisting | ")
+    assert stop_reason == "provider=mock daily budget 1.0000 USD exceeded (spent=2.0000 USD)"


### PR DESCRIPTION
## Summary
- add regression tests for compare runner metrics and budget evaluation
- extract RunMetricsBuilder and BudgetEvaluator into a new compare_runner_support module
- simplify CompareRunner to delegate metric building and budget checks to the new helpers

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_metrics.py
- ruff check projects/04-llm-adapter/adapter/core/compare_runner_support.py projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6e67f9e88321b5af4e411b680e4b