### PR TITLE
Fix import order in aggregation selector tests

### DIFF
--- a/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from pytest import MonkeyPatch
 
 from adapter.core.aggregation_selector import AggregationSelector
+from adapter.core.aggregation_selector_components import SchemaCache
 from adapter.core.metrics import RunMetrics
 from adapter.core.models import (
     PricingConfig,
@@ -16,7 +17,6 @@ from adapter.core.models import (
 )
 from adapter.core.runner_api import RunnerConfig
 from adapter.core.runner_execution import SingleRunResult
-from adapter.core.aggregation_selector_components import SchemaCache
 
 _BASE_METRICS = dict(
     ts="2024-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
- reorder the SchemaCache import in the aggregation selector tests to satisfy Ruff's sorting rules

## Testing
- ruff check projects/04-llm-adapter/tests/test_aggregation_selector_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dc7e122f208321bf6328a60e91731d