### PR TITLE
Ensure cancelled run metrics serialize enum modes

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from threading import Event, Lock
-from typing import Any, cast, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast
 from uuid import uuid4
 
 from .config import ProviderConfig
@@ -122,12 +123,18 @@ def build_cancelled_result(
     config: RunnerConfig,
     cancel_message: str,
 ) -> SingleRunResult:
+    mode = config.mode
+    if isinstance(mode, Enum):
+        mode_value = mode.value if isinstance(mode.value, str) else str(mode.value)
+    else:
+        mode_value = cast(str, mode)
+
     metrics = RunMetrics(
         ts=now_ts(),
         run_id=f"run_{task.task_id}_{attempt_index}_{uuid4().hex}",
         provider=provider_config.provider,
         model=provider_config.model,
-        mode=config.mode,
+        mode=mode_value,
         prompt_id=task.task_id,
         prompt_name=task.name,
         seed=provider_config.seed,

--- a/projects/04-llm-adapter/tests/test_parallel_state_mode.py
+++ b/projects/04-llm-adapter/tests/test_parallel_state_mode.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+from adapter.core.datasets import GoldenTask
+from adapter.core.models import (
+    PricingConfig,
+    ProviderConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
+from adapter.core.parallel_state import build_cancelled_result
+from adapter.core.runner_api import RunnerConfig
+
+
+class RunnerMode(str, Enum):
+    PARALLEL_ANY = "parallel_any"
+
+
+def _make_provider_config(tmp_path: Path) -> ProviderConfig:
+    return ProviderConfig(
+        path=tmp_path / "provider.yaml",
+        schema_version=1,
+        provider="provider",
+        endpoint=None,
+        model="model",
+        auth_env=None,
+        seed=0,
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=1,
+        timeout_s=0,
+        retries=RetryConfig(),
+        persist_output=True,
+        pricing=PricingConfig(),
+        rate_limit=RateLimitConfig(),
+        quality_gates=QualityGatesConfig(),
+        raw={},
+    )
+
+
+def _make_task() -> GoldenTask:
+    return GoldenTask(
+        task_id="task",
+        name="Task",
+        input={},
+        prompt_template="template",
+        expected={},
+    )
+
+
+def test_build_cancelled_result_uses_mode_value(tmp_path: Path) -> None:
+    provider_config = _make_provider_config(tmp_path)
+    task = _make_task()
+    config = RunnerConfig(mode=RunnerMode.PARALLEL_ANY)  # type: ignore[arg-type]
+
+    result = build_cancelled_result(
+        provider_config,
+        task,
+        attempt_index=0,
+        config=config,
+        cancel_message="cancel",
+    )
+
+    metrics = result.metrics
+    assert metrics.mode == RunnerMode.PARALLEL_ANY.value
+    assert type(metrics.mode) is str


### PR DESCRIPTION
## Summary
- add a regression test covering build_cancelled_result with RunnerMode inputs
- normalize the mode stored in RunMetrics to the enum value when building cancelled results

## Testing
- pytest projects/04-llm-adapter/tests/test_parallel_state_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68dc89a24c1c8321a6deacfe69fafd12