### PR TITLE
Add ParallelExecutionError to adapter error hierarchy

### DIFF
--- a/projects/04-llm-adapter/adapter/core/errors.py
+++ b/projects/04-llm-adapter/adapter/core/errors.py
@@ -1,6 +1,7 @@
 """Normalized exception hierarchy for adapter core."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import Enum
 
 
@@ -76,6 +77,21 @@ class AllFailedError(FatalError):
     """Raised when all providers fail to produce a result."""
 
 
+class ParallelExecutionError(FatalError):
+    """Raised when a parallel execution encounters unrecoverable failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failures: Sequence[Exception],
+        batch: object | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failures = failures
+        self.batch = batch
+
+
 __all__ = [
     "AdapterError",
     "RetryableError",
@@ -89,4 +105,5 @@ __all__ = [
     "SkipReason",
     "ConfigError",
     "AllFailedError",
+    "ParallelExecutionError",
 ]

--- a/projects/04-llm-adapter/tests/test_errors_parallel.py
+++ b/projects/04-llm-adapter/tests/test_errors_parallel.py
@@ -1,0 +1,17 @@
+"""Tests for parallel execution specific errors."""
+from adapter.core.errors import FatalError, ParallelExecutionError
+
+
+def test_parallel_execution_error_inherits_and_preserves_attributes() -> None:
+    failures = [RuntimeError("foo"), RuntimeError("bar")]
+    batch = {"inputs": [1, 2]}
+
+    error = ParallelExecutionError(
+        "parallel execution failed",
+        failures=failures,
+        batch=batch,
+    )
+
+    assert isinstance(error, FatalError)
+    assert error.failures is failures
+    assert error.batch is batch


### PR DESCRIPTION
## Summary
- add coverage for ParallelExecutionError behaviour in the adapter error tests
- implement ParallelExecutionError to capture failures and batch context

## Testing
- pytest projects/04-llm-adapter/tests/test_errors_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc896ead5c83219b0ea1df4517600b