### PR TITLE
Add regression test for aggregation candidates and clean imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, cast, TYPE_CHECKING
 
 from . import aggregation as aggregation_module
-from .aggregation import AggregationCandidate, AggregationResult, AggregationStrategy
+from .aggregation import AggregationResult, AggregationStrategy
 from .aggregation_selector_components import (
     CandidateBuilder,
     JudgeProviderFactory,


### PR DESCRIPTION
## Summary
- add coverage ensuring AggregationSelector returns AggregationCandidate instances when building candidates
- remove the unused AggregationCandidate import from aggregation_selector

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector.py
- ruff check projects/04-llm-adapter/adapter/core/aggregation_selector.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68dc7c8177d88321a83944d4a4d8409f