### PR TITLE
Fix uuid4 import in parallel runner

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -7,7 +7,7 @@ from concurrent.futures import CancelledError
 from dataclasses import dataclass
 from threading import Event, Lock
 from typing import Any, cast, Protocol, TYPE_CHECKING
-import uuid
+from uuid import uuid4
 
 from .config import ProviderConfig
 from .datasets import GoldenTask


### PR DESCRIPTION
## Summary
- import `uuid4` directly in the parallel runner helper to avoid unused `uuid` import

## Testing
- `ruff check projects/04-llm-adapter/adapter/core/runner_execution_parallel.py --select F401,F821`


------
https://chatgpt.com/codex/tasks/task_e_68dc7263bb808321a660ca265c23feba