### PR TITLE
Set cost estimate on run metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -101,6 +101,7 @@ class RunMetricsBuilder:
             output_tokens=response.output_tokens,
             latency_ms=latency_ms,
             cost_usd=cost_usd,
+            cost_estimate=cost_usd,
             status=status,
             failure_kind=failure_kind,
             error_message=error_message,

--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -111,6 +111,7 @@ class RunMetrics:
     eval: EvalMetrics = field(default_factory=EvalMetrics)
     budget: BudgetSnapshot = field(default_factory=lambda: BudgetSnapshot(0.0, False))
     ci_meta: Mapping[str, Any] = field(default_factory=dict)
+    cost_estimate: float | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = asdict(self)


### PR DESCRIPTION
## Summary
- add a cost_estimate field to RunMetrics so the value can be persisted
- populate cost_estimate in RunMetricsBuilder using the existing cost_usd amount

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_metrics.py
- pytest projects/04-llm-adapter/tests/test_parallel_state_mode.py *(fails: expected parallel_any vs. parallel-any prior failure remains)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8fba9cf88321bb6da721b59e553e