### PR TITLE
Refactor aggregation selector into modular components

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -4,77 +4,22 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-import json
-from pathlib import Path
-from typing import Any, cast, Protocol, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 from . import aggregation as aggregation_module
-from .aggregation import (
-    AggregationCandidate,
-    AggregationResult,
-    AggregationStrategy,
-    FirstTieBreaker,
-    TieBreaker,
+from .aggregation import AggregationCandidate, AggregationResult, AggregationStrategy
+from .aggregation_selector_components import (
+    CandidateBuilder,
+    JudgeProviderFactory,
+    JudgeScorer,
+    SchemaCache,
+    TieBreakerFactory,
 )
 from .runner_execution import SingleRunResult
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .config import ProviderConfig
     from .runner_api import RunnerConfig
-
-try:  # pragma: no cover - 実環境では src.* が存在する
-    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
-    from dataclasses import dataclass as _dataclass
-    from typing import Any as _Any
-
-    @_dataclass(slots=True)
-    class JudgeProviderResponse:  # type: ignore[override]
-        text: str
-        latency_ms: int
-        tokens_in: int = 0
-        tokens_out: int = 0
-        raw: _Any | None = None
-
-
-class JudgeProviderFactory(Protocol):
-    def create(self, *, model: str) -> object:
-        ...
-
-
-class _CompositeTieBreaker(TieBreaker):
-    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "first"}
-
-    def __init__(
-        self,
-        order: Sequence[tuple[str, Callable[[AggregationCandidate], float | int]]],
-    ) -> None:
-        if not order:
-            raise ValueError("tie breaker order must not be empty")
-        self._order = list(order)
-        self._last_used = self._DISPLAY_NAMES[self._order[-1][0]]
-
-    @property
-    def name(self) -> str:
-        return self._last_used
-
-    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
-        if not candidates:
-            raise ValueError("TieBreaker: candidates must be non-empty")
-        scored: list[tuple[tuple[float | int, ...], AggregationCandidate]] = []
-        for candidate in candidates:
-            score = tuple(key(candidate) for _, key in self._order)
-            scored.append((score, candidate))
-        scored.sort(key=lambda item: item[0])
-        best_score, best_candidate = scored[0]
-        chosen_name = self._order[-1][0]
-        for index, (name, _) in enumerate(self._order):
-            pivot = best_score[index]
-            if any(entry[0][index] != pivot for entry in scored[1:]):
-                chosen_name = name
-                break
-        self._last_used = self._DISPLAY_NAMES[chosen_name]
-        return best_candidate
 
 
 @dataclass(slots=True)
@@ -89,10 +34,16 @@ class AggregationSelector:
         self,
         *,
         judge_factory_builder: Callable[[ProviderConfig], JudgeProviderFactory] | None = None,
+        candidate_builder: CandidateBuilder | None = None,
+        judge_scorer: JudgeScorer | None = None,
+        tie_breaker_factory: TieBreakerFactory | None = None,
+        schema_cache: SchemaCache | None = None,
     ) -> None:
         self._judge_factory_builder = judge_factory_builder
