### PR TITLE
Add regression coverage for sequential runner success handling

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 import time
-from typing import cast, Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn, Protocol, cast
 
 from .errors import (
     AllFailedError,
@@ -134,7 +134,7 @@ class _SequentialRunTracker:
         self,
         provider: ProviderSPI,
         attempt: int,
-        result: "ProviderInvocationResult",
+        result: ProviderInvocationResult,
     ) -> ProviderResponse | None:
         response = result.response
         if response is None:
@@ -206,7 +206,7 @@ class _SequentialRunTracker:
             return
         raise error
 
-    def finalize_and_raise(self) -> None:
+    def finalize_and_raise(self) -> NoReturn:
         event_logger = self._event_logger
         if event_logger is not None:
             event_logger.emit(

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -31,6 +31,20 @@ class _FailingProvider:
         raise self._error
 
 
+class _SuccessfulProvider:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:  # pragma: no cover - not used
+        raise AssertionError("_invoke_provider_sync is patched in tests")
+
+
 def test_sequential_raises_all_failed_error_with_cause() -> None:
     request = ProviderRequest(model="gpt-test", prompt="hello")
     first_error = TimeoutError("slow")
@@ -130,6 +144,52 @@ def test_sequential_strategy_emits_fallback_for_auth_error(monkeypatch: pytest.M
     assert event_type == "provider_fallback"
     assert payload["provider"] == "primary"
     assert payload["attempt"] == 1
+
+
+def test_sequential_strategy_handles_successful_provider_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    providers = [_SuccessfulProvider("primary")]
+    runner = Runner(providers, config=RunnerConfig())
+    strategy = SequentialStrategy()
+    logger = _RecordingLogger()
+    context = _make_context(runner, logger=logger)
+
+    response = ProviderResponse("ok", latency_ms=12, token_usage=TokenUsage(prompt=3, completion=4))
+
+    def fake_invoke(
+        provider: Any,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        **_: Any,
+    ) -> ProviderInvocationResult:
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=response,
+            error=None,
+            latency_ms=5,
+            tokens_in=3,
+            tokens_out=4,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        )
+
+    monkeypatch.setattr(runner, "_invoke_provider_sync", fake_invoke)
+
+    result = strategy.execute(context)
+
+    assert result is response
+    run_metric_events = [event for event in logger.events if event[0] == "run_metric"]
+    assert len(run_metric_events) == 1
+    _, payload = run_metric_events[0]
+    assert payload["status"] == "ok"
+    assert payload["tokens_in"] == 3
+    assert payload["tokens_out"] == 4
 
 
 def test_sequential_strategy_all_failed_logs_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a regression scenario for sequential runner success handling of ProviderInvocationResult
- update sequential runner typing to use the ProviderInvocationResult symbol directly and mark finalize-and-raise as non-returning

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py -k successful
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py --select UP037
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py


------
https://chatgpt.com/codex/tasks/task_e_68dc829ec8048321abfbd71f0de2fe35