### PR TITLE
Fix run_id uuid usage

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -7,7 +7,7 @@ from concurrent.futures import CancelledError
 from dataclasses import dataclass
 from threading import Event, Lock
 from typing import Any, cast, Protocol, TYPE_CHECKING
-from uuid import uuid4
+import uuid
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
@@ -100,7 +100,7 @@ class _ParallelCoordinatorBase:
         provider_config, _ = self._providers[index]
         metrics = RunMetrics(
             ts=now_ts(),
-            run_id=f"run_{self._task.task_id}_{self._attempt_index}_{uuid4().hex}",
+            run_id=f"run_{self._task.task_id}_{self._attempt_index}_{uuid.uuid4().hex}",
             provider=provider_config.provider,
             model=provider_config.model,
             mode=self._config.mode,


### PR DESCRIPTION
## Summary
- import the uuid module in the parallel runner helper and use uuid.uuid4 when building run IDs

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc754f5c0883219036aa47aeda5b86