### PR TITLE
Reorder sequential runner test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -9,8 +9,7 @@ from src.llm_adapter.errors import AllFailedError, AuthError, TimeoutError
 from src.llm_adapter.observability import EventLogger
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner_config import RunnerConfig
-from src.llm_adapter.runner_sync import Runner
-from src.llm_adapter.runner_sync import ProviderInvocationResult
+from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy, SyncRunContext
 
 


### PR DESCRIPTION
## Summary
- reorder the sequential runner test imports to follow standard library, third-party, and local grouping with alphabetical ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_sequential.py --select I001
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py

------
https://chatgpt.com/codex/tasks/task_e_68dc82a2f1348321b6b8ceb3f94457e3