### PR TITLE
Refactor parallel coordinators

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/__init__.py
@@ -1,0 +1,21 @@
+"""Parallel execution helpers."""
+
+from .coordinators import (
+    _is_parallel_any_mode,
+    _normalize_mode_value,
+    _ParallelAllCoordinator,
+    _ParallelAnyCoordinator,
+    _ParallelCoordinatorBase,
+    build_cancelled_result,
+    ProviderFailureSummary,
+)
+
+__all__ = [
+    "ProviderFailureSummary",
+    "_ParallelAllCoordinator",
+    "_ParallelAnyCoordinator",
+    "_ParallelCoordinatorBase",
+    "_is_parallel_any_mode",
+    "_normalize_mode_value",
+    "build_cancelled_result",
+]

--- a/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
@@ -1,0 +1,280 @@
+"""Parallel coordinator implementations for :mod:`adapter.core.runner_execution_parallel`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from concurrent.futures import CancelledError
+from enum import Enum
+from threading import Event
+from typing import cast, TYPE_CHECKING
+
+from ..config import ProviderConfig
+from ..datasets import GoldenTask
+from ..parallel_state import (
+    build_cancelled_result,
+    ParallelAnyState,
+    ProviderFailureSummary,
+)
+from ..providers import BaseProvider
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from ..runner_api import RunnerConfig
+    from ..runner_execution import SingleRunResult
+    from ..runner_execution_parallel import ParallelAttemptExecutor
+
+if TYPE_CHECKING:
+    _BuildCancelledResult = Callable[
+        [ProviderConfig, GoldenTask, int, RunnerConfig, str],
+        SingleRunResult,
+    ]
+else:
+    _BuildCancelledResult = Callable[
+        [ProviderConfig, GoldenTask, int, object, str],
+        object,
+    ]
+
+if TYPE_CHECKING:
+    _StateFactory = Callable[[Event], ParallelAnyState]
+else:
+    _StateFactory = Callable[[Event], ParallelAnyState]
+
+
+def _normalize_mode_value(mode: object) -> str:
+    if isinstance(mode, Enum):
+        return cast(str, mode.value)
+    return cast(str, mode)
+
+
+def _is_parallel_any_mode(mode: object) -> bool:
+    return _normalize_mode_value(mode) == "parallel-any"
+
+
+class _ParallelCoordinatorBase:
+    CANCEL_MESSAGE = "parallel-any cancelled after winner"
+
+    def __init__(
+        self,
+        executor: ParallelAttemptExecutor,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
+    ) -> None:
+        self._executor = executor
+        self._providers = providers
+        self._task = task
+        self._attempt_index = attempt_index
+        self._config = config
+        self._build_cancelled_result = cancel_builder
+        max_concurrency = getattr(config, "max_concurrency", None)
+        self._max_workers = executor._normalize_concurrency(
+            len(providers), max_concurrency
+        )
+        self._results: list[SingleRunResult | None] = [None] * len(providers)
+        self._stop_reason: str | None = None
+        self._cancel_event = Event()
+        self._mode_value = _normalize_mode_value(config.mode)
+
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        raise NotImplementedError
+
+    def _mark_cancelled(self, index: int) -> None:
+        result = self._results[index]
+        if result is not None:
+            metrics = result.metrics
+            metrics.status = "skip"
+            if not metrics.failure_kind:
+                metrics.failure_kind = "cancelled"
+            metrics.error_message = self.CANCEL_MESSAGE
+            result.stop_reason = result.stop_reason or "cancelled"
+            return
+        provider_config, _ = self._providers[index]
+        self._results[index] = self._build_cancelled_result(
+            provider_config,
+            self._task,
+            self._attempt_index,
+            self._config,
+            self.CANCEL_MESSAGE,
+        )
+
+    def _update_stop_reason(self, result: SingleRunResult) -> None:
+        if result.stop_reason and not self._stop_reason:
+            self._stop_reason = result.stop_reason
+
+    def _build_batch(self) -> list[tuple[int, SingleRunResult]]:
+        return [
+            (index, result)
+            for index, result in enumerate(self._results)
+            if result is not None
+        ]
+
+
+class _ParallelAllCoordinator(_ParallelCoordinatorBase):
+    def __init__(
+        self,
+        executor: ParallelAttemptExecutor,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
+    ) -> None:
+        super().__init__(
+            executor,
+            providers,
+            task,
+            attempt_index,
+            config,
+            cancel_builder=cancel_builder,
+        )
+
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        workers = [
+            self._build_worker(index, provider_config, provider)
+            for index, (provider_config, provider) in enumerate(self._providers)
+        ]
+        self._executor._run_parallel_all_sync(
+            workers, max_concurrency=self._max_workers
+        )
+        return self._build_batch(), self._stop_reason
+
+    def _build_worker(
+        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
+    ) -> Callable[[], int]:
+        def worker() -> int:
+            if self._cancel_event.is_set():
+                raise CancelledError()
+            try:
+                result = self._executor._run_single(
+                    provider_config,
+                    provider,
+                    self._task,
+                    self._attempt_index,
+                    self._mode_value,
+                )
+                self._results[index] = result
+                self._update_stop_reason(result)
+                return index
+            except CancelledError:
+                self._mark_cancelled(index)
+                raise
+
+        return worker
+
+
+class _ParallelAnyCoordinator(_ParallelCoordinatorBase):
+    def __init__(
+        self,
+        executor: ParallelAttemptExecutor,
+        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
+        task: GoldenTask,
+        attempt_index: int,
+        config: RunnerConfig,
+        *,
+        cancel_builder: _BuildCancelledResult,
+        state_factory: _StateFactory,
+    ) -> None:
+        super().__init__(
+            executor,
+            providers,
+            task,
+            attempt_index,
+            config,
+            cancel_builder=cancel_builder,
+        )
+        self._state = state_factory(self._cancel_event)
+
+    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
+        workers = [
+            self._build_worker(index, provider_config, provider)
+            for index, (provider_config, provider) in enumerate(self._providers)
+        ]
+        parallel_error = self._executor._parallel_execution_error
+        try:
+            self._executor._run_parallel_any_sync(
+                workers, max_concurrency=self._max_workers
+            )
+        except Exception as exc:  # noqa: BLE001
+            if isinstance(exc, parallel_error) or isinstance(exc, RuntimeError):
+                self._state.record_caught_error(exc)
+            else:
+                raise
+        self._finalize()
+        return self._build_batch(), self._stop_reason
+
+    def _build_worker(
+        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
+    ) -> Callable[[], int]:
+        def worker() -> int:
+            if self._state.should_cancel():
+                raise CancelledError()
+            try:
+                result = self._executor._run_single(
+                    provider_config,
+                    provider,
+                    self._task,
+                    self._attempt_index,
+                    self._mode_value,
+                )
+                should_cancel = self._state.should_cancel()
+                if result.metrics.status != "ok":
+                    self._results[index] = result
+                    summary = self._build_failure_summary(
+                        index, provider_config, result
+                    )
+                    self._state.register_failure(index, summary)
+                    raise RuntimeError("parallel-any failure")
+                should_cancel = self._state.register_success(index) or should_cancel
+                self._results[index] = result
+                if should_cancel:
+                    raise CancelledError()
+                self._update_stop_reason(result)
+                return index
+            except CancelledError:
+                self._mark_cancelled(index)
+                raise
+
+        return worker
+
+    def _finalize(self) -> None:
+        for index, result in enumerate(self._results):
+            if result is None:
+                self._mark_cancelled(index)
+        self._state.finalize(
+            self._providers,
+            self._results,
+            self._build_failure_summary,
+            self._executor._parallel_execution_error,
+        )
+
+    def _build_failure_summary(
+        self,
+        index: int,
+        provider_config: ProviderConfig,
+        result: SingleRunResult,
+    ) -> ProviderFailureSummary:
+        metrics = result.metrics
+        return ProviderFailureSummary(
+            index=index,
+            provider=provider_config.provider,
+            status=metrics.status,
+            failure_kind=metrics.failure_kind,
+            error_message=metrics.error_message,
+            backoff_next_provider=result.backoff_next_provider,
+            retries=metrics.retries,
+            error_type=type(result.error).__name__ if result.error else None,
+        )
+
+
+__all__ = [
+    "_ParallelCoordinatorBase",
+    "_ParallelAllCoordinator",
+    "_ParallelAnyCoordinator",
+    "_normalize_mode_value",
+    "_is_parallel_any_mode",
+    "ProviderFailureSummary",
+    "build_cancelled_result",
+]

--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from concurrent.futures import CancelledError
-from enum import Enum
 from threading import Event
-from typing import Protocol, TYPE_CHECKING, cast
+from typing import Protocol, TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .parallel_state import build_cancelled_result, ParallelAnyState, ProviderFailureSummary
+from .parallel.coordinators import (
+    _is_parallel_any_mode,
+    _ParallelAllCoordinator,
+    _ParallelAnyCoordinator,
+    _ParallelCoordinatorBase,
+    build_cancelled_result,
+    ProviderFailureSummary,
+)
+from .parallel_state import ParallelAnyState
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
@@ -37,242 +43,13 @@ else:
 _StateFactory = Callable[[Event], ParallelAnyState]
 
 
-def _normalize_mode_value(mode: object) -> str:
-    if isinstance(mode, Enum):
-        return cast(str, mode.value)
-    return cast(str, mode)
-
-
-def _is_parallel_any_mode(mode: object) -> bool:
-    return _normalize_mode_value(mode) == "parallel-any"
-
-
 class _ParallelRunner(Protocol):
     def __call__(
         self,
         workers: Sequence[Callable[[], int]],
         *,
         max_concurrency: int | None = None,
-    ) -> object:
-        ...
-
-
-class _ParallelCoordinatorBase:
-    CANCEL_MESSAGE = "parallel-any cancelled after winner"
-
-    def __init__(
-        self,
-        executor: ParallelAttemptExecutor,
-        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        task: GoldenTask,
-        attempt_index: int,
-        config: RunnerConfig,
-        *,
-        cancel_builder: _BuildCancelledResult,
-    ) -> None:
-        self._executor = executor
-        self._providers = providers
-        self._task = task
-        self._attempt_index = attempt_index
-        self._config = config
-        self._build_cancelled_result = cancel_builder
-        max_concurrency = getattr(config, "max_concurrency", None)
-        self._max_workers = executor._normalize_concurrency(
-            len(providers), max_concurrency
-        )
-        self._results: list[SingleRunResult | None] = [None] * len(providers)
-        self._stop_reason: str | None = None
-        self._cancel_event = Event()
-        self._mode_value = _normalize_mode_value(config.mode)
-
-    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
-        raise NotImplementedError
-
-    def _mark_cancelled(self, index: int) -> None:
-        result = self._results[index]
-        if result is not None:
-            metrics = result.metrics
-            metrics.status = "skip"
-            if not metrics.failure_kind:
-                metrics.failure_kind = "cancelled"
-            metrics.error_message = self.CANCEL_MESSAGE
-            result.stop_reason = result.stop_reason or "cancelled"
-            return
-        provider_config, _ = self._providers[index]
-        self._results[index] = self._build_cancelled_result(
-            provider_config,
-            self._task,
-            self._attempt_index,
-            self._config,
-            self.CANCEL_MESSAGE,
-        )
-
-    def _update_stop_reason(self, result: SingleRunResult) -> None:
-        if result.stop_reason and not self._stop_reason:
-            self._stop_reason = result.stop_reason
-
-    def _build_batch(self) -> list[tuple[int, SingleRunResult]]:
-        return [
-            (index, result)
-            for index, result in enumerate(self._results)
-            if result is not None
-        ]
-
-
-class _ParallelAllCoordinator(_ParallelCoordinatorBase):
-    def __init__(
-        self,
-        executor: ParallelAttemptExecutor,
-        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        task: GoldenTask,
-        attempt_index: int,
-        config: RunnerConfig,
-        *,
-        cancel_builder: _BuildCancelledResult,
-    ) -> None:
-        super().__init__(
-            executor,
-            providers,
-            task,
-            attempt_index,
-            config,
-            cancel_builder=cancel_builder,
-        )
-
-    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
-        workers = [
-            self._build_worker(index, provider_config, provider)
-            for index, (provider_config, provider) in enumerate(self._providers)
-        ]
-        self._executor._run_parallel_all_sync(
-            workers, max_concurrency=self._max_workers
-        )
-        return self._build_batch(), self._stop_reason
-
-    def _build_worker(
-        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
-    ) -> Callable[[], int]:
-        def worker() -> int:
-            if self._cancel_event.is_set():
-                raise CancelledError()
-            try:
-                result = self._executor._run_single(
-                    provider_config,
-                    provider,
-                    self._task,
-                    self._attempt_index,
-                    self._mode_value,
-                )
-                self._results[index] = result
-                self._update_stop_reason(result)
-                return index
-            except CancelledError:
-                self._mark_cancelled(index)
-                raise
-
-        return worker
-
-
-class _ParallelAnyCoordinator(_ParallelCoordinatorBase):
-    def __init__(
-        self,
-        executor: ParallelAttemptExecutor,
-        providers: Sequence[tuple[ProviderConfig, BaseProvider]],
-        task: GoldenTask,
-        attempt_index: int,
-        config: RunnerConfig,
-        *,
-        cancel_builder: _BuildCancelledResult,
-        state_factory: _StateFactory,
-    ) -> None:
-        super().__init__(
-            executor,
-            providers,
-            task,
-            attempt_index,
-            config,
-            cancel_builder=cancel_builder,
-        )
-        self._state = state_factory(self._cancel_event)
-
-    def execute(self) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
-        workers = [
-            self._build_worker(index, provider_config, provider)
-            for index, (provider_config, provider) in enumerate(self._providers)
-        ]
-        parallel_error = self._executor._parallel_execution_error
-        try:
-            self._executor._run_parallel_any_sync(
-                workers, max_concurrency=self._max_workers
-            )
-        except Exception as exc:  # noqa: BLE001
-            if isinstance(exc, parallel_error) or isinstance(exc, RuntimeError):
-                self._state.record_caught_error(exc)
-            else:
-                raise
-        self._finalize()
-        return self._build_batch(), self._stop_reason
-
-    def _build_worker(
-        self, index: int, provider_config: ProviderConfig, provider: BaseProvider
-    ) -> Callable[[], int]:
-        def worker() -> int:
-            if self._state.should_cancel():
-                raise CancelledError()
-            try:
-                result = self._executor._run_single(
-                    provider_config,
-                    provider,
-                    self._task,
-                    self._attempt_index,
-                    self._mode_value,
-                )
-                should_cancel = self._state.should_cancel()
-                if result.metrics.status != "ok":
-                    self._results[index] = result
-                    summary = self._build_failure_summary(index, provider_config, result)
-                    self._state.register_failure(index, summary)
-                    raise RuntimeError("parallel-any failure")
-                should_cancel = self._state.register_success(index) or should_cancel
-                self._results[index] = result
-                if should_cancel:
-                    raise CancelledError()
-                self._update_stop_reason(result)
-                return index
-            except CancelledError:
-                self._mark_cancelled(index)
-                raise
-
-        return worker
-
-    def _finalize(self) -> None:
-        for index, result in enumerate(self._results):
-            if result is None:
-                self._mark_cancelled(index)
-        self._state.finalize(
-            self._providers,
-            self._results,
-            self._build_failure_summary,
-            self._executor._parallel_execution_error,
-        )
-
-    def _build_failure_summary(
-        self,
-        index: int,
-        provider_config: ProviderConfig,
-        result: SingleRunResult,
-    ) -> ProviderFailureSummary:
-        metrics = result.metrics
-        return ProviderFailureSummary(
-            index=index,
-            provider=provider_config.provider,
-            status=metrics.status,
-            failure_kind=metrics.failure_kind,
-            error_message=metrics.error_message,
-            backoff_next_provider=result.backoff_next_provider,
-            retries=metrics.retries,
-            error_type=type(result.error).__name__ if result.error else None,
-        )
+    ) -> object: ...
 
 
 class ParallelAttemptExecutor:
@@ -332,4 +109,3 @@ __all__ = [
     "ParallelAttemptExecutor",
     "ProviderFailureSummary",
 ]
-

--- a/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_parallel.py
@@ -17,6 +17,7 @@ if str(PROJECT_ROOT) not in sys.path:
 if SHADOW_ROOT.exists() and str(SHADOW_ROOT) not in sys.path:
     sys.path.insert(0, str(SHADOW_ROOT))
 
+from adapter.core import errors  # noqa: E402
 from adapter.core.aggregation import (  # noqa: E402
     AggregationCandidate,
     MajorityVoteStrategy,
@@ -41,7 +42,6 @@ from adapter.core.providers import (  # noqa: E402
     ProviderResponse,
 )
 from adapter.core.runner_api import RunnerConfig  # noqa: E402
-from adapter.core import errors  # noqa: E402
 from adapter.core.runner_execution import RunnerExecution, SingleRunResult  # noqa: E402
 from adapter.core.runner_execution_parallel import (  # noqa: E402
     ParallelAttemptExecutor,
@@ -308,11 +308,15 @@ def test_auto_tie_breaker_applies_latency_cost_and_order() -> None:
 
     latency_lookup = {
         0: SingleRunResult(
-            metrics=_make_run_metrics(provider="p1", model="m1", latency_ms=5, cost_usd=0.5),
+            metrics=_make_run_metrics(
+                provider="p1", model="m1", latency_ms=5, cost_usd=0.5
+            ),
             raw_output="same",
         ),
         1: SingleRunResult(
-            metrics=_make_run_metrics(provider="p2", model="m2", latency_ms=10, cost_usd=0.1),
+            metrics=_make_run_metrics(
+                provider="p2", model="m2", latency_ms=10, cost_usd=0.1
+            ),
             raw_output="same",
         ),
     }
@@ -324,11 +328,15 @@ def test_auto_tie_breaker_applies_latency_cost_and_order() -> None:
 
     cost_lookup = {
         0: SingleRunResult(
-            metrics=_make_run_metrics(provider="p1", model="m1", latency_ms=5, cost_usd=0.4),
+            metrics=_make_run_metrics(
+                provider="p1", model="m1", latency_ms=5, cost_usd=0.4
+            ),
             raw_output="same",
         ),
         1: SingleRunResult(
-            metrics=_make_run_metrics(provider="p2", model="m2", latency_ms=5, cost_usd=0.1),
+            metrics=_make_run_metrics(
+                provider="p2", model="m2", latency_ms=5, cost_usd=0.1
+            ),
             raw_output="same",
         ),
     }
@@ -340,11 +348,15 @@ def test_auto_tie_breaker_applies_latency_cost_and_order() -> None:
 
     order_lookup = {
         0: SingleRunResult(
-            metrics=_make_run_metrics(provider="p1", model="m1", latency_ms=5, cost_usd=0.1),
+            metrics=_make_run_metrics(
+                provider="p1", model="m1", latency_ms=5, cost_usd=0.1
+            ),
             raw_output="same",
         ),
         1: SingleRunResult(
-            metrics=_make_run_metrics(provider="p2", model="m2", latency_ms=5, cost_usd=0.1),
+            metrics=_make_run_metrics(
+                provider="p2", model="m2", latency_ms=5, cost_usd=0.1
+            ),
             raw_output="same",
         ),
     }
@@ -373,8 +385,12 @@ def test_parallel_any_stops_after_first_success(
 
     monkeypatch.setitem(ProviderFactory._registry, "recording", RecordingProvider)
 
-    fast_config = _make_provider_config(tmp_path, name="fast", provider="recording", model="fast")
-    slow_config = _make_provider_config(tmp_path, name="slow", provider="recording", model="slow")
+    fast_config = _make_provider_config(
+        tmp_path, name="fast", provider="recording", model="fast"
+    )
+    slow_config = _make_provider_config(
+        tmp_path, name="slow", provider="recording", model="slow"
+    )
 
     from adapter.core import runners as runners_module
 
@@ -438,7 +454,9 @@ def test_parallel_any_cancels_pending_workers(
         _make_budget_manager(),
         tmp_path / "metrics_cancel.jsonl",
     )
-    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2))
+    results = runner.run(
+        repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2)
+    )
 
     assert len(results) == 2
     status_by_model = {metric.model: metric.status for metric in results}
@@ -467,7 +485,9 @@ def test_parallel_any_populates_metrics_for_unscheduled_workers(
     class IdleProvider(BaseProvider):
         called = False
 
-        def generate(self, prompt: str) -> ProviderResponse:  # pragma: no cover - 防御ライン
+        def generate(
+            self, prompt: str
+        ) -> ProviderResponse:  # pragma: no cover - 防御ライン
             IdleProvider.called = True
             raise AssertionError("idle provider should not run")
 
@@ -494,7 +514,9 @@ def test_parallel_any_populates_metrics_for_unscheduled_workers(
         _make_budget_manager(),
         tmp_path / "metrics_unscheduled.jsonl",
     )
-    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2))
+    results = runner.run(
+        repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2)
+    )
 
     metrics_by_model = {metric.model: metric for metric in results}
     assert WinnerProvider.calls == 1
@@ -539,7 +561,9 @@ def test_parallel_any_failure_summary_includes_all_failures(
     )
 
     with pytest.raises(errors.ParallelExecutionError) as exc_info:
-        runner.run(repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2))
+        runner.run(
+            repeat=1, config=RunnerConfig(mode="parallel-any", max_concurrency=2)
+        )
 
     failures = getattr(exc_info.value, "failures", ())
     assert len(failures) == 2
@@ -581,15 +605,21 @@ def test_consensus_majority_and_judge_tiebreak(
     metrics_path = tmp_path / "metrics_consensus.jsonl"
     runner = CompareRunner(
         [
-            _make_provider_config(tmp_path, name="c1", provider="consensus", model="YES"),
-            _make_provider_config(tmp_path, name="c2", provider="consensus", model="YES"),
+            _make_provider_config(
+                tmp_path, name="c1", provider="consensus", model="YES"
+            ),
+            _make_provider_config(
+                tmp_path, name="c2", provider="consensus", model="YES"
+            ),
         ],
         [task],
         _make_budget_manager(),
         metrics_path,
     )
     results = runner.run(repeat=1, config=RunnerConfig(mode="consensus", quorum=2))
-    winner = next(metric for metric in results if metric.ci_meta.get("aggregate_strategy"))
+    winner = next(
+        metric for metric in results if metric.ci_meta.get("aggregate_strategy")
+    )
     assert winner.providers == ["consensus"]
     assert winner.token_usage == {"prompt": 1, "completion": 1, "total": 2}
     assert winner.retries == 0
@@ -603,7 +633,6 @@ def test_consensus_majority_and_judge_tiebreak(
     assert consensus_meta["votes"] == 2
     assert consensus_meta["chosen_provider"] == "consensus"
     assert consensus_meta.get("metadata", {}) == {"bucket_size": 2}
-
 
     class JudgeProvider(BaseProvider):
         calls = 0
@@ -636,7 +665,9 @@ def test_consensus_majority_and_judge_tiebreak(
     )
     judge_results = tie_runner.run(repeat=1, config=judge_config_instance)
     judge_winner = next(
-        metric for metric in judge_results if metric.ci_meta.get("aggregate_strategy") == "judge"
+        metric
+        for metric in judge_results
+        if metric.ci_meta.get("aggregate_strategy") == "judge"
     )
     assert judge_winner.model == "B"
     assert JudgeProvider.calls == 1
@@ -699,8 +730,12 @@ def test_consensus_quorum_failure_marks_metrics(
 
     runner = CompareRunner(
         [
-            _make_provider_config(tmp_path, name="c1", provider="consensus", model="M1"),
-            _make_provider_config(tmp_path, name="c2", provider="consensus", model="M2"),
+            _make_provider_config(
+                tmp_path, name="c1", provider="consensus", model="M1"
+            ),
+            _make_provider_config(
+                tmp_path, name="c2", provider="consensus", model="M2"
+            ),
         ],
         [_make_task()],
         _make_budget_manager(),
@@ -765,7 +800,9 @@ def test_consensus_quorum_falls_back_to_judge(
     )
 
     winner = next(
-        metric for metric in results if metric.ci_meta.get("aggregate_strategy") == "judge"
+        metric
+        for metric in results
+        if metric.ci_meta.get("aggregate_strategy") == "judge"
     )
 
     assert winner.status == "ok"
@@ -790,7 +827,9 @@ def test_consensus_default_quorum_requires_two_votes(
                 latency_ms=latency,
             )
 
-    monkeypatch.setitem(ProviderFactory._registry, "split-consensus", SplitConsensusProvider)
+    monkeypatch.setitem(
+        ProviderFactory._registry, "split-consensus", SplitConsensusProvider
+    )
 
     runner = CompareRunner(
         [
@@ -910,7 +949,9 @@ def test_run_metrics_records_error_type_and_attempts(
     runner = CompareRunner(
         [
             _make_provider_config(tmp_path, name="flaky", provider="flaky", model="F"),
-            _make_provider_config(tmp_path, name="stable", provider="stable", model="S"),
+            _make_provider_config(
+                tmp_path, name="stable", provider="stable", model="S"
+            ),
         ],
         [_make_task()],
         _make_budget_manager(),
@@ -918,7 +959,9 @@ def test_run_metrics_records_error_type_and_attempts(
     )
     results = runner.run(repeat=2, config=RunnerConfig(mode="parallel-all"))
 
-    flaky_attempts = {metric.attempts: metric for metric in results if metric.provider == "flaky"}
+    flaky_attempts = {
+        metric.attempts: metric for metric in results if metric.provider == "flaky"
+    }
     stable_attempts = sorted(
         (metric.attempts, metric.error_type)
         for metric in results
@@ -957,15 +1000,24 @@ def _run_parallel_any_sync(
 
 
 def _run_parallel_case(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
-) -> tuple[dict[int, SingleRunResult], list[ProviderFailureSummary], str]:
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    behaviours: dict[str, dict[str, dict[str, object]]] | None = None,
+) -> tuple[list[tuple[int, SingleRunResult]], list[ProviderFailureSummary], str | None]:
     from adapter.core.runner_execution_parallel import ParallelAnyState
 
     task = _make_task()
-    providers = [_make_provider_config(tmp_path, name=n, provider=n, model=n) for n in ("fail", "win", "tail")]
+    providers = [
+        _make_provider_config(tmp_path, name=n, provider=n, model=n)
+        for n in ("fail", "win", "tail")
+    ]
     summaries: list[ProviderFailureSummary] = []
     if mode == "parallel-any":
-        def _record(self: ParallelAnyState, index: int, summary: ProviderFailureSummary) -> None:
+
+        def _record(
+            self: ParallelAnyState, index: int, summary: ProviderFailureSummary
+        ) -> None:
             summaries.append(summary)
             ParallelAnyState.register_failure(self, index, summary)
 
@@ -976,7 +1028,7 @@ def _run_parallel_case(
     state_factory = sys.modules[
         "adapter.core.runner_execution_parallel"
     ].ParallelAnyState
-    behaviours: dict[str, dict[str, dict[str, object]]] = {
+    behaviour_map = behaviours or {
         "parallel-any": {
             "fail": {
                 "status": "error",
@@ -997,10 +1049,16 @@ def _run_parallel_case(
     }
 
     def run_single(
-        config: ProviderConfig, _provider: object, _task: GoldenTask, _attempt: int, _mode: str
+        config: ProviderConfig,
+        _provider: object,
+        _task: GoldenTask,
+        _attempt: int,
+        _mode: str,
     ) -> SingleRunResult:
-        metrics = _make_run_metrics(provider=config.provider, model=config.model, latency_ms=0, cost_usd=0.0)
-        data = behaviours[mode][config.provider]
+        metrics = _make_run_metrics(
+            provider=config.provider, model=config.model, latency_ms=0, cost_usd=0.0
+        )
+        data = behaviour_map[mode][config.provider]
         status = data.get("status")
         if isinstance(status, str):
             metrics.status = status
@@ -1017,7 +1075,9 @@ def _run_parallel_case(
             metrics=metrics,
             raw_output=config.provider,
             stop_reason=data.get("stop") if isinstance(data.get("stop"), str) else None,
-            error=data.get("error") if isinstance(data.get("error"), Exception) else None,
+            error=(
+                data.get("error") if isinstance(data.get("error"), Exception) else None
+            ),
             backoff_next_provider=bool(data.get("backoff", False)),
         )
 
@@ -1029,27 +1089,179 @@ def _run_parallel_case(
         parallel_execution_error=RuntimeError,
         parallel_any_state_factory=state_factory,
     )
-    batch, stop_reason = executor.run(
-        [(cfg, cast(BaseProvider, object())) for cfg in providers],
-        task,
-        attempt_index=0,
-        config=RunnerConfig(mode=mode),
-    )
-    return dict(batch), summaries, stop_reason
+    try:
+        batch, stop_reason = executor.run(
+            [(cfg, cast(BaseProvider, object())) for cfg in providers],
+            task,
+            attempt_index=0,
+            config=RunnerConfig(mode=mode),
+        )
+    except RuntimeError as exc:  # pragma: no cover - parallel-any failure path
+        error_batch = getattr(exc, "batch", [])
+        error_failures = getattr(exc, "failures", [])
+        if not summaries and error_failures:
+            summaries.extend(error_failures)
+        return list(error_batch), summaries, None
+    return list(batch), summaries, stop_reason
 
 
-@pytest.mark.parametrize(("mode", "expected_stop"), [("parallel-any", "completed"), ("parallel-all", "all-done")])
+@pytest.mark.parametrize(
+    ("mode", "expected_stop"),
+    [("parallel-any", "completed"), ("parallel-all", "all-done")],
+)
 def test_parallel_executor_parallel_modes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str, expected_stop: str
 ) -> None:
-    results, summaries, stop_reason = _run_parallel_case(tmp_path, monkeypatch, mode)
+    batch, summaries, stop_reason = _run_parallel_case(tmp_path, monkeypatch, mode)
     assert stop_reason == expected_stop
+    results = dict(batch)
     if mode == "parallel-any":
         assert results[2].metrics.failure_kind == "cancelled"
         assert summaries[0].backoff_next_provider is True
         assert summaries[0].error_type == "RuntimeError"
     else:
         assert results[1].stop_reason == expected_stop
+
+
+def test_parallel_attempt_executor_parallel_all_regression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    batch, summaries, stop_reason = _run_parallel_case(
+        tmp_path, monkeypatch, mode="parallel-all"
+    )
+
+    assert stop_reason == "all-done"
+    assert summaries == []
+    assert [index for index, _ in batch] == [0, 1, 2]
+
+    assert [result.metrics.status for _, result in batch] == ["ok", "ok", "ok"]
+    assert [result.stop_reason for _, result in batch] == [None, "all-done", None]
+
+
+def test_parallel_attempt_executor_parallel_all_failure_regression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    behaviours = {
+        "parallel-all": {
+            "fail": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "boom",  # noqa: S106 - テスト入力
+            },
+            "win": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "boom",  # noqa: S106 - テスト入力
+            },
+            "tail": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "boom",  # noqa: S106 - テスト入力
+            },
+        },
+        "parallel-any": {
+            "fail": {},
+            "win": {},
+            "tail": {},
+        },
+    }
+
+    batch, summaries, stop_reason = _run_parallel_case(
+        tmp_path, monkeypatch, mode="parallel-all", behaviours=behaviours
+    )
+
+    assert stop_reason is None
+    assert summaries == []
+    assert [result.metrics.status for _, result in batch] == ["error", "error", "error"]
+    assert [result.metrics.failure_kind for _, result in batch] == [
+        "runtime",
+        "runtime",
+        "runtime",
+    ]
+    assert all(result.stop_reason is None for _, result in batch)
+
+
+def test_parallel_attempt_executor_parallel_any_regression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    batch, summaries, stop_reason = _run_parallel_case(
+        tmp_path, monkeypatch, mode="parallel-any"
+    )
+
+    assert stop_reason == "completed"
+    assert [index for index, _ in batch] == [0, 1, 2]
+
+    failure_result = dict(batch)[0]
+    assert failure_result.metrics.status == "error"
+    assert failure_result.metrics.failure_kind == "runtime"
+    assert failure_result.metrics.error_message == "boom"
+    assert failure_result.backoff_next_provider is True
+
+    assert [summary.provider for summary in summaries] == ["fail"]
+    assert summaries[0].status == "error"
+    assert summaries[0].failure_kind == "runtime"
+    assert summaries[0].error_message == "boom"
+    assert summaries[0].backoff_next_provider is True
+    assert summaries[0].retries == 1
+    assert summaries[0].error_type == "RuntimeError"
+
+
+def test_parallel_attempt_executor_parallel_any_failure_regression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    behaviours = {
+        "parallel-any": {
+            "fail": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "fail",  # noqa: S106 - テスト入力
+                "retries": 2,
+                "error": RuntimeError("fail"),
+                "backoff": True,
+            },
+            "win": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "fail",  # noqa: S106 - テスト入力
+                "retries": 3,
+                "error": RuntimeError("fail"),
+            },
+            "tail": {
+                "status": "error",
+                "failure_kind": "runtime",
+                "error_message": "fail",  # noqa: S106 - テスト入力
+                "retries": 4,
+                "error": RuntimeError("fail"),
+            },
+        },
+        "parallel-all": {
+            "fail": {},
+            "win": {},
+            "tail": {},
+        },
+    }
+
+    batch, summaries, stop_reason = _run_parallel_case(
+        tmp_path, monkeypatch, mode="parallel-any", behaviours=behaviours
+    )
+
+    assert stop_reason is None
+    assert [result.metrics.status for _, result in batch] == ["error", "error", "error"]
+    assert [result.metrics.error_message for _, result in batch] == [
+        "fail",
+        "fail",
+        "fail",
+    ]
+
+    assert [summary.provider for summary in summaries] == ["fail", "win", "tail"]
+    assert [summary.retries for summary in summaries] == [2, 3, 4]
+    assert all(summary.status == "error" for summary in summaries)
+    assert all(summary.failure_kind == "runtime" for summary in summaries)
+    assert all(summary.error_message == "fail" for summary in summaries)
+    assert summaries[0].backoff_next_provider is True
+    assert summaries[0].error_type == "RuntimeError"
+
+
 class _RunnerMode(str, Enum):
     SEQUENTIAL = "sequential"
     PARALLEL_ANY = "parallel-any"
@@ -1088,7 +1300,7 @@ def test_compare_runner_normalizes_enum_mode(
 
     monkeypatch.setattr(runner, "_log_attempt_failures", fake_log)
 
-    expected_error = getattr(errors, "ParallelExecutionError")
+    expected_error = errors.ParallelExecutionError
 
     def fake_run_tasks(
         *,
@@ -1116,4 +1328,3 @@ def test_compare_runner_normalizes_enum_mode(
     assert results == []
     assert captured.aggregation == ["parallel-any", "parallel-any"]
     assert captured.logs == ["parallel-any"]
-


### PR DESCRIPTION
## Summary
- add regression coverage for ParallelAttemptExecutor covering both parallel-all and parallel-any success and failure scenarios
- extract the parallel coordinator utilities into adapter/core/parallel/coordinators.py and expose them via adapter.core.parallel
- update ParallelAttemptExecutor to rely on the new coordinator module and slim the legacy runner_execution_parallel module

## Testing
- ruff check adapter/core/parallel adapter/core/runner_execution_parallel.py tests/test_compare_runner_parallel.py
- black adapter/core/parallel adapter/core/runner_execution_parallel.py tests/test_compare_runner_parallel.py
- pytest tests/test_compare_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8e3c8e7c8321bbe8adb5fe34c4b0