### PR TITLE
Refactor aggregation strategies into dedicated module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation.py
@@ -1,28 +1,22 @@
 """応答集約ストラテジ。"""
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
-import json
+import importlib
 from pathlib import Path
-import re
-from typing import Any, cast, Protocol, runtime_checkable, TYPE_CHECKING
+from typing import Any, Protocol, runtime_checkable, TYPE_CHECKING
 
 __path__ = [str(Path(__file__).with_name("aggregation"))]
 
-# 依存は実行時読み込み。型は実体を使う（mypy用に直import）
-try:  # pragma: no cover - 実環境では src.* が存在する
-    from src.llm_adapter.provider_spi import ProviderResponse  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
-    from .providers import ProviderResponse  # type: ignore
-
-# ===== 基本データ構造 =====
+try:  # pragma: no cover
+    from src.llm_adapter.provider_spi import ProviderResponse
+except ModuleNotFoundError:  # pragma: no cover
+    from .providers import ProviderResponse
 
 
 @dataclass(slots=True)
 class AggregationCandidate:
-    """集約対象となる各候補。"""
-
     index: int
     provider: str
     response: ProviderResponse
@@ -32,8 +26,6 @@ class AggregationCandidate:
 
 @dataclass(slots=True)
 class AggregationResult:
-    """集約の最終結果。"""
-
     chosen: AggregationCandidate
     candidates: list[AggregationCandidate]
     strategy: str
@@ -42,45 +34,11 @@ class AggregationResult:
     metadata: dict[str, Any] | None = None
 
 
-# ===== タイブレーカー抽象 =====
-
-
 @runtime_checkable
 class TieBreaker(Protocol):
     name: str
 
-    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
-        ...
-
-
-class FirstTieBreaker:
-    """決定的：先勝（index最小）"""
-
-    name = "first"
-
-    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
-        if not candidates:
-            raise ValueError("TieBreaker: candidates must be non-empty")
-        return min(candidates, key=lambda c: c.index)
-
-
-class MaxScoreTieBreaker:
-    """スコア最大。全員 None の場合は First にフォールバック。"""
-
-    name = "max_score"
-
-    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
-        if not candidates:
-            raise ValueError("TieBreaker: candidates must be non-empty")
-        if any(c.score is not None for c in candidates):
-            return max(
-                candidates,
-                key=lambda c: (c.score is not None, float(c.score or float("-inf")), -c.index),
-            )
-        return FirstTieBreaker().break_tie(candidates)
-
-
-# ===== 集約ストラテジ抽象 =====
+    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate: ...
 
 
 @runtime_checkable
@@ -89,233 +47,24 @@ class AggregationStrategy(Protocol):
 
     def aggregate(
         self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
-    ) -> AggregationResult:
-        ...
+    ) -> AggregationResult: ...
 
     @staticmethod
     def from_string(kind: str, **kwargs: Any) -> AggregationStrategy:
