### PR TITLE
Set cost estimate on cancelled run metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -154,6 +154,7 @@ def build_cancelled_result(
         budget=BudgetSnapshot(0.0, False),
         ci_meta={},
     )
+    metrics.cost_estimate = 0.0
     single_run_result_cls = _get_single_run_result_cls()
     return single_run_result_cls(
         metrics=metrics,

--- a/projects/04-llm-adapter/tests/test_parallel_state_mode.py
+++ b/projects/04-llm-adapter/tests/test_parallel_state_mode.py
@@ -65,5 +65,7 @@ def test_build_cancelled_result_uses_mode_value(tmp_path: Path) -> None:
     )
 
     metrics = result.metrics
-    assert metrics.mode == RunnerMode.PARALLEL_ANY.value
+    expected_mode = config.mode.value if isinstance(config.mode, Enum) else str(config.mode)
+    assert metrics.mode == expected_mode
     assert type(metrics.mode) is str
+    assert metrics.cost_estimate == 0.0


### PR DESCRIPTION
## Summary
- ensure build_cancelled_result populates the cost_estimate field when synthesizing RunMetrics
- update the parallel state test to assert the normalized mode value and the zero cost estimate

## Testing
- pytest projects/04-llm-adapter/tests/test_parallel_state_mode.py
- pytest projects/04-llm-adapter/tests/test_compare_runner_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8fbb2b5c8321af2b0bc897080167