### PR TITLE
Refactor sync runner invocation helpers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -1,0 +1,310 @@
+"""Helpers for synchronous runner invocations."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import CancelledError
+from dataclasses import dataclass
+import time
+from typing import cast, Protocol
+
+from .errors import ProviderSkip
+from .observability import EventLogger
+from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from .runner_shared import (
+    estimate_cost,
+    log_provider_call,
+    log_provider_skipped,
+    log_run_metric,
+    MetricsPath,
+    RateLimiter,
+)
+from .shadow import run_with_shadow, ShadowMetrics
+from .utils import elapsed_ms
+
+
+class _RunWithShadowCallable(Protocol):
+    def __call__(
+        self,
+        primary: ProviderSPI,
+        shadow: ProviderSPI | None,
+        request: ProviderRequest,
+        metrics_path: MetricsPath = ...,
+        logger: EventLogger | None = ...,
+        capture_metrics: bool = ...,
+    ) -> ProviderResponse | tuple[ProviderResponse, ShadowMetrics | None]:
+        ...
+
+
+@dataclass(slots=True)
+class ProviderInvocationResult:
+    provider: ProviderSPI
+    attempt: int
+    total_providers: int
+    response: ProviderResponse | None
+    error: Exception | None
+    latency_ms: int | None
+    tokens_in: int | None
+    tokens_out: int | None
+    shadow_metrics: ShadowMetrics | None
+    shadow_metrics_extra: dict[str, object] | None
+    provider_call_logged: bool
+
+
+class ProviderInvoker:
+    """Invoke providers while capturing metrics."""
+
+    def __init__(
+        self,
+        *,
+        rate_limiter: RateLimiter | None,
+        run_with_shadow: _RunWithShadowCallable = run_with_shadow,
+        log_provider_call: Callable[..., None] = log_provider_call,
+        log_provider_skipped: Callable[..., None] = log_provider_skipped,
+        time_fn: Callable[[], float] = time.time,
+        elapsed_ms: Callable[[float], int] = elapsed_ms,
+    ) -> None:
+        self._rate_limiter = rate_limiter
+        self._run_with_shadow = run_with_shadow
+        self._log_provider_call = log_provider_call
+        self._log_provider_skipped = log_provider_skipped
+        self._time_fn = time_fn
+        self._elapsed_ms = elapsed_ms
+
+    def invoke(
+        self,
+        provider: ProviderSPI,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        event_logger: EventLogger | None,
+        request_fingerprint: str,
+        metadata: Mapping[str, object],
+        shadow: ProviderSPI | None,
+        metrics_path: MetricsPath,
+        capture_shadow_metrics: bool,
+    ) -> ProviderInvocationResult:
+        if self._rate_limiter is not None:
+            self._rate_limiter.acquire()
+        attempt_started = self._time_fn()
+        response: ProviderResponse | None = None
+        error: Exception | None = None
+        tokens_in: int | None = None
+        tokens_out: int | None = None
+        shadow_metrics: ShadowMetrics | None = None
+        try:
+            result = self._run_with_shadow(
+                provider,
+                shadow,
+                request,
+                metrics_path=metrics_path,
+                logger=event_logger,
+                capture_metrics=capture_shadow_metrics,
+            )
+            if capture_shadow_metrics:
+                response, shadow_metrics = cast(
+                    tuple[ProviderResponse, ShadowMetrics | None],
+                    result,
+                )
+            else:
+                response = cast(ProviderResponse, result)
+        except Exception as exc:  # noqa: BLE001
+            error = exc
+            latency_ms = self._elapsed_ms(attempt_started)
+            if isinstance(exc, ProviderSkip):
+                self._log_provider_skipped(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=provider,
+                    request=request,
+                    attempt=attempt,
+                    total_providers=total_providers,
+                    error=exc,
+                )
+        else:
+            latency_ms = response.latency_ms
+            usage = response.token_usage
+            tokens_in = usage.prompt
+            tokens_out = usage.completion
+        status = "ok" if error is None else "error"
+        self._log_provider_call(
+            event_logger,
+            request_fingerprint=request_fingerprint,
+            provider=provider,
+            request=request,
+            attempt=attempt,
+            total_providers=total_providers,
+            status=status,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            error=error,
+            metadata=metadata,
+            shadow_used=shadow is not None,
+        )
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=response,
+            error=error,
+            latency_ms=latency_ms,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            shadow_metrics=shadow_metrics,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        )
+
+
+class CancelledResultsBuilder:
+    """Construct cancelled results for providers that never executed."""
+
+    def __init__(
+        self,
+        *,
+        run_started: float,
+        elapsed_ms: Callable[[float], int] = elapsed_ms,
+    ) -> None:
+        self._run_started = run_started
+        self._elapsed_ms = elapsed_ms
+
+    def build(
+        self,
+        *,
+        provider: ProviderSPI,
+        attempt: int,
+        total_providers: int,
+    ) -> ProviderInvocationResult:
+        latency_ms = self._elapsed_ms(self._run_started)
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=None,
+            error=CancelledError(),
+            latency_ms=latency_ms,
+            tokens_in=None,
+            tokens_out=None,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=False,
+        )
+
+    def apply(
+        self,
+        results: list[ProviderInvocationResult | None],
+        *,
+        providers: Sequence[ProviderSPI],
+        cancelled_indices: Sequence[int],
+        total_providers: int,
+    ) -> None:
+        for index in cancelled_indices:
+            if index < 0 or index >= len(providers):
+                continue
+            if index >= len(results):
+                continue
+            if results[index] is not None:
+                continue
+            provider = providers[index]
+            results[index] = self.build(
+                provider=provider,
+                attempt=index + 1,
+                total_providers=total_providers,
+            )
+
+
+class ParallelResultLogger:
+    """Emit provider call and metric events for parallel execution results."""
+
+    def __init__(
+        self,
+        *,
+        log_provider_call: Callable[..., None] = log_provider_call,
+        log_run_metric: Callable[..., None] = log_run_metric,
+        estimate_cost: Callable[[object, int, int], float] = estimate_cost,
+        elapsed_ms: Callable[[float], int] = elapsed_ms,
+    ) -> None:
+        self._log_provider_call = log_provider_call
+        self._log_run_metric = log_run_metric
+        self._estimate_cost = estimate_cost
+        self._elapsed_ms = elapsed_ms
+
+    def log_results(
+        self,
+        results: Sequence[ProviderInvocationResult | None],
+        *,
+        event_logger: EventLogger | None,
+        request: ProviderRequest,
+        request_fingerprint: str,
+        metadata: Mapping[str, object],
+        run_started: float,
+        shadow_used: bool,
+        skip: tuple[ProviderInvocationResult, ...] | None = None,
+        attempts_override: Mapping[int, int] | None = None,
+    ) -> None:
+        skipped = skip or ()
+        attempts_map = dict(attempts_override or {})
+        for result in results:
+            if result is None:
+                continue
+            if result.shadow_metrics is not None:
+                result.shadow_metrics.emit(result.shadow_metrics_extra)
+            if any(result is skipped_result for skipped_result in skipped):
+                continue
+            status = "ok" if result.response is not None else "error"
+            if status == "ok":
+                tokens_in = result.tokens_in if result.tokens_in is not None else 0
+                tokens_out = result.tokens_out if result.tokens_out is not None else 0
+                cost_usd = self._estimate_cost(result.provider, tokens_in, tokens_out)
+                error_for_metric: Exception | None = None
+            else:
+                tokens_in = None
+                tokens_out = None
+                cost_usd = 0.0
+                error_for_metric = result.error
+            latency_ms = result.latency_ms
+            if latency_ms is None:
+                latency_ms = self._elapsed_ms(run_started)
+            if not result.provider_call_logged:
+                self._log_provider_call(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=result.provider,
+                    request=request,
+                    attempt=result.attempt,
+                    total_providers=result.total_providers,
+                    status=status,
+                    latency_ms=latency_ms,
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    error=error_for_metric,
+                    metadata=metadata,
+                    shadow_used=shadow_used,
+                )
+                result.provider_call_logged = True
+            attempts_value = attempts_map.get(result.attempt, result.attempt)
+            self._log_run_metric(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                request=request,
+                provider=result.provider,
+                status=status,
+                attempts=attempts_value,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=cost_usd,
+                error=error_for_metric,
+                metadata=metadata,
+                shadow_used=shadow_used,
+            )
+
+
+__all__ = [
+    "ProviderInvocationResult",
+    "ProviderInvoker",
+    "CancelledResultsBuilder",
+    "ParallelResultLogger",
+]
+

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -134,7 +134,7 @@ class _SequentialRunTracker:
         self,
         provider: ProviderSPI,
         attempt: int,
-        result: "ProviderInvocationResult",
+        result: ProviderInvocationResult,
     ) -> ProviderResponse | None:
         response = result.response
         if response is None:
@@ -175,7 +175,7 @@ class _SequentialRunTracker:
             }
         )
         if isinstance(error, FatalError):
-            if isinstance(error, (AuthError, ConfigError)):
+            if isinstance(error, AuthError | ConfigError):
                 if self._event_logger is not None:
                     self._event_logger.emit(
                         "provider_fallback",
@@ -202,7 +202,7 @@ class _SequentialRunTracker:
             if self._config.backoff.retryable_next_provider:
                 return
             raise error
-        if isinstance(error, (SkipError, ProviderSkip)):
+        if isinstance(error, SkipError | ProviderSkip):
             return
         raise error
 

--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -39,7 +39,7 @@ def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
     assert event["providers"] == ["primary"]
     assert event["provider_id"] == event["provider"]
     cost_usd = event["cost_usd"]
-    assert isinstance(cost_usd, (int, float))
+    assert isinstance(cost_usd, int | float)
     assert event["cost_estimate"] == pytest.approx(float(cost_usd))
 
     attempts = event["attempts"]

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -9,8 +9,7 @@ from src.llm_adapter.errors import AllFailedError, AuthError, TimeoutError
 from src.llm_adapter.observability import EventLogger
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner_config import RunnerConfig
-from src.llm_adapter.runner_sync import Runner
-from src.llm_adapter.runner_sync import ProviderInvocationResult
+from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy, SyncRunContext
 
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sync_invocation.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from concurrent.futures import CancelledError
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from src.llm_adapter.errors import ProviderSkip
+from src.llm_adapter.observability import EventLogger
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
+from src.llm_adapter.runner_shared import RateLimiter
+from src.llm_adapter.runner_sync_invocation import (
+    CancelledResultsBuilder,
+    ParallelResultLogger,
+    ProviderInvocationResult,
+    ProviderInvoker,
+)
+from src.llm_adapter.shadow import ShadowMetrics
+
+
+class _RecorderLogger(EventLogger):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: dict[str, Any]) -> None:  # type: ignore[override]
+        self.events.append((event_type, dict(record)))
+
+
+class _StubProvider:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:  # pragma: no cover - protocol compat
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+class _FakeMetrics(ShadowMetrics):
+    def __init__(self) -> None:
+        super().__init__(payload={}, logger=None)
+        self.emitted: list[Mapping[str, Any] | None] = []
+
+    def emit(self, extra: Mapping[str, Any] | None = None) -> None:
+        self.emitted.append(extra)
+
+
+def _make_response() -> ProviderResponse:
+    return ProviderResponse(
+        "ok",
+        latency_ms=42,
+        token_usage=TokenUsage(prompt=3, completion=5),
+    )
+
+
+def test_invoker_returns_shadow_metrics_after_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _StubProvider("primary")
+    shadow = _StubProvider("shadow")
+    request = ProviderRequest(model="gpt", prompt="hi")
+    response = _make_response()
+    metrics = _FakeMetrics()
+    rate_calls: list[str] = []
+    rate_limiter_ns = SimpleNamespace(acquire=lambda: None)
+    monkeypatch.setattr(rate_limiter_ns, "acquire", lambda: rate_calls.append("acquire"))
+    rate_limiter = cast(RateLimiter, rate_limiter_ns)
+
+    run_calls: list[tuple[Any, ...]] = []
+
+    def fake_run_with_shadow(*args: Any, **kwargs: Any) -> tuple[ProviderResponse, _FakeMetrics]:
+        run_calls.append(args)
+        assert rate_calls == ["acquire"]
+        assert kwargs["capture_metrics"] is True
+        return response, metrics
+
+    log_provider_call_args: list[dict[str, Any]] = []
+
+    def fake_log_provider_call(*_: Any, **kwargs: Any) -> None:
+        log_provider_call_args.append(dict(kwargs))
+
+    invoker = ProviderInvoker(
+        rate_limiter=rate_limiter,
+        run_with_shadow=cast(Any, fake_run_with_shadow),
+        log_provider_call=fake_log_provider_call,
+        log_provider_skipped=lambda *a, **k: None,
+        time_fn=lambda: 10.0,
+        elapsed_ms=lambda start: 7,
+    )
+
+    result = invoker.invoke(
+        provider,
+        request,
+        attempt=1,
+        total_providers=2,
+        event_logger=_RecorderLogger(),
+        request_fingerprint="fp",
+        metadata={},
+        shadow=shadow,
+        metrics_path="path.jsonl",
+        capture_shadow_metrics=True,
+    )
+
+    assert rate_calls == ["acquire"]
+    assert run_calls and run_calls[0][0] is provider
+    assert result.response is response
+    assert result.shadow_metrics is metrics
+    assert result.error is None
+    assert log_provider_call_args and log_provider_call_args[-1]["status"] == "ok"
+
+
+def test_invoker_logs_skip_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _StubProvider("primary")
+    request = ProviderRequest(model="gpt", prompt="hi")
+    skip_error = ProviderSkip("skip")
+
+    log_skipped: list[dict[str, Any]] = []
+    log_calls: list[dict[str, Any]] = []
+
+    def fake_log_skipped(*_: Any, **kwargs: Any) -> None:
+        log_skipped.append(dict(kwargs))
+
+    def fake_log_call(*_: Any, **kwargs: Any) -> None:
+        log_calls.append(dict(kwargs))
+
+    invoker = ProviderInvoker(
+        rate_limiter=None,
+        run_with_shadow=cast(Any, lambda *a, **k: (_ for _ in ()).throw(skip_error)),
+        log_provider_call=fake_log_call,
+        log_provider_skipped=fake_log_skipped,
+        time_fn=time.time,
+        elapsed_ms=lambda start: 11,
+    )
+
+    result = invoker.invoke(
+        provider,
+        request,
+        attempt=1,
+        total_providers=1,
+        event_logger=_RecorderLogger(),
+        request_fingerprint="fp",
+        metadata={},
+        shadow=None,
+        metrics_path=None,
+        capture_shadow_metrics=False,
+    )
+
+    assert result.error is skip_error
+    assert len(log_skipped) == 1
+    assert log_skipped[0]["error"] is skip_error
+    assert len(log_calls) == 1
+    assert log_calls[0]["status"] == "error"
+
+    non_skip_error = RuntimeError("boom")
+    invoker_non_skip = ProviderInvoker(
+        rate_limiter=None,
+        run_with_shadow=cast(Any, lambda *a, **k: (_ for _ in ()).throw(non_skip_error)),
+        log_provider_call=fake_log_call,
+        log_provider_skipped=fake_log_skipped,
+        time_fn=time.time,
+        elapsed_ms=lambda start: 17,
+    )
+
+    log_skipped.clear()
+    log_calls.clear()
+
+    result_non_skip = invoker_non_skip.invoke(
+        provider,
+        request,
+        attempt=1,
+        total_providers=1,
+        event_logger=_RecorderLogger(),
+        request_fingerprint="fp",
+        metadata={},
+        shadow=None,
+        metrics_path=None,
+        capture_shadow_metrics=False,
+    )
+
+    assert result_non_skip.error is non_skip_error
+    assert log_skipped == []
+    assert len(log_calls) == 1
+    assert log_calls[0]["error"] is non_skip_error
+
+
+def test_cancelled_results_skip_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    providers = [_StubProvider("primary"), _StubProvider("secondary")]
+    results: list[ProviderInvocationResult | None] = [None, None]
+    builder = CancelledResultsBuilder(run_started=1.0, elapsed_ms=lambda start: 99)
+
+    builder.apply(results, providers=providers, cancelled_indices=[0, 1], total_providers=2)
+
+    assert all(isinstance(entry, ProviderInvocationResult) for entry in results)
+    assert all(isinstance(entry.error, CancelledError) for entry in results if entry is not None)
+
+    logger = _RecorderLogger()
+    log_run_metric_calls: list[dict[str, Any]] = []
+
+    def fake_log_run_metric(*_: Any, **kwargs: Any) -> None:
+        log_run_metric_calls.append(dict(kwargs))
+
+    parallel_logger = ParallelResultLogger(
+        log_provider_call=lambda *a, **k: None,
+        log_run_metric=fake_log_run_metric,
+        estimate_cost=lambda provider, tokens_in, tokens_out: 0.0,
+        elapsed_ms=lambda start: 13,
+    )
+
+    parallel_logger.log_results(
+        results,
+        event_logger=logger,
+        request=ProviderRequest(model="gpt", prompt="hi"),
+        request_fingerprint="fp",
+        metadata={},
+        run_started=0.0,
+        shadow_used=False,
+        skip=tuple(result for result in results if result is not None),
+    )
+
+    assert log_run_metric_calls == []
+    assert all(isinstance(entry.error, CancelledError) for entry in results if entry is not None)


### PR DESCRIPTION
## Summary
- extract the synchronous invocation helpers into `runner_sync_invocation.py`, exposing `ProviderInvocationResult`, `ProviderInvoker`, `CancelledResultsBuilder`, and `ParallelResultLogger`
- update the synchronous `Runner` to delegate to the new helpers while keeping the public API unchanged and tidy up strategy annotations
- backfill targeted unit tests covering provider invocation, cancellation handling, and logging behaviour

## Testing
- ruff check projects/04-llm-adapter-shadow
- mypy --strict --follow-imports=skip projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
- mypy --strict --follow-imports=skip projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sync_invocation.py

------
https://chatgpt.com/codex/tasks/task_e_68dc82560898832196e3c5d9a44d8aed