### PR TITLE
Support Enum mode values in RunMetricsBuilder

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import replace
+from enum import Enum
 import logging
 import os
 import re
@@ -68,7 +69,7 @@ class RunMetricsBuilder:
         provider_config: ProviderConfig,
         task: GoldenTask,
         attempt_index: int,
-        mode: str,
+        mode: str | Enum,
         response: ProviderResponse,
         status: str,
         failure_kind: str | None,
@@ -83,12 +84,13 @@ class RunMetricsBuilder:
         status, failure_kind = self._merge_eval_failure(status, failure_kind, eval_failure_kind)
         output_text_record = output_text if provider_config.persist_output else None
         output_hash = self._compute_output_hash(output_text)
+        resolved_mode = mode.value if isinstance(mode, Enum) else mode
         run_metrics = RunMetrics(
             ts=now_ts(),
             run_id=f"run_{task.task_id}_{attempt_index}_{uuid.uuid4().hex}",
             provider=provider_config.provider,
             model=provider_config.model,
-            mode=mode,
+            mode=str(resolved_mode),
             prompt_id=task.task_id,
             prompt_name=task.name,
             seed=provider_config.seed,

--- a/projects/04-llm-adapter/tests/test_run_metrics_builder_mode.py
+++ b/projects/04-llm-adapter/tests/test_run_metrics_builder_mode.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from adapter.core.compare_runner_support import RunMetricsBuilder
+from adapter.core.config import ProviderConfig
+from adapter.core.datasets import GoldenTask
+from adapter.core.metrics import BudgetSnapshot
+from adapter.core.models import (
+    PricingConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from adapter.core.providers import ProviderResponse
+
+
+class DummyMode(str, Enum):
+    SEQUENTIAL = "sequential"
+
+
+@pytest.fixture(name="provider_config")
+def _provider_config(tmp_path: Path) -> ProviderConfig:
+    config_path = tmp_path / "provider.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    return ProviderConfig(
+        path=config_path,
+        schema_version=1,
+        provider="mock",
+        endpoint=None,
+        model="test-model",
+        auth_env=None,
+        seed=42,
+        temperature=0.1,
+        top_p=0.9,
+        max_tokens=16,
+        timeout_s=30,
+        retries=RetryConfig(max=0, backoff_s=0.0),
+        persist_output=True,
+        pricing=PricingConfig(),
+        rate_limit=RateLimitConfig(),
+        quality_gates=QualityGatesConfig(),
+        raw={},
+    )
+
+
+@pytest.fixture(name="golden_task")
+def _golden_task() -> GoldenTask:
+    return GoldenTask(
+        task_id="task-1",
+        name="sample",
+        input={},
+        prompt_template="",
+        expected={"type": "literal", "value": "answer"},
+    )
+
+
+@pytest.fixture(name="provider_response")
+def _provider_response() -> ProviderResponse:
+    return ProviderResponse(
+        output_text="answer",
+        latency_ms=123,
+        input_tokens=5,
+        output_tokens=7,
+    )
+
+
+def test_run_metrics_builder_coerces_enum_mode_to_string(
+    provider_config: ProviderConfig,
+    golden_task: GoldenTask,
+    provider_response: ProviderResponse,
+) -> None:
+    builder = RunMetricsBuilder()
+    snapshot = BudgetSnapshot(run_budget_usd=1.0, hit_stop=False)
+
+    run_metrics, _ = builder.build(
+        provider_config=provider_config,
+        task=golden_task,
+        attempt_index=1,
+        mode=DummyMode.SEQUENTIAL,
+        response=provider_response,
+        status="ok",
+        failure_kind=None,
+        error_message=None,
+        latency_ms=provider_response.latency_ms,
+        budget_snapshot=snapshot,
+        cost_usd=0.5,
+    )
+
+    assert isinstance(run_metrics.mode, str)
+    assert run_metrics.mode == DummyMode.SEQUENTIAL.value


### PR DESCRIPTION
## Summary
- add coverage ensuring `RunMetricsBuilder` serializes enum mode values to strings
- convert enum `mode` arguments to their string value when building `RunMetrics`

## Testing
- pytest projects/04-llm-adapter/tests/test_run_metrics_builder_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68dc89a40f708321a16d74cb55502826