### PR TITLE
Refine sequential strategy tracking and add fallback tests

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -117,6 +117,138 @@ def _raise_no_attempts(context: SyncRunContext) -> None:
     raise error
 
 
+class _SequentialRunTracker:
+    def __init__(self, context: SyncRunContext) -> None:
+        self._context = context
+        self._runner = context.runner
+        self._config = context.runner._config
+        self._event_logger = context.event_logger
+        self._last_error: Exception | None = None
+        self._failure_details: list[dict[str, str]] = []
+        self.attempt_count = 0
+
+    def record_attempt(self, attempt: int) -> None:
+        self.attempt_count = attempt
+
+    def handle_success(
+        self,
+        provider: ProviderSPI,
+        attempt: int,
+        result: "ProviderInvocationResult",
+    ) -> ProviderResponse | None:
+        response = result.response
+        if response is None:
+            return None
+        tokens_in = result.tokens_in if result.tokens_in is not None else 0
+        tokens_out = result.tokens_out if result.tokens_out is not None else 0
+        cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+        log_run_metric(
+            self._event_logger,
+            request_fingerprint=self._context.request_fingerprint,
+            request=self._context.request,
+            provider=provider,
+            status="ok",
+            attempts=attempt,
+            latency_ms=elapsed_ms(self._context.run_started),
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+            error=None,
+            metadata=self._context.metadata,
+            shadow_used=self._context.shadow_used,
+        )
+        return response
+
+    def handle_failure(
+        self,
+        provider: ProviderSPI,
+        attempt: int,
+        error: Exception,
+    ) -> None:
+        self._last_error = error
+        summary = f"{type(error).__name__}: {error}"
+        self._failure_details.append(
+            {
+                "provider": provider.name(),
+                "attempt": str(attempt),
+                "summary": summary,
+            }
+        )
+        if isinstance(error, FatalError):
+            if isinstance(error, (AuthError, ConfigError)):
+                if self._event_logger is not None:
+                    self._event_logger.emit(
+                        "provider_fallback",
+                        {
+                            "request_fingerprint": self._context.request_fingerprint,
+                            "provider": provider.name(),
+                            "attempt": attempt,
+                            "error_type": type(error).__name__,
+                            "error_message": str(error),
+                        },
+                    )
+                return
+            raise error
+        if isinstance(error, RateLimitError):
+            sleep_duration = self._config.backoff.rate_limit_sleep_s
+            if sleep_duration > 0:
+                time.sleep(sleep_duration)
+            return
+        if isinstance(error, RetryableError):
+            if isinstance(error, TimeoutError):
+                if not self._config.backoff.timeout_next_provider:
+                    raise error
+                return
+            if self._config.backoff.retryable_next_provider:
+                return
+            raise error
+        if isinstance(error, (SkipError, ProviderSkip)):
+            return
+        raise error
+
+    def finalize_and_raise(self) -> None:
+        event_logger = self._event_logger
+        if event_logger is not None:
+            event_logger.emit(
+                "provider_chain_failed",
+                {
+                    "request_fingerprint": self._context.request_fingerprint,
+                    "provider_attempts": self.attempt_count,
+                    "providers": [provider.name() for provider in self._runner.providers],
+                    "last_error_type": type(self._last_error).__name__ if self._last_error else None,
+                    "last_error_message": str(self._last_error) if self._last_error else None,
+                    "last_error_family": error_family(self._last_error),
+                },
+            )
+        detail_text = "; ".join(
+            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
+            for item in self._failure_details
+        )
+        message = "all providers failed"
+        if detail_text:
+            message = f"{message}: {detail_text}"
+        failure_error = AllFailedError(message, failures=self._failure_details)
+        metric_error = self._last_error if self._last_error is not None else failure_error
+        log_run_metric(
+            event_logger,
+            request_fingerprint=self._context.request_fingerprint,
+            request=self._context.request,
+            provider=None,
+            status="error",
+            attempts=self.attempt_count,
+            latency_ms=elapsed_ms(self._context.run_started),
+            tokens_in=None,
+            tokens_out=None,
+            cost_usd=0.0,
+            error=metric_error,
+            metadata=self._context.metadata,
+            shadow_used=self._context.shadow_used,
+        )
+        if self._last_error is not None:
+            raise failure_error from self._last_error
+        raise failure_error
+
+
 class SequentialStrategy:
     def execute(
         self, context: SyncRunContext
@@ -126,133 +258,35 @@ class SequentialStrategy:
         runner = context.runner
         config = runner._config
         max_attempts = config.max_attempts
-        event_logger = context.event_logger
-        last_err: Exception | None = None
-        failure_details: list[dict[str, str]] = []
-        attempt_count = 0
+        tracker = _SequentialRunTracker(context)
 
         for loop_index, provider in enumerate(runner.providers, start=1):
             if max_attempts is not None and loop_index > max_attempts:
                 break
             attempt_index = loop_index
-            attempt_count = attempt_index
+            tracker.record_attempt(attempt_index)
             result = runner._invoke_provider_sync(
                 provider,
                 context.request,
                 attempt=attempt_index,
                 total_providers=len(runner.providers),
-                event_logger=event_logger,
+                event_logger=context.event_logger,
                 request_fingerprint=context.request_fingerprint,
                 metadata=context.metadata,
                 shadow=context.shadow,
                 metrics_path=context.metrics_path,
                 capture_shadow_metrics=False,
             )
-            if result.response is not None:
-                tokens_in = result.tokens_in if result.tokens_in is not None else 0
-                tokens_out = result.tokens_out if result.tokens_out is not None else 0
-                cost_usd = estimate_cost(provider, tokens_in, tokens_out)
-                log_run_metric(
-                    event_logger,
-                    request_fingerprint=context.request_fingerprint,
-                    request=context.request,
-                    provider=provider,
-                    status="ok",
-                    attempts=attempt_index,
-                    latency_ms=elapsed_ms(context.run_started),
-                    tokens_in=tokens_in,
-                    tokens_out=tokens_out,
-                    cost_usd=cost_usd,
-                    error=None,
-                    metadata=context.metadata,
-                    shadow_used=context.shadow_used,
-                )
-                return result.response
+            response = tracker.handle_success(provider, attempt_index, result)
+            if response is not None:
+                return response
 
             error = result.error
-            last_err = error
-            if error is not None:
-                summary = f"{type(error).__name__}: {error}"
-                failure_details.append(
-                    {
-                        "provider": provider.name(),
-                        "attempt": str(attempt_index),
-                        "summary": summary,
-                    }
-                )
             if error is None:
                 continue
-            if isinstance(error, FatalError):
-                if isinstance(error, (AuthError, ConfigError)):
-                    if event_logger is not None:
-                        event_logger.emit(
-                            "provider_fallback",
-                            {
-                                "request_fingerprint": context.request_fingerprint,
-                                "provider": provider.name(),
-                                "attempt": attempt_index,
-                                "error_type": type(error).__name__,
-                                "error_message": str(error),
-                            },
-                        )
-                    continue
-                raise error
-            if isinstance(error, RateLimitError):
-                sleep_duration = config.backoff.rate_limit_sleep_s
-                if sleep_duration > 0:
-                    time.sleep(sleep_duration)
-                continue
-            if isinstance(error, RetryableError):
-                if isinstance(error, TimeoutError):
-                    if not config.backoff.timeout_next_provider:
-                        raise error
-                    continue
-                if config.backoff.retryable_next_provider:
-                    continue
-                raise error
-            if isinstance(error, (SkipError, ProviderSkip)):
-                continue
-            raise error
+            tracker.handle_failure(provider, attempt_index, error)
 
-        if event_logger is not None:
-            event_logger.emit(
-                "provider_chain_failed",
-                {
-                    "request_fingerprint": context.request_fingerprint,
-                    "provider_attempts": attempt_count,
-                    "providers": [provider.name() for provider in runner.providers],
-                    "last_error_type": type(last_err).__name__ if last_err else None,
-                    "last_error_message": str(last_err) if last_err else None,
-                    "last_error_family": error_family(last_err),
-                },
-            )
-        detail_text = "; ".join(
-            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
-            for item in failure_details
-        )
-        message = "all providers failed"
-        if detail_text:
-            message = f"{message}: {detail_text}"
-        failure_error = AllFailedError(message, failures=failure_details)
-        metric_error = last_err if last_err is not None else failure_error
-        log_run_metric(
-            event_logger,
-            request_fingerprint=context.request_fingerprint,
-            request=context.request,
-            provider=None,
-            status="error",
-            attempts=attempt_count,
-            latency_ms=elapsed_ms(context.run_started),
-            tokens_in=None,
-            tokens_out=None,
-            cost_usd=0.0,
-            error=metric_error,
-            metadata=context.metadata,
-            shadow_used=context.shadow_used,
-        )
-        if last_err is not None:
-            raise failure_error from last_err
-        raise failure_error
+        tracker.finalize_and_raise()
 
 
 class ParallelAnyStrategy:

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import time
+from typing import Any
+
 import pytest
 
-from src.llm_adapter.errors import AllFailedError, TimeoutError
-from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.errors import AllFailedError, AuthError, TimeoutError
+from src.llm_adapter.observability import EventLogger
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner_config import RunnerConfig
 from src.llm_adapter.runner_sync import Runner
+from src.llm_adapter.runner_sync import ProviderInvocationResult
+from src.llm_adapter.runner_sync_modes import SequentialStrategy, SyncRunContext
 
 
 class _FailingProvider:
@@ -42,3 +48,142 @@ def test_sequential_raises_all_failed_error_with_cause() -> None:
     assert error.__cause__ is second_error
     assert providers[0].calls == 1
     assert providers[1].calls == 1
+
+
+class _RecordingLogger(EventLogger):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: dict[str, Any]) -> None:  # type: ignore[override]
+        self.events.append((event_type, dict(record)))
+
+
+def _make_context(runner: Runner, *, logger: EventLogger | None = None) -> SyncRunContext:
+    return SyncRunContext(
+        runner=runner,
+        request=ProviderRequest(model="gpt-test", prompt="hello"),
+        event_logger=logger,
+        metadata={},
+        run_started=time.time(),
+        request_fingerprint="fp",  # 任意の固定値
+        shadow=None,
+        shadow_used=False,
+        metrics_path=None,
+        run_parallel_all=lambda workers, **_: [],
+        run_parallel_any=lambda workers, **_: workers[0](),
+    )
+
+
+def test_sequential_strategy_emits_fallback_for_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    providers = [_FailingProvider("primary", TimeoutError("boom")), _FailingProvider("secondary", TimeoutError("boom"))]
+    runner = Runner(providers, config=RunnerConfig())
+    strategy = SequentialStrategy()
+    logger = _RecordingLogger()
+    context = _make_context(runner, logger=logger)
+
+    response = ProviderResponse("ok", latency_ms=10, token_usage=TokenUsage(prompt=0, completion=0))
+
+    def fake_invoke(
+        provider: Any,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        **_: Any,
+    ) -> ProviderInvocationResult:
+        if provider.name() == "primary":
+            return ProviderInvocationResult(
+                provider=provider,
+                attempt=attempt,
+                total_providers=total_providers,
+                response=None,
+                error=AuthError("bad key"),
+                latency_ms=5,
+                tokens_in=None,
+                tokens_out=None,
+                shadow_metrics=None,
+                shadow_metrics_extra=None,
+                provider_call_logged=True,
+            )
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=response,
+            error=None,
+            latency_ms=5,
+            tokens_in=0,
+            tokens_out=0,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        )
+
+    monkeypatch.setattr(runner, "_invoke_provider_sync", fake_invoke)
+
+    result = strategy.execute(context)
+
+    assert result is response
+    fallback_events = [event for event in logger.events if event[0] == "provider_fallback"]
+    assert len(fallback_events) == 1
+    event_type, payload = fallback_events[0]
+    assert event_type == "provider_fallback"
+    assert payload["provider"] == "primary"
+    assert payload["attempt"] == 1
+
+
+def test_sequential_strategy_all_failed_logs_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    providers = [_FailingProvider("primary", TimeoutError("slow")), _FailingProvider("secondary", TimeoutError("boom"))]
+    runner = Runner(providers, config=RunnerConfig())
+    strategy = SequentialStrategy()
+    logger = _RecordingLogger()
+    context = _make_context(runner, logger=logger)
+
+    errors = {
+        "primary": TimeoutError("slow"),
+        "secondary": TimeoutError("boom"),
+    }
+
+    def fake_invoke(
+        provider: Any,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        **_: Any,
+    ) -> ProviderInvocationResult:
+        error = errors[provider.name()]
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=None,
+            error=error,
+            latency_ms=5,
+            tokens_in=None,
+            tokens_out=None,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        )
+
+    monkeypatch.setattr(runner, "_invoke_provider_sync", fake_invoke)
+
+    log_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def fake_log_run_metric(*args: Any, **kwargs: Any) -> None:
+        log_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        "src.llm_adapter.runner_sync_modes.log_run_metric",
+        fake_log_run_metric,
+    )
+
+    with pytest.raises(AllFailedError) as exc_info:
+        strategy.execute(context)
+
+    message = str(exc_info.value)
+    assert "primary (attempt 1)" in message
+    assert "secondary (attempt 2)" in message
+    assert len(log_calls) == 1
+    assert log_calls[0][1]["status"] == "error"


### PR DESCRIPTION
## Summary
- add regression tests that exercise SequentialStrategy fallback handling and error metrics
- extract a private _SequentialRunTracker to centralize failure detail aggregation and provider fallback events
- refactor SequentialStrategy to delegate to the tracker while preserving retry and sleep behavior

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py -k sequential_strategy

------
https://chatgpt.com/codex/tasks/task_e_68dc7c7bc6308321bc980f6bfedddd36