### PR TITLE
Refactor runner metrics finalization

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -1,4 +1,5 @@
 """メトリクス関連ユーティリティ。"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -6,12 +7,13 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, UTC
 import hashlib
 from statistics import median
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal, Protocol, TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:  # pragma: no cover - 循環参照の回避
     from .config import ProviderConfig
+    from .execution.shadow_runner import ShadowRunnerResult
     from .providers import ProviderResponse
 
 
@@ -114,6 +116,84 @@ class RunMetrics:
         payload: dict[str, Any] = asdict(self)
         payload["eval"] = {k: v for k, v in payload["eval"].items() if v is not None}
         return payload
+
+
+class ProviderCallResult(Protocol):
+    error: Exception | None
+    retries: int
+
+
+def finalize_run_metrics(
+    run_metrics: RunMetrics,
+    *,
+    attempt_index: int,
+    provider_result: ProviderCallResult,
+    response: ProviderResponse,
+    status: str,
+    failure_kind: str | None,
+    error_message: str | None,
+    schema_error: str | None,
+    shadow_result: ShadowRunnerResult | None,
+    fallback_shadow_id: str | None,
+    active_provider_ids: Sequence[str],
+    current_attempt_index: int,
+) -> None:
+    provider_ids: list[str] = []
+    for provider_id in active_provider_ids:
+        if provider_id not in provider_ids:
+            provider_ids.append(provider_id)
+    run_metrics.providers = provider_ids
+    usage = response.token_usage
+    prompt_tokens = int(getattr(usage, "prompt", response.input_tokens))
+    completion_tokens = int(getattr(usage, "completion", response.output_tokens))
+    total_tokens = int(getattr(usage, "total", prompt_tokens + completion_tokens))
+    run_metrics.token_usage = {
+        "prompt": prompt_tokens,
+        "completion": completion_tokens,
+        "total": total_tokens,
+    }
+    run_metrics.attempts = attempt_index + 1
+    run_metrics.error_type = (
+        type(provider_result.error).__name__ if provider_result.error else None
+    )
+    run_metrics.retries = max(current_attempt_index, 0) + max(
+        provider_result.retries - 1, 0
+    )
+    if schema_error:
+        run_metrics.status = status
+        run_metrics.failure_kind = failure_kind
+        run_metrics.error_message = error_message
+    run_metrics.outcome = _resolve_outcome(run_metrics.status)
+    apply_shadow_metrics(run_metrics, shadow_result, fallback_shadow_id)
+
+
+def apply_shadow_metrics(
+    run_metrics: RunMetrics,
+    shadow_result: ShadowRunnerResult | None,
+    fallback_shadow_id: str | None,
+) -> None:
+    if shadow_result is None:
+        if fallback_shadow_id is not None:
+            run_metrics.shadow_provider_id = fallback_shadow_id
+        return
+    provider_id = shadow_result.provider_id or fallback_shadow_id
+    if provider_id is not None:
+        run_metrics.shadow_provider_id = provider_id
+    if shadow_result.latency_ms is not None:
+        run_metrics.shadow_latency_ms = int(shadow_result.latency_ms)
+    if shadow_result.status is not None:
+        run_metrics.shadow_status = shadow_result.status
+        run_metrics.shadow_outcome = _resolve_outcome(shadow_result.status)
+    if shadow_result.error_message is not None:
+        run_metrics.shadow_error_message = shadow_result.error_message
+
+
+def _resolve_outcome(status: str) -> Literal["success", "skip", "error"]:
+    if status == "ok":
+        return "success"
+    if status == "skip":
+        return "skip"
+    return "error"
 
 
 def now_ts() -> str:


### PR DESCRIPTION
## Summary
- add a regression test covering sequential attempt metrics and shadow metadata updates
- extract run-metric finalization helpers into adapter.core.metrics and reuse them from RunnerExecution
- update CompareRunner utilities to pass through the additional RunnerExecution dependencies and expose budget/metrics helpers

## Testing
- ruff check .
- mypy --config-file pyproject.toml adapter
- pytest projects/04-llm-adapter/tests


------
https://chatgpt.com/codex/tasks/task_e_68dc874c2c388321b800f5b6286bf5b2