### PR TITLE
Fix ruff lint issues

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 import time
-from typing import TYPE_CHECKING, NoReturn, Protocol, cast
+from typing import cast, NoReturn, Protocol, TYPE_CHECKING
 
 from .errors import (
     AllFailedError,
@@ -175,7 +175,7 @@ class _SequentialRunTracker:
             }
         )
         if isinstance(error, FatalError):
-            if isinstance(error, (AuthError, ConfigError)):
+            if isinstance(error, AuthError | ConfigError):
                 if self._event_logger is not None:
                     self._event_logger.emit(
                         "provider_fallback",
@@ -202,7 +202,7 @@ class _SequentialRunTracker:
             if self._config.backoff.retryable_next_provider:
                 return
             raise error
-        if isinstance(error, (SkipError, ProviderSkip)):
+        if isinstance(error, SkipError | ProviderSkip):
             return
         raise error
 

--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -39,7 +39,7 @@ def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
     assert event["providers"] == ["primary"]
     assert event["provider_id"] == event["provider"]
     cost_usd = event["cost_usd"]
-    assert isinstance(cost_usd, (int, float))
+    assert isinstance(cost_usd, int | float)
     assert event["cost_estimate"] == pytest.approx(float(cost_usd))
 
     attempts = event["attempts"]

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -86,7 +86,7 @@ class AggregationSelector:
             if decision.metadata:
                 key = "bucket_weight" if is_weighted else "bucket_size"
                 raw_votes = decision.metadata.get(key)
-                if isinstance(raw_votes, (int, float)):
+                if isinstance(raw_votes, int | float):
                     votes = float(raw_votes)
             metadata = dict(decision.metadata or {})
             if is_weighted:

--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -107,7 +107,7 @@ class JudgeScorer:
         raw = getattr(response, "raw", None)
         if isinstance(raw, Mapping):
             value = raw.get("quality_score")
-            if isinstance(value, (int, float)):
+            if isinstance(value, int | float):
                 return float(value)
         text = getattr(response, "text", None)
         if isinstance(text, str):

--- a/projects/04-llm-adapter/adapter/core/providers/openai.py
+++ b/projects/04-llm-adapter/adapter/core/providers/openai.py
@@ -160,7 +160,9 @@ class OpenAIProvider(BaseProvider):
                 break
             except Exception as exc:  # pragma: no cover - 実行時エラーを保持して次のモードへ
                 normalized = _normalize_openai_exception(exc)
-                if isinstance(normalized, (RateLimitError, AuthError, TimeoutError, ProviderSkip)):
+                if isinstance(
+                    normalized, RateLimitError | AuthError | TimeoutError | ProviderSkip
+                ):
                     raise normalized from exc
                 last_error = normalized
                 last_cause = exc

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -101,7 +101,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, (bool, int, float)):
+    if isinstance(value, bool | int | float):
         return str(value)
     return None
 
@@ -110,7 +110,7 @@ def to_float(value: object) -> float | None:
         return None
     if isinstance(value, bool):
         return float(value)
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return float(value)
     if isinstance(value, str):
         s = value.strip()

--- a/tools/weekly_summary/io.py
+++ b/tools/weekly_summary/io.py
@@ -41,7 +41,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, (int, float, bool)):
+    if isinstance(value, int | float | bool):
         return str(value)
     return None
 


### PR DESCRIPTION
## Summary
- sort typing imports in the synchronous runner strategy module
- replace tuple-based isinstance checks with union syntax across linted modules to satisfy Ruff

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68dc84ec42008321a30bfe051549af7a