### PR TITLE
Normalize stable order tie-breaker reporting

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
@@ -26,7 +26,7 @@ _WHITESPACE_RE = re.compile(r"\s+")
 
 
 class FirstTieBreaker:
-    name = "first"
+    name = "stable_order"
 
     def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
         if not candidates:
@@ -238,16 +238,24 @@ def _build_weighted(**kwargs: Any) -> AggregationStrategy:
     return WeightedVoteStrategy(weights=weights, schema=schema)
 
 
+def _build_judge(**kwargs: Any) -> AggregationStrategy:
+    from .judge import JudgeStrategy
+
+    return JudgeStrategy(**kwargs)
+
+
 _STRATEGY_FACTORIES: dict[str, StrategyFactory] = {
     "majority": _build_majority,
     "max_score": _build_max_score,
     "weighted_vote": _build_weighted,
+    "judge": _build_judge,
 }
 
 _STRATEGY_ALIASES: dict[str, set[str]] = {
     "majority": {"majority", "majority_vote", "vote", "maj"},
     "max_score": {"max", "max_score", "score", "top"},
     "weighted_vote": {"weighted_vote", "weighted"},
+    "judge": {"judge", "llm_judge"},
 }
 
 

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, cast, TYPE_CHECKING
 
 from . import aggregation as aggregation_module
-from .aggregation import AggregationResult, AggregationStrategy
+from .aggregation import AggregationResult, AggregationStrategy, TieBreaker
 from .aggregation_selector_components import (
     CandidateBuilder,
     JudgeProviderFactory,
@@ -127,6 +127,14 @@ class AggregationSelector:
             if votes is not None and not is_weighted:
                 votes = int(votes)
         return AggregationDecision(decision=decision, lookup=lookup, votes=votes)
+
+    @staticmethod
+    def _resolve_tie_breaker(
+        config: RunnerConfig,
+        lookup: Mapping[int, SingleRunResult],
+    ) -> TieBreaker | None:
+        factory = TieBreakerFactory()
+        return factory.create(config, lookup)
 
     def _resolve_aggregation_strategy(
         self,

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -119,7 +119,7 @@ class JudgeScorer:
 
 
 class _CompositeTieBreaker(TieBreaker):
-    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "first"}
+    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "stable_order"}
 
     def __init__(
         self,
@@ -161,7 +161,7 @@ class TieBreakerFactory:
         config: RunnerConfig,
         lookup: Mapping[int, SingleRunResult],
     ) -> TieBreaker | None:
-        tie_name = (config.tie_breaker or "").strip().lower()
+        tie_name = (config.tie_breaker or "").strip().lower().replace("-", "_")
         alias = {
             "latency": "latency",
             "min_latency": "latency",

--- a/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
@@ -156,7 +156,7 @@ def test_invalid_tie_breaker_uses_first_strategy() -> None:
     decision = selector.select("consensus", config, batch, default_judge_config=None)
 
     assert decision is not None
-    assert decision.decision.tie_breaker_used == "first"
+    assert decision.decision.tie_breaker_used == "stable_order"
     assert decision.decision.chosen.provider == "p1"
 
 

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -150,7 +150,7 @@ def test_majority_vote_normalizes_text_variants() -> None:
 
     assert result.chosen.index == 0
     assert result.metadata == {"bucket_size": 2}
-    assert result.tie_breaker_used == "first"
+    assert result.tie_breaker_used == "stable_order"
 
 
 def test_runner_execution_records_shadow_budget_and_schema(
@@ -354,7 +354,7 @@ def test_auto_tie_breaker_applies_latency_cost_and_order() -> None:
     assert order_breaker is not None
     chosen_order = order_breaker.break_tie(base_candidates)
     assert chosen_order.index == 0
-    assert order_breaker.name == "first"
+    assert order_breaker.name == "stable_order"
 
 
 def test_parallel_any_stops_after_first_success(


### PR DESCRIPTION
## Summary
- update regression tests to assert the stable_order tie-breaker metadata
- report stable_order consistently from FirstTieBreaker and composite tie breaker normalization
- register the judge aggregation strategy and expose tie-breaker resolution for controller helpers

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector_components.py projects/04-llm-adapter/tests/test_compare_runner_parallel.py


------
https://chatgpt.com/codex/tasks/task_e_68dc81f35c4c83218631c083475f42de