### PR TITLE
Refactor parallel runner state helpers

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -1,0 +1,162 @@
+"""State helpers for parallel runner execution."""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from threading import Event, Lock
+from typing import Any, cast, TYPE_CHECKING
+from uuid import uuid4
+
+from .config import ProviderConfig
+from .datasets import GoldenTask
+from .metrics import BudgetSnapshot, EvalMetrics, now_ts, RunMetrics
+from .providers import BaseProvider
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .runner_api import RunnerConfig
+    from .runner_execution import SingleRunResult
+
+    _ResultSeq = Sequence[SingleRunResult | None]
+else:
+    _ResultSeq = Sequence[object | None]
+
+_single_run_result_cls: type[Any] | None = None
+
+
+def _get_single_run_result_cls() -> type[SingleRunResult]:
+    global _single_run_result_cls
+    if _single_run_result_cls is None:
+        from .runner_execution import SingleRunResult as _SingleRunResult
+
+        _single_run_result_cls = _SingleRunResult
+    return _single_run_result_cls
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderFailureSummary:
+    index: int
+    provider: str
+    status: str
+    failure_kind: str | None
+    error_message: str | None
+    backoff_next_provider: bool
+    retries: int
+    error_type: str | None
+
+
+if TYPE_CHECKING:
+    _BuildSummary = Callable[
+        [int, ProviderConfig, SingleRunResult],
+        ProviderFailureSummary,
+    ]
+else:
+    _BuildSummary = Callable[[int, ProviderConfig, object], ProviderFailureSummary]
+
+
+class ParallelAnyState:
+    def __init__(self, cancel_event: Event) -> None:
+        self._cancel_event = cancel_event
+        self._failure_lock = Lock()
+        self._winner_lock = Lock()
+        self._failure_indices: set[int] = set()
+        self._failure_summaries: list[ProviderFailureSummary] = []
+        self._winner_index: int | None = None
+        self._caught_error: Exception | None = None
+
+    def should_cancel(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def register_failure(self, index: int, summary: ProviderFailureSummary) -> None:
+        with self._failure_lock:
+            self._failure_indices.add(index)
+            self._failure_summaries.append(summary)
+
+    def register_success(self, index: int) -> bool:
+        with self._winner_lock:
+            if self._winner_index is None:
+                self._winner_index = index
+                self._cancel_event.set()
+                return False
+            return self._winner_index != index
+
+    def record_caught_error(self, exc: Exception) -> None:
+        self._caught_error = exc
+
+    def finalize(
+        self,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        results: _ResultSeq,
+        build_summary: _BuildSummary,
+        error_factory: Callable[[str], Exception],
+    ) -> None:
+        success_found = any(
+            result is not None and getattr(result.metrics, "status", None) == "ok"
+            for result in results
+        )
+        if success_found:
+            return
+        for index, result in enumerate(results):
+            if result is None or index in self._failure_indices:
+                continue
+            provider_config, _ = providers[index]
+            summary = build_summary(index, provider_config, cast("SingleRunResult", result))
+            self._failure_indices.add(index)
+            self._failure_summaries.append(summary)
+        error = error_factory("parallel-any failed")
+        error_any = cast(Any, error)
+        error_any.failures = self._failure_summaries
+        error_any.batch = [
+            (index, cast("SingleRunResult", result))
+            for index, result in enumerate(results)
+            if result is not None
+        ]
+        if self._caught_error is not None:
+            raise error from self._caught_error
+        raise error
+
+
+def build_cancelled_result(
+    provider_config: ProviderConfig,
+    task: GoldenTask,
+    attempt_index: int,
+    config: RunnerConfig,
+    cancel_message: str,
+) -> SingleRunResult:
+    metrics = RunMetrics(
+        ts=now_ts(),
+        run_id=f"run_{task.task_id}_{attempt_index}_{uuid4().hex}",
+        provider=provider_config.provider,
+        model=provider_config.model,
+        mode=config.mode,
+        prompt_id=task.task_id,
+        prompt_name=task.name,
+        seed=provider_config.seed,
+        temperature=provider_config.temperature,
+        top_p=provider_config.top_p,
+        max_tokens=provider_config.max_tokens,
+        input_tokens=0,
+        output_tokens=0,
+        latency_ms=0,
+        cost_usd=0.0,
+        status="skip",
+        failure_kind="cancelled",
+        error_message=cancel_message,
+        output_text=None,
+        output_hash=None,
+        eval=EvalMetrics(),
+        budget=BudgetSnapshot(0.0, False),
+        ci_meta={},
+    )
+    single_run_result_cls = _get_single_run_result_cls()
+    return single_run_result_cls(
+        metrics=metrics,
+        raw_output="",
+        stop_reason="cancelled",
+    )
+
+
+__all__ = [
+    "ProviderFailureSummary",
+    "ParallelAnyState",
+    "build_cancelled_result",
+]

--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from concurrent.futures import CancelledError
-from dataclasses import dataclass
-from threading import Event, Lock
-from typing import Any, cast, Protocol, TYPE_CHECKING
-import uuid
+from threading import Event
+from typing import Protocol, TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import BudgetSnapshot, EvalMetrics, now_ts, RunMetrics
+from .parallel_state import build_cancelled_result, ParallelAnyState, ProviderFailureSummary
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -25,6 +23,18 @@ if TYPE_CHECKING:  # pragma: no cover - 型補完用
 else:
     _RunSingle = Callable[[ProviderConfig, BaseProvider, GoldenTask, int, str], object]
 
+if TYPE_CHECKING:
+    _BuildCancelledResult = Callable[
+        [ProviderConfig, GoldenTask, int, RunnerConfig, str],
+        SingleRunResult,
+    ]
+else:
+    _BuildCancelledResult = Callable[
+        [ProviderConfig, GoldenTask, int, object, str],
+        object,
+    ]
+_StateFactory = Callable[[Event], ParallelAnyState]
+
 
 class _ParallelRunner(Protocol):
     def __call__(
@@ -34,30 +44,6 @@ class _ParallelRunner(Protocol):
         max_concurrency: int | None = None,
     ) -> object:
         ...
-
-
-_single_run_result_cls: type[Any] | None = None
-
-
-def _get_single_run_result_cls() -> type[SingleRunResult]:
-    global _single_run_result_cls
-    if _single_run_result_cls is None:
-        from .runner_execution import SingleRunResult as _SingleRunResult
-
-        _single_run_result_cls = _SingleRunResult
-    return _single_run_result_cls
-
-
-@dataclass(frozen=True, slots=True)
-class ProviderFailureSummary:
-    index: int
-    provider: str
-    status: str
-    failure_kind: str | None
-    error_message: str | None
-    backoff_next_provider: bool
-    retries: int
-    error_type: str | None
 
 
 class _ParallelCoordinatorBase:
@@ -70,12 +56,15 @@ class _ParallelCoordinatorBase:
         task: GoldenTask,
         attempt_index: int,
         config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
     ) -> None:
         self._executor = executor
         self._providers = providers
         self._task = task
         self._attempt_index = attempt_index
         self._config = config
