### PR TITLE
Normalize stable order tie breaker reporting

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
@@ -26,7 +26,7 @@ _WHITESPACE_RE = re.compile(r"\s+")
 
 
 class FirstTieBreaker:
-    name = "first"
+    name = "stable_order"
 
     def break_tie(self, candidates: Sequence[AggregationCandidate]) -> AggregationCandidate:
         if not candidates:

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -119,7 +119,11 @@ class JudgeScorer:
 
 
 class _CompositeTieBreaker(TieBreaker):
-    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "first"}
+    _DISPLAY_NAMES = {
+        "latency": "latency",
+        "cost": "cost",
+        "stable_order": "stable_order",
+    }
 
     def __init__(
         self,
@@ -161,7 +165,9 @@ class TieBreakerFactory:
         config: RunnerConfig,
         lookup: Mapping[int, SingleRunResult],
     ) -> TieBreaker | None:
-        tie_name = (config.tie_breaker or "").strip().lower()
+        raw_name = (config.tie_breaker or "").strip()
+        normalized = raw_name.lower().replace("-", "_").replace(" ", "_")
+        tie_name = "_".join(part for part in normalized.split("_") if part)
         alias = {
             "latency": "latency",
             "min_latency": "latency",
@@ -171,7 +177,7 @@ class TieBreakerFactory:
             "stable_order": "stable_order",
         }
         preferred = alias.get(tie_name) if tie_name else None
-        if preferred == "stable_order" and tie_name:
+        if preferred == "stable_order":
             return FirstTieBreaker()
         if tie_name and preferred is None:
             return None

--- a/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
@@ -156,7 +156,7 @@ def test_invalid_tie_breaker_uses_first_strategy() -> None:
     decision = selector.select("consensus", config, batch, default_judge_config=None)
 
     assert decision is not None
-    assert decision.decision.tie_breaker_used == "first"
+    assert decision.decision.tie_breaker_used == "stable_order"
     assert decision.decision.chosen.provider == "p1"
 
 

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -150,7 +150,7 @@ def test_majority_vote_normalizes_text_variants() -> None:
 
     assert result.chosen.index == 0
     assert result.metadata == {"bucket_size": 2}
-    assert result.tie_breaker_used == "first"
+    assert result.tie_breaker_used == "stable_order"
 
 
 def test_runner_execution_records_shadow_budget_and_schema(
@@ -354,7 +354,7 @@ def test_auto_tie_breaker_applies_latency_cost_and_order() -> None:
     assert order_breaker is not None
     chosen_order = order_breaker.break_tie(base_candidates)
     assert chosen_order.index == 0
-    assert order_breaker.name == "first"
+    assert order_breaker.name == "stable_order"
 
 
 def test_parallel_any_stops_after_first_success(


### PR DESCRIPTION
## Summary
- update regression tests to expect the stable order tie-breaker label when majority vote falls back to index ordering
- normalize tie-breaker naming so stable order is always reported, including composite fallbacks and judge aggregation paths

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector_components.py projects/04-llm-adapter/tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc825056f48321892e2745fa02e880