-        kind_norm = (kind or "").strip().lower()
-        if kind_norm in {"majority", "vote", "maj"}:
-            schema = kwargs.get("schema")
-            return cast(AggregationStrategy, MajorityVoteStrategy(schema=schema))
-        if kind_norm in {"max", "score", "top"}:
-            return cast(AggregationStrategy, MaxScoreStrategy())
-        if kind_norm in {"weighted_vote", "weighted"}:
-            schema = kwargs.get("schema")
-            provider_weights = kwargs.get("provider_weights")
-            return cast(
-                AggregationStrategy,
-                WeightedVoteStrategy(
-                    weights=cast(Mapping[str, float] | None, provider_weights),
-                    schema=cast(Mapping[str, Any] | None, schema),
-                ),
-            )
-        if kind_norm in {"judge", "llm-judge"}:
-            try:
-                model = kwargs["model"]
-            except KeyError as e:
-                raise ValueError("JudgeStrategy requires `model=`") from e
-            provider_factory = kwargs.get("provider_factory")
-            if provider_factory is None:
-                raise ValueError("JudgeStrategy requires `provider_factory=`")
-            prompt_template = kwargs.get("prompt_template")
-            return cast(
-                AggregationStrategy,
-                JudgeStrategy(
-                    model=str(model),
-                    provider_factory=provider_factory,
-                    prompt_template=prompt_template,
-                ),
-            )
-        raise ValueError(f"Unknown aggregation strategy: {kind!r}")
+        from .aggregation import strategies_builtin as _strategies_builtin
+
+        return _strategies_builtin.resolve_builtin_strategy(kind, **kwargs)
 
 
-# ===== 既定ストラテジ実装 =====
+_strategies_builtin = importlib.import_module("adapter.core.aggregation.strategies_builtin")
+
+FirstTieBreaker = _strategies_builtin.FirstTieBreaker
+MaxScoreTieBreaker = _strategies_builtin.MaxScoreTieBreaker
+MajorityVoteStrategy = _strategies_builtin.MajorityVoteStrategy
+MaxScoreStrategy = _strategies_builtin.MaxScoreStrategy
+WeightedVoteStrategy = _strategies_builtin.WeightedVoteStrategy
 
 
-_WHITESPACE_RE = re.compile(r"\s+")
-
-
-class MajorityVoteStrategy:
-    """テキスト同一性の多数決（正規化+JSON対応）。引き分けはタイブレーカー。"""
-
-    name = "majority"
-
-    def __init__(self, *, schema: Mapping[str, Any] | None = None) -> None:
-        self._schema = schema
-
-    def _normalize_text(self, value: str | None) -> str:
-        normalized = (value or "").strip()
-        if not normalized:
-            return ""
-        normalized = _WHITESPACE_RE.sub(" ", normalized)
-        return normalized.lower()
-
-    def _json_bucket_key(self, value: str) -> str | None:
-        if not self._schema:
-            return None
-        try:
-            payload = json.loads(value)
-        except json.JSONDecodeError:
-            return None
-        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-        return f"json:{canonical}"
-
-    def _bucket_key(self, candidate: AggregationCandidate) -> str:
-        raw = candidate.text if candidate.text is not None else candidate.response.text
-        json_key = self._json_bucket_key(raw)
-        if json_key is not None:
-            return json_key
-        return self._normalize_text(raw)
-
-    def aggregate(
-        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
-    ) -> AggregationResult:
-        if not candidates:
-            raise ValueError("majority: candidates must be non-empty")
-
-        buckets: dict[str, list[AggregationCandidate]] = {}
-        for candidate in candidates:
-            key = self._bucket_key(candidate)
-            buckets.setdefault(key, []).append(candidate)
-
-        max_bucket: list[AggregationCandidate] = []
-        max_count = -1
-        for bucket in buckets.values():
-            if len(bucket) > max_count:
-                max_bucket = bucket
-                max_count = len(bucket)
-
-        breaker = tiebreaker or FirstTieBreaker()
-        chosen = max_bucket[0] if len(max_bucket) == 1 else breaker.break_tie(max_bucket)
-        reason = f"majority({max_count})"
-        tie_used = None if len(max_bucket) == 1 else breaker.name
-
-        return AggregationResult(
-            chosen=chosen,
-            candidates=list(candidates),
-            strategy=self.name,
-            reason=reason,
-            tie_breaker_used=tie_used,
-            metadata={"bucket_size": max_count},
-        )
-
-
-class MaxScoreStrategy:
-    """score 最大値を採用。全件 score=None の場合はタイブレーカー。"""
-
-    name = "max_score"
-
-    def aggregate(
-        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
-    ) -> AggregationResult:
-        if not candidates:
-            raise ValueError("max_score: candidates must be non-empty")
-
-        if any(candidate.score is not None for candidate in candidates):
-            chosen = max(
-                candidates,
-                key=lambda c: (c.score is not None, float(c.score or float("-inf")), -c.index),
-            )
-            return AggregationResult(
-                chosen=chosen,
-                candidates=list(candidates),
-                strategy=self.name,
-                reason=f"score={chosen.score}",
-                tie_breaker_used=None,
-                metadata=None,
-            )
-
-        breaker = tiebreaker or FirstTieBreaker()
-        chosen = breaker.break_tie(candidates)
-        return AggregationResult(
-            chosen=chosen,
-            candidates=list(candidates),
-            strategy=self.name,
-            reason="all scores are None → tie-break",
-            tie_breaker_used=breaker.name,
-            metadata=None,
-        )
-
-
-class WeightedVoteStrategy:
-    """プロバイダ重み付き多数決。"""
-
-    name = "weighted_vote"
-
-    def __init__(
-        self,
-        *,
-        weights: Mapping[str, float] | None = None,
-        schema: Mapping[str, Any] | None = None,
-    ) -> None:
-        self._weights = dict(weights or {})
-        self._majority = MajorityVoteStrategy(schema=schema)
-
-    def _resolve_weight(self, provider: str) -> float:
-        weight = self._weights.get(provider)
-        if weight is None:
-            return 1.0
-        return float(weight)
-
-    def aggregate(
-        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
-    ) -> AggregationResult:
-        if not candidates:
-            raise ValueError("weighted_vote: candidates must be non-empty")
-
-        buckets: dict[str, dict[str, Any]] = {}
-        for candidate in candidates:
-            key = self._majority._bucket_key(candidate)  # noqa: SLF001 - 同一モジュール内の利用
-            entry = buckets.setdefault(
-                key,
-                {
-                    "candidates": [],
-                    "weight": 0.0,
-                    "text": (candidate.text if candidate.text is not None else candidate.response.text) or "",
-                },
-            )
-            entry["candidates"].append(candidate)
-            entry["weight"] += self._resolve_weight(candidate.provider)
-
-        max_bucket_key = next(iter(buckets))
-        max_bucket = buckets[max_bucket_key]
-        max_weight = float(max_bucket["weight"])
-        for key, bucket in buckets.items():
-            weight = float(bucket["weight"])
-            if weight > max_weight:
-                max_bucket_key = key
-                max_bucket = bucket
-                max_weight = weight
-
-        bucket_candidates: Sequence[AggregationCandidate] = max_bucket["candidates"]
-        breaker = tiebreaker or FirstTieBreaker()
-        chosen = (
-            bucket_candidates[0]
-            if len(bucket_candidates) == 1
-            else breaker.break_tie(bucket_candidates)
-        )
-
-        metadata = {
-            "bucket_weight": max_weight,
-            "bucket_size": len(bucket_candidates),
-            "weighted_votes": {
-                bucket["text"]: float(bucket["weight"])
-                for bucket in buckets.values()
-            },
-        }
-
-        return AggregationResult(
-            chosen=chosen,
-            candidates=list(candidates),
-            strategy=self.name,
-            reason=f"weighted({max_weight})",
-            tie_breaker_used=None if len(bucket_candidates) == 1 else breaker.name,
-            metadata=metadata,
-        )
-
-
-# 便利ヘルパー：API/CLI から簡単に呼べるように
 def AggregationResolver(kind: str, **kwargs: Any) -> AggregationStrategy:
     return AggregationStrategy.from_string(kind, **kwargs)
 