+        self._build_cancelled_result = cancel_builder
         max_concurrency = getattr(config, "max_concurrency", None)
         self._max_workers = executor._normalize_concurrency(
             len(providers), max_concurrency
@@ -98,36 +87,12 @@ class _ParallelCoordinatorBase:
             result.stop_reason = result.stop_reason or "cancelled"
             return
         provider_config, _ = self._providers[index]
-        metrics = RunMetrics(
-            ts=now_ts(),
-            run_id=f"run_{self._task.task_id}_{self._attempt_index}_{uuid4().hex}",
-            provider=provider_config.provider,
-            model=provider_config.model,
-            mode=self._config.mode,
-            prompt_id=self._task.task_id,
-            prompt_name=self._task.name,
-            seed=provider_config.seed,
-            temperature=provider_config.temperature,
-            top_p=provider_config.top_p,
-            max_tokens=provider_config.max_tokens,
-            input_tokens=0,
-            output_tokens=0,
-            latency_ms=0,
-            cost_usd=0.0,
-            status="skip",
-            failure_kind="cancelled",
-            error_message=self.CANCEL_MESSAGE,
-            output_text=None,
-            output_hash=None,
-            eval=EvalMetrics(),
-            budget=BudgetSnapshot(0.0, False),
-            ci_meta={},
-        )
-        single_run_result_cls = _get_single_run_result_cls()
-        self._results[index] = single_run_result_cls(
-            metrics=metrics,
-            raw_output="",
-            stop_reason="cancelled",
+        self._results[index] = self._build_cancelled_result(
+            provider_config,
+            self._task,
+            self._attempt_index,
+            self._config,
+            self.CANCEL_MESSAGE,
         )
 
     def _update_stop_reason(self, result: SingleRunResult) -> None:
@@ -142,69 +107,26 @@ class _ParallelCoordinatorBase:
         ]
 
 
-class ParallelAnyState:
-    def __init__(self, cancel_event: Event) -> None:
-        self._cancel_event = cancel_event
-        self._failure_lock = Lock()
-        self._winner_lock = Lock()
-        self._failure_indices: set[int] = set()
-        self._failure_summaries: list[ProviderFailureSummary] = []
-        self._winner_index: int | None = None
-        self._caught_error: Exception | None = None
-
-    def should_cancel(self) -> bool:
-        return self._cancel_event.is_set()
-
-    def register_failure(self, index: int, summary: ProviderFailureSummary) -> None:
-        with self._failure_lock:
-            self._failure_indices.add(index)
-            self._failure_summaries.append(summary)
-
-    def register_success(self, index: int) -> bool:
-        with self._winner_lock:
-            if self._winner_index is None:
-                self._winner_index = index
-                self._cancel_event.set()
-                return False
-            return self._winner_index != index
-
-    def record_caught_error(self, exc: Exception) -> None:
-        self._caught_error = exc
-
-    def finalize(
-        self,
-        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        results: Sequence[SingleRunResult | None],
-        build_summary: Callable[[int, ProviderConfig, SingleRunResult], ProviderFailureSummary],
-        error_factory: Callable[[str], Exception],
-    ) -> None:
-        success_found = any(
-            result is not None and result.metrics.status == "ok"
-            for result in results
-        )
-        if success_found:
-            return
-        for index, result in enumerate(results):
-            if result is None or index in self._failure_indices:
-                continue
-            provider_config, _ = providers[index]
-            summary = build_summary(index, provider_config, result)
-            self._failure_indices.add(index)
-            self._failure_summaries.append(summary)
-        error = error_factory("parallel-any failed")
-        error_any = cast(Any, error)
-        error_any.failures = self._failure_summaries
-        error_any.batch = [
-            (index, result)
-            for index, result in enumerate(results)
-            if result is not None
-        ]
-        if self._caught_error is not None:
-            raise error from self._caught_error
-        raise error
-
-
 class _ParallelAllCoordinator(_ParallelCoordinatorBase):
+    def __init__(
+        self,
+        executor: ParallelAttemptExecutor,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
+    ) -> None:
+        super().__init__(
+            executor,
+            providers,
+            task,
+            attempt_index,
+            config,
+            cancel_builder=cancel_builder,
+        )
+
     def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
         workers = [
             self._build_worker(index, provider_config, provider)
@@ -247,9 +169,19 @@ class _ParallelAnyCoordinator(_ParallelCoordinatorBase):
         task: GoldenTask,
         attempt_index: int,
         config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
+        state_factory: _StateFactory,
     ) -> None:
-        super().__init__(executor, providers, task, attempt_index, config)
-        self._state = ParallelAnyState(self._cancel_event)
+        super().__init__(
+            executor,
+            providers,
+            task,
+            attempt_index,
+            config,
+            cancel_builder=cancel_builder,
+        )
+        self._state = state_factory(self._cancel_event)
 
     def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
         workers = [
@@ -342,12 +274,16 @@ class ParallelAttemptExecutor:
         run_parallel_all_sync: _ParallelRunner,
         run_parallel_any_sync: _ParallelRunner,
         parallel_execution_error: type[Exception],
+        build_cancelled_result: _BuildCancelledResult = build_cancelled_result,
+        parallel_any_state_factory: _StateFactory = ParallelAnyState,
     ) -> None:
         self._run_single = run_single
         self._normalize_concurrency = normalize_concurrency
         self._run_parallel_all_sync = run_parallel_all_sync
         self._run_parallel_any_sync = run_parallel_any_sync
         self._parallel_execution_error = parallel_execution_error
+        self._build_cancelled_result = build_cancelled_result
+        self._parallel_any_state_factory = parallel_any_state_factory
 
     def run(
         self,
@@ -360,11 +296,22 @@ class ParallelAttemptExecutor:
             return [], None
         if config.mode == "parallel-any":
             coordinator: _ParallelCoordinatorBase = _ParallelAnyCoordinator(
-                self, providers, task, attempt_index, config
+                self,
+                providers,
+                task,
+                attempt_index,
+                config,
+                cancel_builder=self._build_cancelled_result,
+                state_factory=self._parallel_any_state_factory,
             )
         else:
             coordinator = _ParallelAllCoordinator(
-                self, providers, task, attempt_index, config
+                self,
+                providers,
+                task,
+                attempt_index,
+                config,
+                cancel_builder=self._build_cancelled_result,
             )
         return coordinator.execute()
 

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from pathlib import Path
 import sys
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -42,6 +44,10 @@ from adapter.core.runner_execution import (  # noqa: E402
     ParallelExecutionError,
     RunnerExecution,
     SingleRunResult,
+)
+from adapter.core.runner_execution_parallel import (  # noqa: E402
+    ParallelAttemptExecutor,
+    ProviderFailureSummary,
 )
 from adapter.core.runners import CompareRunner  # noqa: E402
 
@@ -868,3 +874,123 @@ def test_run_metrics_records_error_type_and_attempts(
     assert flaky_attempts[2].status == "ok"
     assert flaky_attempts[2].error_type is None
     assert stable_attempts == [(1, None), (2, None)]
+
+
+def _run_parallel_all_sync(
+    workers: Sequence[Callable[[], int]], *, max_concurrency: int | None = None
+) -> list[int]:
+    return [worker() for worker in workers]
+
+
+def _run_parallel_any_sync(
+    workers: Sequence[Callable[[], int]], *, max_concurrency: int | None = None
+) -> int:
+    winner: int | None = None
+    last_error: BaseException | None = None
+    for worker in workers:
+        try:
+            idx = worker()
+        except BaseException as exc:  # noqa: BLE001
+            last_error = exc
+        else:
+            if winner is None:
+                winner = idx
+    if winner is not None:
+        return winner
+    raise RuntimeError("parallel-any failed") from last_error
+
+
+def _run_parallel_case(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> tuple[dict[int, SingleRunResult], list[ProviderFailureSummary], str]:
+    from adapter.core.runner_execution_parallel import ParallelAnyState
+
+    task = _make_task()
+    providers = [_make_provider_config(tmp_path, name=n, provider=n, model=n) for n in ("fail", "win", "tail")]
+    summaries: list[ProviderFailureSummary] = []
+    if mode == "parallel-any":
+        def _record(self: ParallelAnyState, index: int, summary: ProviderFailureSummary) -> None:
+            summaries.append(summary)
+            ParallelAnyState.register_failure(self, index, summary)
+
+        monkeypatch.setattr(
+            "adapter.core.runner_execution_parallel.ParallelAnyState",
+            type("RecordingState", (ParallelAnyState,), {"register_failure": _record}),
+        )
+    state_factory = sys.modules[
+        "adapter.core.runner_execution_parallel"
+    ].ParallelAnyState
+    behaviours: dict[str, dict[str, dict[str, object]]] = {
+        "parallel-any": {
+            "fail": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "boom",
+                "retries": 1,
+                "error": RuntimeError("boom"),
+                "backoff": True,
+            },
+            "win": {"stop": "completed"},
+            "tail": {},
+        },
+        "parallel-all": {
+            "fail": {},
+            "win": {"stop": "all-done"},
+            "tail": {},
+        },
+    }
+
+    def run_single(
+        config: ProviderConfig, _provider: object, _task: GoldenTask, _attempt: int, _mode: str
+    ) -> SingleRunResult:
+        metrics = _make_run_metrics(provider=config.provider, model=config.model, latency_ms=0, cost_usd=0.0)
+        data = behaviours[mode][config.provider]
+        status = data.get("status")
+        if isinstance(status, str):
+            metrics.status = status
+        failure_kind = data.get("failure_kind")
+        if isinstance(failure_kind, str):
+            metrics.failure_kind = failure_kind
+        message = data.get("error_message")
+        if isinstance(message, str):
+            metrics.error_message = message
+        retries = data.get("retries")
+        if isinstance(retries, int):
+            metrics.retries = retries
+        return SingleRunResult(
+            metrics=metrics,
+            raw_output=config.provider,
+            stop_reason=data.get("stop") if isinstance(data.get("stop"), str) else None,
+            error=data.get("error") if isinstance(data.get("error"), Exception) else None,
+            backoff_next_provider=bool(data.get("backoff", False)),
+        )
+
+    executor = ParallelAttemptExecutor(
+        run_single,
+        lambda total, limit: total,
+        run_parallel_all_sync=_run_parallel_all_sync,
+        run_parallel_any_sync=_run_parallel_any_sync,
+        parallel_execution_error=RuntimeError,
+        parallel_any_state_factory=state_factory,
+    )
+    batch, stop_reason = executor.run(
+        [(cfg, cast(BaseProvider, object())) for cfg in providers],
+        task,
+        attempt_index=0,
+        config=RunnerConfig(mode=mode),
+    )
+    return dict(batch), summaries, stop_reason
+
+
+@pytest.mark.parametrize(("mode", "expected_stop"), [("parallel-any", "completed"), ("parallel-all", "all-done")])
+def test_parallel_executor_parallel_modes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str, expected_stop: str
+) -> None:
+    results, summaries, stop_reason = _run_parallel_case(tmp_path, monkeypatch, mode)
+    assert stop_reason == expected_stop
+    if mode == "parallel-any":
+        assert results[2].metrics.failure_kind == "cancelled"
+        assert summaries[0].backoff_next_provider is True
+        assert summaries[0].error_type == "RuntimeError"
+    else:
+        assert results[1].stop_reason == expected_stop


### PR DESCRIPTION
## Summary
- move `ProviderFailureSummary` and `ParallelAnyState` into a dedicated `parallel_state` module and expose a reusable `build_cancelled_result`
- refactor `ParallelAttemptExecutor` to consume injected cancellation/state helpers while keeping the public interface unchanged
- add a concise parametrized regression test that exercises cancellation summaries for parallel-any and stop reason propagation for parallel-all

## Testing
- `ruff check projects/04-llm-adapter/adapter/core/parallel_state.py projects/04-llm-adapter/adapter/core/runner_execution_parallel.py projects/04-llm-adapter/tests/test_compare_runner_parallel.py`
- `mypy --strict --follow-imports=skip projects/04-llm-adapter/adapter/core/parallel_state.py projects/04-llm-adapter/adapter/core/runner_execution_parallel.py`
- `pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py -k parallel`


------
https://chatgpt.com/codex/tasks/task_e_68dc725fa888832191b55a9207cd10a3