-        self._cached_schema_path: Path | None = None
-        self._cached_schema: Mapping[str, Any] | None = None
+        self._candidate_builder = candidate_builder or CandidateBuilder()
+        self._tie_breaker_factory = tie_breaker_factory or TieBreakerFactory()
+        self._schema_cache = schema_cache or SchemaCache()
+        self._judge_scorer = judge_scorer or JudgeScorer(judge_factory_builder)
 
     def select(
         self,
@@ -105,21 +56,7 @@ class AggregationSelector:
         if not batch:
             return None
         lookup: dict[int, SingleRunResult] = {index: result for index, result in batch}
-        candidates = [
-            AggregationCandidate(
-                index=index,
-                provider=result.metrics.provider,
-                response=JudgeProviderResponse(
-                    text=result.raw_output,
-                    latency_ms=result.metrics.latency_ms,
-                    tokens_in=result.metrics.input_tokens,
-                    tokens_out=result.metrics.output_tokens,
-                ),
-                text=result.raw_output,
-            )
-            for index, result in batch
-            if result.metrics.status == "ok" and result.raw_output.strip()
-        ]
+        candidates = self._candidate_builder.build(batch)
         if not candidates:
             return None
         strategy = self._resolve_aggregation_strategy(
@@ -131,12 +68,12 @@ class AggregationSelector:
             return None
         score_metadata: dict[str, float] | None = None
         if strategy.name == "max_score":
-            score_metadata = self._score_candidates_with_judge(
+            score_metadata = self._judge_scorer.score(
                 candidates,
                 config=config,
                 default_judge_config=default_judge_config,
             )
-        tiebreaker = self._resolve_tie_breaker(config, lookup)
+        tiebreaker = self._tie_breaker_factory.create(config, lookup)
         decision = strategy.aggregate(candidates, tiebreaker=tiebreaker)
         if score_metadata is not None:
             metadata = dict(decision.metadata) if decision.metadata else {}
@@ -191,53 +128,6 @@ class AggregationSelector:
                 votes = int(votes)
         return AggregationDecision(decision=decision, lookup=lookup, votes=votes)
 
-    def _score_candidates_with_judge(
-        self,
-        candidates: Sequence[AggregationCandidate],
-        *,
-        config: RunnerConfig,
-        default_judge_config: ProviderConfig | None,
-    ) -> dict[str, float]:
-        judge_config = config.judge_provider or default_judge_config
-        if judge_config is None:
-            raise ValueError("max_score aggregation requires judge provider configuration")
-        if self._judge_factory_builder is None:
-            raise ValueError("judge_factory_builder must be provided for max_score aggregation")
-        factory = self._judge_factory_builder(judge_config)
-        judge = factory.create(model=judge_config.model)
-        invoke = getattr(judge, "invoke", None)
-        if not callable(invoke):
-            raise ValueError("judge instance must expose invoke(request)")
-        scores: dict[str, float] = {}
-        for candidate in candidates:
-            request = {
-                "mode": getattr(config, "mode", ""),
-                "provider": candidate.provider,
-                "index": candidate.index,
-                "text": candidate.text if candidate.text is not None else candidate.response.text,
-            }
-            response = invoke(request)
-            score = self._extract_quality_score(response)
-            candidate.score = score
-            if score is not None:
-                scores[candidate.provider] = score
-        return scores
-
-    @staticmethod
-    def _extract_quality_score(response: object) -> float | None:
-        raw = getattr(response, "raw", None)
-        if isinstance(raw, Mapping):
-            value = raw.get("quality_score")
-            if isinstance(value, (int, float)):
-                return float(value)
-        text = getattr(response, "text", None)
-        if isinstance(text, str):
-            try:
-                return float(text.strip())
-            except ValueError:
-                return None
-        return None
-
     def _resolve_aggregation_strategy(
         self,
         mode: str,
@@ -267,66 +157,13 @@ class AggregationSelector:
                 model=judge_config.model,
                 provider_factory=factory,
             )
-        schema_data = self._load_schema(getattr(config, "schema", None))
+        schema_data = self._schema_cache.load(getattr(config, "schema", None))
         provider_weights = getattr(config, "provider_weights", None)
         extra: dict[str, Any] = {"schema": schema_data}
         normalized = aggregate.lower().replace("-", "_") if aggregate else ""
         if normalized in {"weighted_vote", "weighted"}:
             extra["provider_weights"] = provider_weights
         return AggregationStrategy.from_string(aggregate, **extra)
-
-    @staticmethod
-    def _resolve_tie_breaker(
-        config: RunnerConfig,
-        lookup: Mapping[int, SingleRunResult],
-    ) -> TieBreaker | None:
-        tie_name = (config.tie_breaker or "").strip().lower()
-        alias = {
-            "latency": "latency",
-            "min_latency": "latency",
-            "cost": "cost",
-            "min_cost": "cost",
-            "first": "stable_order",
-            "stable_order": "stable_order",
-        }
-        preferred = alias.get(tie_name) if tie_name else None
-        if preferred == "stable_order" and tie_name:
-            return FirstTieBreaker()
-        if tie_name and preferred is None:
-            return None
-
-        key_funcs: dict[str, Callable[[AggregationCandidate], float | int]] = {
-            "latency": lambda candidate: lookup[candidate.index].metrics.latency_ms,
-            "cost": lambda candidate: lookup[candidate.index].metrics.cost_usd,
-            "stable_order": lambda candidate: candidate.index,
-        }
-
-        order: list[tuple[str, Callable[[AggregationCandidate], float | int]]] = []
-        if preferred is not None:
-            order.append((preferred, key_funcs[preferred]))
-        for fallback in ("latency", "cost", "stable_order"):
-            if all(existing_name != fallback for existing_name, _ in order):
-                order.append((fallback, key_funcs[fallback]))
-        if not order:
-            return None
-        if order[0][0] == "stable_order" and len(order) == 1:
-            return FirstTieBreaker()
-        return _CompositeTieBreaker(order)
-
-    def _load_schema(self, schema_path: Path | None) -> Mapping[str, Any] | None:
-        if schema_path is None:
-            self._cached_schema_path = None
-            self._cached_schema = None
-            return None
-        if self._cached_schema_path == schema_path and self._cached_schema is not None:
-            return self._cached_schema
-        if schema_path.exists():
-            with schema_path.open("r", encoding="utf-8") as fp:
-                self._cached_schema = cast(Mapping[str, Any], json.load(fp))
-        else:
-            self._cached_schema = None
-        self._cached_schema_path = schema_path
-        return self._cached_schema
 
 
 __all__ = [

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -1,0 +1,227 @@
+"""AggregationSelector のコンポーネント群."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import json
+from pathlib import Path
+from typing import Any, Protocol, TYPE_CHECKING, cast
+
+from .aggregation import AggregationCandidate, FirstTieBreaker, TieBreaker
+from .runner_execution import SingleRunResult
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .config import ProviderConfig
+    from .runner_api import RunnerConfig
+
+try:  # pragma: no cover - 実環境では src.* が存在する
+    from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+    from dataclasses import dataclass as _dataclass
+    from typing import Any as _Any
+
+    @_dataclass(slots=True)
+    class JudgeProviderResponse:  # type: ignore[override]
+        text: str
+        latency_ms: int
+        tokens_in: int = 0
+        tokens_out: int = 0
+        raw: _Any | None = None
+
+
+class JudgeProviderFactory(Protocol):
+    def create(self, *, model: str) -> object:
+        ...
+
+
+class CandidateBuilder:
+    """SingleRunResult から AggregationCandidate を構築する."""
+
+    def build(self, batch: Sequence[tuple[int, SingleRunResult]]) -> list[AggregationCandidate]:
+        candidates: list[AggregationCandidate] = []
+        for index, result in batch:
+            if result.metrics.status != "ok":
+                continue
+            text = result.raw_output.strip()
+            if not text:
+                continue
+            response = JudgeProviderResponse(
+                text=result.raw_output,
+                latency_ms=result.metrics.latency_ms,
+                tokens_in=result.metrics.input_tokens,
+                tokens_out=result.metrics.output_tokens,
+            )
+            candidate = AggregationCandidate(
+                index=index,
+                provider=result.metrics.provider,
+                response=response,
+                text=result.raw_output,
+            )
+            candidates.append(candidate)
+        return candidates
+
+
+class JudgeScorer:
+    """LLM ジャッジを介して候補へスコアを付与する."""
+
+    def __init__(
+        self,
+        judge_factory_builder: Callable[[ProviderConfig], JudgeProviderFactory] | None,
+    ) -> None:
+        self._judge_factory_builder = judge_factory_builder
+
+    def score(
+        self,
+        candidates: Sequence[AggregationCandidate],
+        *,
+        config: RunnerConfig,
+        default_judge_config: ProviderConfig | None,
+    ) -> dict[str, float]:
+        judge_config = config.judge_provider or default_judge_config
+        if judge_config is None:
+            raise ValueError("max_score aggregation requires judge provider configuration")
+        if self._judge_factory_builder is None:
+            raise ValueError("judge_factory_builder must be provided for max_score aggregation")
+        factory = self._judge_factory_builder(judge_config)
+        judge = factory.create(model=judge_config.model)
+        invoke = getattr(judge, "invoke", None)
+        if not callable(invoke):
+            raise ValueError("judge instance must expose invoke(request)")
+        scores: dict[str, float] = {}
+        for candidate in candidates:
+            request = {
+                "mode": getattr(config, "mode", ""),
+                "provider": candidate.provider,
+                "index": candidate.index,
+                "text": candidate.text if candidate.text is not None else candidate.response.text,
+            }
+            response = invoke(request)
+            score = self._extract_quality_score(response)
+            candidate.score = score
+            if score is not None:
+                scores[candidate.provider] = score
+        return scores
+
+    @staticmethod
+    def _extract_quality_score(response: object) -> float | None:
+        raw = getattr(response, "raw", None)
+        if isinstance(raw, Mapping):
+            value = raw.get("quality_score")
+            if isinstance(value, (int, float)):
+                return float(value)
+        text = getattr(response, "text", None)
+        if isinstance(text, str):
+            try:
+                return float(text.strip())
+            except ValueError:
+                return None
+        return None
+
+
+class _CompositeTieBreaker(TieBreaker):
+    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "first"}
+
+    def __init__(
+        self,
+        order: Sequence[tuple[str, Callable[[AggregationCandidate], float | int]]],
+    ) -> None:
+        if not order:
+            raise ValueError("tie breaker order must not be empty")
+        self._order = list(order)
+        self._last_used = self._DISPLAY_NAMES[self._order[-1][0]]
+
+    @property
+    def name(self) -> str:
+        return self._last_used
+
+    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
+        if not candidates:
+            raise ValueError("TieBreaker: candidates must be non-empty")
+        scored: list[tuple[tuple[float | int, ...], AggregationCandidate]] = []
+        for candidate in candidates:
+            score = tuple(key(candidate) for _, key in self._order)
+            scored.append((score, candidate))
+        scored.sort(key=lambda item: item[0])
+        best_score, best_candidate = scored[0]
+        chosen_name = self._order[-1][0]
+        for index, (name, _) in enumerate(self._order):
+            pivot = best_score[index]
+            if any(entry[0][index] != pivot for entry in scored[1:]):
+                chosen_name = name
+                break
+        self._last_used = self._DISPLAY_NAMES[chosen_name]
+        return best_candidate
+
+
+class TieBreakerFactory:
+    """タイブレーカの生成と表示名管理."""
+
+    def create(
+        self,
+        config: RunnerConfig,
+        lookup: Mapping[int, SingleRunResult],
+    ) -> TieBreaker | None:
+        tie_name = (config.tie_breaker or "").strip().lower()
+        alias = {
+            "latency": "latency",
+            "min_latency": "latency",
+            "cost": "cost",
+            "min_cost": "cost",
+            "first": "stable_order",
+            "stable_order": "stable_order",
+        }
+        preferred = alias.get(tie_name) if tie_name else None
+        if preferred == "stable_order" and tie_name:
+            return FirstTieBreaker()
+        if tie_name and preferred is None:
+            return None
+
+        key_funcs: dict[str, Callable[[AggregationCandidate], float | int]] = {
+            "latency": lambda candidate: lookup[candidate.index].metrics.latency_ms,
+            "cost": lambda candidate: lookup[candidate.index].metrics.cost_usd,
+            "stable_order": lambda candidate: candidate.index,
+        }
+
+        order: list[tuple[str, Callable[[AggregationCandidate], float | int]]] = []
+        if preferred is not None:
+            order.append((preferred, key_funcs[preferred]))
+        for fallback in ("latency", "cost", "stable_order"):
+            if all(existing_name != fallback for existing_name, _ in order):
+                order.append((fallback, key_funcs[fallback]))
+        if not order:
+            return None
+        if order[0][0] == "stable_order" and len(order) == 1:
+            return FirstTieBreaker()
+        return _CompositeTieBreaker(order)
+
+
+class SchemaCache:
+    """スキーマファイルのキャッシュ管理."""
+
+    def __init__(self) -> None:
+        self._cached_path: Path | None = None
+        self._cached_schema: Mapping[str, Any] | None = None
+
+    def load(self, schema_path: Path | None) -> Mapping[str, Any] | None:
+        if schema_path is None:
+            self._cached_path = None
+            self._cached_schema = None
+            return None
+        if self._cached_path == schema_path and self._cached_schema is not None:
+            return self._cached_schema
+        if schema_path.exists():
+            with schema_path.open("r", encoding="utf-8") as fp:
+                self._cached_schema = cast(Mapping[str, Any], json.load(fp))
+        else:
+            self._cached_schema = None
+        self._cached_path = schema_path
+        return self._cached_schema
+
+
+__all__ = [
+    "CandidateBuilder",
+    "JudgeScorer",
+    "TieBreakerFactory",
+    "SchemaCache",
+    "JudgeProviderFactory",
+]

--- a/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from adapter.core.aggregation_selector import AggregationSelector
+from adapter.core.metrics import RunMetrics
+from adapter.core.models import (
+    PricingConfig,
+    ProviderConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from adapter.core.runner_api import RunnerConfig
+from adapter.core.runner_execution import SingleRunResult
+
+
+_BASE_METRICS = dict(
+    ts="2024-01-01T00:00:00Z",
+    run_id="run",
+    mode="consensus",
+    prompt_id="prompt",
+    prompt_name="Prompt",
+    seed=0,
+    temperature=0.0,
+    top_p=1.0,
+    max_tokens=16,
+    input_tokens=1,
+    output_tokens=1,
+    latency_ms=1,
+    cost_usd=0.0,
+    status="ok",
+    failure_kind=None,
+    error_message=None,
+    output_hash=None,
+)
+
+
+def _metrics(provider: str, *, latency_ms: int = 1, cost_usd: float = 0.0) -> RunMetrics:
+    payload = dict(_BASE_METRICS)
+    payload.update(
+        provider=provider,
+        model=f"{provider}-model",
+        output_text=provider,
+        latency_ms=latency_ms,
+        cost_usd=cost_usd,
+    )
+    return RunMetrics(**payload)
+
+
+def _judge_config() -> ProviderConfig:
+    return ProviderConfig(
+        path=Path("judge.yaml"),
+        schema_version=1,
+        provider="judge",
+        endpoint=None,
+        model="judge-model",
+        auth_env=None,
+        seed=0,
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=16,
+        timeout_s=0,
+        retries=RetryConfig(),
+        persist_output=True,
+        pricing=PricingConfig(),
+        rate_limit=RateLimitConfig(),
+        quality_gates=QualityGatesConfig(),
+        raw={},
+    )
+
+
+class _StubJudge:
+    def __init__(self, scores: list[float]) -> None:
+        self._scores = scores
+        self.requests: list[dict[str, object]] = []
+
+    def invoke(self, request: dict[str, object]) -> SimpleNamespace:
+        self.requests.append(request)
+        score = self._scores[len(self.requests) - 1]
+        return SimpleNamespace(text=str(score), raw={"quality_score": score})
+
+
+class _StubFactory:
+    def __init__(self, judge: _StubJudge) -> None:
+        self._judge = judge
+        self.create_calls: list[str] = []
+
+    def create(self, *, model: str) -> _StubJudge:
+        self.create_calls.append(model)
+        return self._judge
+
+
+def test_max_score_propagates_judge_scores() -> None:
+    judge_config = _judge_config()
+    judge = _StubJudge([0.4, 0.9])
+    factory = _StubFactory(judge)
+
+    def builder(config: ProviderConfig) -> _StubFactory:
+        assert config is judge_config
+        return factory
+
+    selector = AggregationSelector(judge_factory_builder=builder)
+    config = RunnerConfig(mode="consensus", aggregate="max")
+    batch = [
+        (0, SingleRunResult(metrics=_metrics("p1"), raw_output="Alpha")),
+        (1, SingleRunResult(metrics=_metrics("p2"), raw_output="Beta")),
+    ]
+
+    decision = selector.select("consensus", config, batch, default_judge_config=judge_config)
+
+    assert decision is not None
+    scores = {candidate.provider: candidate.score for candidate in decision.decision.candidates}
+    assert scores == {"p1": 0.4, "p2": 0.9}
+    assert decision.decision.metadata == {"scores": {"p1": 0.4, "p2": 0.9}}
+
+
+def test_tie_breaker_falls_back_to_latency_cost_stable_order() -> None:
+    selector = AggregationSelector(judge_factory_builder=lambda config: _StubFactory(_StubJudge([])))
+    config = RunnerConfig(mode="consensus", aggregate="majority")
+    batch = [
+        (
+            0,
+            SingleRunResult(metrics=_metrics("p1", latency_ms=20, cost_usd=1.0), raw_output="Same"),
+        ),
+        (
+            1,
+            SingleRunResult(metrics=_metrics("p2", latency_ms=10, cost_usd=5.0), raw_output="Same"),
+        ),
+    ]
+
+    decision = selector.select("consensus", config, batch, default_judge_config=None)
+
+    assert decision is not None
+    assert decision.decision.tie_breaker_used == "latency"
+    assert decision.decision.chosen.provider == "p2"
+
+
+def test_schema_cache_reads_schema_only_once(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{}", encoding="utf-8")
+    selector = AggregationSelector(judge_factory_builder=lambda config: _StubFactory(_StubJudge([])))
+    config = RunnerConfig(mode="consensus", aggregate="majority", schema=schema_path)
+    batch = [
+        (0, SingleRunResult(metrics=_metrics("p1"), raw_output="One")),
+        (1, SingleRunResult(metrics=_metrics("p2"), raw_output="Two")),
+    ]
+    calls: list[None] = []
+
+    def fake_json_load(fp: object) -> dict[str, object]:
+        calls.append(None)
+        return {}
+
+    monkeypatch.setattr(
+        "adapter.core.aggregation_selector_components.json.load",
+        fake_json_load,
+    )
+
+    decision1 = selector.select("consensus", config, batch, default_judge_config=None)
+    decision2 = selector.select("consensus", config, batch, default_judge_config=None)
+
+    assert decision1 is not None
+    assert decision2 is not None
+    assert calls == [None]


### PR DESCRIPTION
## Summary
- extract aggregation selector helpers into dedicated components for candidate building, judging, tie-breaking, and schema caching
- rewrite AggregationSelector to orchestrate the new components while preserving the external API
- add aggregation selector component tests covering judge scoring, tie-break fallbacks, and schema caching

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector_components.py
- pytest projects/04-llm-adapter/tests/test_aggregation_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68dc759d2400832192539bdc87b33e93