@@ -336,13 +85,15 @@ __all__ = [
 ]
 
 
-if TYPE_CHECKING:  # pragma: no cover - 型補完用
+if TYPE_CHECKING:  # pragma: no cover
     from .aggregation.judge import DEFAULT_JUDGE_TEMPLATE, JudgeStrategy
 
 
-def __getattr__(name: str) -> Any:  # pragma: no cover - 動的リレーエクスポート
+def __getattr__(name: str) -> Any:  # pragma: no cover
     if name in {"DEFAULT_JUDGE_TEMPLATE", "JudgeStrategy"}:
         from .aggregation.judge import DEFAULT_JUDGE_TEMPLATE, JudgeStrategy
 
         return DEFAULT_JUDGE_TEMPLATE if name == "DEFAULT_JUDGE_TEMPLATE" else JudgeStrategy
+    if hasattr(_strategies_builtin, name):
+        return getattr(_strategies_builtin, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
@@ -1,0 +1,260 @@
+"""組み込み集約ストラテジ群。"""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import json
+import re
+from typing import Any, cast
+
+from ..aggregation import (
+    AggregationCandidate,
+    AggregationResult,
+    AggregationStrategy,
+    TieBreaker,
+)
+
+__all__ = [
+    "FirstTieBreaker",
+    "MaxScoreTieBreaker",
+    "MajorityVoteStrategy",
+    "MaxScoreStrategy",
+    "WeightedVoteStrategy",
+    "resolve_builtin_strategy",
+]
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class FirstTieBreaker:
+    name = "first"
+
+    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
+        if not candidates:
+            raise ValueError("TieBreaker: candidates must be non-empty")
+        return min(candidates, key=lambda c: c.index)
+
+
+class MaxScoreTieBreaker:
+    name = "max_score"
+
+    def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
+        if not candidates:
+            raise ValueError("TieBreaker: candidates must be non-empty")
+        if any(c.score is not None for c in candidates):
+            return max(
+                candidates,
+                key=lambda c: (c.score is not None, float(c.score or float("-inf")), -c.index),
+            )
+        return FirstTieBreaker().break_tie(candidates)
+
+
+class MajorityVoteStrategy:
+    name = "majority"
+
+    def __init__(self, *, schema: Mapping[str, Any] | None = None) -> None:
+        self._schema = schema
+
+    def _normalize_text(self, value: str | None) -> str:
+        normalized = (value or "").strip()
+        if not normalized:
+            return ""
+        normalized = _WHITESPACE_RE.sub(" ", normalized)
+        return normalized.lower()
+
+    def _json_bucket_key(self, value: str) -> str | None:
+        if not self._schema:
+            return None
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return f"json:{canonical}"
+
+    def _bucket_key(self, candidate: AggregationCandidate) -> str:
+        raw = candidate.text if candidate.text is not None else candidate.response.text
+        json_key = self._json_bucket_key(raw)
+        if json_key is not None:
+            return json_key
+        return self._normalize_text(raw)
+
+    def aggregate(
+        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
+    ) -> AggregationResult:
+        if not candidates:
+            raise ValueError("majority: candidates must be non-empty")
+
+        buckets: dict[str, list[AggregationCandidate]] = {}
+        for candidate in candidates:
+            key = self._bucket_key(candidate)
+            buckets.setdefault(key, []).append(candidate)
+
+        max_bucket: list[AggregationCandidate] = []
+        max_count = -1
+        for bucket in buckets.values():
+            if len(bucket) > max_count:
+                max_bucket = bucket
+                max_count = len(bucket)
+
+        breaker = tiebreaker or FirstTieBreaker()
+        chosen = max_bucket[0] if len(max_bucket) == 1 else breaker.break_tie(max_bucket)
+        reason = f"majority({max_count})"
+        tie_used = None if len(max_bucket) == 1 else breaker.name
+
+        return AggregationResult(
+            chosen=chosen,
+            candidates=list(candidates),
+            strategy=self.name,
+            reason=reason,
+            tie_breaker_used=tie_used,
+            metadata={"bucket_size": max_count},
+        )
+
+
+class MaxScoreStrategy:
+    name = "max_score"
+
+    def aggregate(
+        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
+    ) -> AggregationResult:
+        if not candidates:
+            raise ValueError("max_score: candidates must be non-empty")
+
+        if any(candidate.score is not None for candidate in candidates):
+            chosen = max(
+                candidates,
+                key=lambda c: (c.score is not None, float(c.score or float("-inf")), -c.index),
+            )
+            return AggregationResult(
+                chosen=chosen,
+                candidates=list(candidates),
+                strategy=self.name,
+                reason=f"score={chosen.score}",
+                tie_breaker_used=None,
+                metadata=None,
+            )
+
+        breaker = tiebreaker or FirstTieBreaker()
+        chosen = breaker.break_tie(candidates)
+        return AggregationResult(
+            chosen=chosen,
+            candidates=list(candidates),
+            strategy=self.name,
+            reason="all scores are None → tie-break",
+            tie_breaker_used=breaker.name,
+            metadata=None,
+        )
+
+
+class WeightedVoteStrategy:
+    name = "weighted_vote"
+
+    def __init__(
+        self,
+        *,
+        weights: Mapping[str, float] | None = None,
+        schema: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._weights = dict(weights or {})
+        self._majority = MajorityVoteStrategy(schema=schema)
+
+    def _resolve_weight(self, provider: str) -> float:
+        weight = self._weights.get(provider)
+        if weight is None:
+            return 1.0
+        return float(weight)
+
+    def aggregate(
+        self, candidates: Sequence[AggregationCandidate], *, tiebreaker: TieBreaker | None = None
+    ) -> AggregationResult:
+        if not candidates:
+            raise ValueError("weighted_vote: candidates must be non-empty")
+
+        buckets: dict[str, dict[str, Any]] = {}
+        for candidate in candidates:
+            key = self._majority._bucket_key(candidate)  # noqa: SLF001
+            entry = buckets.setdefault(
+                key,
+                {
+                    "candidates": [],
+                    "weight": 0.0,
+                    "text": (candidate.text if candidate.text is not None else candidate.response.text) or "",
+                },
+            )
+            entry["candidates"].append(candidate)
+            entry["weight"] += self._resolve_weight(candidate.provider)
+
+        max_bucket_key = next(iter(buckets))
+        max_bucket = buckets[max_bucket_key]
+        max_weight = float(max_bucket["weight"])
+        for key, bucket in buckets.items():
+            weight = float(bucket["weight"])
+            if weight > max_weight:
+                max_bucket_key = key
+                max_bucket = bucket
+                max_weight = weight
+
+        bucket_candidates: Sequence[AggregationCandidate] = max_bucket["candidates"]
+        breaker = tiebreaker or FirstTieBreaker()
+        chosen = (
+            bucket_candidates[0]
+            if len(bucket_candidates) == 1
+            else breaker.break_tie(bucket_candidates)
+        )
+
+        metadata = {
+            "bucket_weight": max_weight,
+            "bucket_size": len(bucket_candidates),
+            "weighted_votes": {
+                bucket["text"]: float(bucket["weight"])
+                for bucket in buckets.values()
+            },
+        }
+
+        return AggregationResult(
+            chosen=chosen,
+            candidates=list(candidates),
+            strategy=self.name,
+            reason=f"weighted({max_weight})",
+            tie_breaker_used=None if len(bucket_candidates) == 1 else breaker.name,
+            metadata=metadata,
+        )
+
+
+StrategyFactory = Callable[..., AggregationStrategy]
+
+def _build_majority(**kwargs: Any) -> AggregationStrategy:
+    schema = cast(Mapping[str, Any] | None, kwargs.get("schema"))
+    return MajorityVoteStrategy(schema=schema)
+
+
+def _build_max_score(**_kwargs: Any) -> AggregationStrategy:
+    return MaxScoreStrategy()
+
+
+def _build_weighted(**kwargs: Any) -> AggregationStrategy:
+    weights = cast(Mapping[str, float] | None, kwargs.get("provider_weights"))
+    schema = cast(Mapping[str, Any] | None, kwargs.get("schema"))
+    return WeightedVoteStrategy(weights=weights, schema=schema)
+
+
+_STRATEGY_FACTORIES: dict[str, StrategyFactory] = {
+    "majority": _build_majority,
+    "max_score": _build_max_score,
+    "weighted_vote": _build_weighted,
+}
+
+_STRATEGY_ALIASES: dict[str, set[str]] = {
+    "majority": {"majority", "vote", "maj"},
+    "max_score": {"max", "score", "top"},
+    "weighted_vote": {"weighted_vote", "weighted"},
+}
+
+
+def resolve_builtin_strategy(kind: str, **kwargs: Any) -> AggregationStrategy:
+    kind_norm = (kind or "").strip().lower()
+    for key, aliases in _STRATEGY_ALIASES.items():
+        if kind_norm in aliases:
+            factory = _STRATEGY_FACTORIES[key]
+            return factory(**kwargs)
+    raise ValueError(f"Unknown aggregation strategy: {kind!r}")

--- a/projects/04-llm-adapter/tests/test_aggregation_strategies.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_strategies.py
@@ -1,0 +1,51 @@
+from adapter.core.aggregation import (
+    AggregationCandidate,
+    MajorityVoteStrategy,
+    MaxScoreStrategy,
+    MaxScoreTieBreaker,
+    WeightedVoteStrategy,
+)
+from adapter.core.provider_spi import ProviderResponse
+
+
+def _candidate(index: int, provider: str, text: str, *, score: float | None = None) -> AggregationCandidate:
+    response = ProviderResponse(text=text, latency_ms=0)
+    return AggregationCandidate(index=index, provider=provider, response=response, text=text, score=score)
+
+
+def test_majority_vote_normalizes_buckets() -> None:
+    majority = MajorityVoteStrategy()
+    cands = [
+        _candidate(0, "a", " Hello  WORLD "),
+        _candidate(1, "b", "hello world"),
+        _candidate(2, "c", "bye"),
+    ]
+    result = majority.aggregate(cands)
+    assert result.chosen == cands[0]
+    assert result.reason == "majority(2)"
+
+
+def test_max_score_falls_back_to_tiebreaker() -> None:
+    strategy = MaxScoreStrategy()
+    cands = [_candidate(0, "a", "x"), _candidate(1, "b", "y")]
+    breaker = MaxScoreTieBreaker()
+    result = strategy.aggregate(cands, tiebreaker=breaker)
+    assert result.chosen == cands[0]
+    assert result.tie_breaker_used == breaker.name
+
+
+def test_weighted_vote_respects_weights_and_tiebreaker() -> None:
+    strategy = WeightedVoteStrategy(weights={"a": 2.0, "b": 1.0})
+    cands = [
+        _candidate(0, "a", "foo", score=0.1),
+        _candidate(1, "b", "bar", score=0.9),
+        _candidate(2, "b", "foo", score=0.8),
+    ]
+    breaker = MaxScoreTieBreaker()
+    result = strategy.aggregate(cands, tiebreaker=breaker)
+    assert result.chosen == cands[2]
+    assert result.metadata == {
+        "bucket_weight": 3.0,
+        "bucket_size": 2,
+        "weighted_votes": {"foo": 3.0, "bar": 1.0},
+    }


### PR DESCRIPTION
## Summary
- add targeted regression tests that lock in majority, max-score fallback, and weighted-vote behaviours
- move the built-in tie-breakers and aggregation strategies into a new `strategies_builtin` module while keeping their utilities intact
- slim down `aggregation.py` to core data structures/protocols and re-export the moved strategies via the new registry

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation.py projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py projects/04-llm-adapter/tests/test_aggregation_strategies.py
- mypy --strict projects/04-llm-adapter/tests/test_aggregation_strategies.py
- pytest projects/04-llm-adapter/tests/test_aggregation_strategies.py


------
https://chatgpt.com/codex/tasks/task_e_68dc73fce890832195562fe9b9a98eef