### PR TITLE
Clarify runner shadow callable typing and add regression test

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -29,9 +29,10 @@ from .runner_sync_invocation import (
     ParallelResultLogger,
     ProviderInvocationResult,
     ProviderInvoker,
+    _DEFAULT_RUN_WITH_SHADOW,
 )
 from .runner_sync_modes import get_sync_strategy, SyncRunContext
-from .shadow import DEFAULT_METRICS_PATH, run_with_shadow
+from .shadow import DEFAULT_METRICS_PATH
 from .utils import content_hash, elapsed_ms
 
 
@@ -55,7 +56,7 @@ class Runner:
         self._elapsed_ms = elapsed_ms
         self._provider_invoker = ProviderInvoker(
             rate_limiter=self._rate_limiter,
-            run_with_shadow=run_with_shadow,
+            run_with_shadow=_DEFAULT_RUN_WITH_SHADOW,
             log_provider_call=log_provider_call,
             log_provider_skipped=log_provider_skipped,
             time_fn=self._time_fn,

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow.py
@@ -5,7 +5,7 @@ import asyncio
 import contextlib
 import threading
 import time
-from typing import Any
+from typing import Any, Literal, overload
 
 from .observability import EventLogger
 from .provider_spi import (
@@ -131,6 +131,32 @@ def _finalize_shadow_metrics(
         metrics_path=metrics_path,
         capture_metrics=capture_metrics,
     )
+
+
+@overload
+def run_with_shadow(
+    primary: ProviderSPI,
+    shadow: ProviderSPI | None,
+    req: ProviderRequest,
+    metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+    *,
+    logger: EventLogger | None = None,
+    capture_metrics: Literal[True],
+) -> tuple[ProviderResponse, ShadowMetrics | None]:
+    ...
+
+
+@overload
+def run_with_shadow(
+    primary: ProviderSPI,
+    shadow: ProviderSPI | None,
+    req: ProviderRequest,
+    metrics_path: MetricsPath = DEFAULT_METRICS_PATH,
+    *,
+    logger: EventLogger | None = None,
+    capture_metrics: Literal[False] = False,
+) -> ProviderResponse:
+    ...
 
 
 def run_with_shadow(


### PR DESCRIPTION
## Summary
- add regression coverage to ensure Runner works with a dummy shadow callable
- specialize the shadow callable protocol and default wiring to allow mypy to infer shadow metrics handling
- overload the public run_with_shadow helper for precise typing

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_modes.py
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src

------
https://chatgpt.com/codex/tasks/task_e_68dc875e6064832196c5a14e2d12a275