### PR TITLE
Update aggregation controller mode test to expect majority_vote

### DIFF
--- a/projects/04-llm-adapter/tests/test_aggregation_controller_mode.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_controller_mode.py
@@ -53,7 +53,7 @@ def test_apply_records_string_mode_when_enum_input() -> None:
     decision = SimpleNamespace(
         chosen=candidate,
         candidates=[candidate],
-        strategy="majority",
+        strategy="majority_vote",
         reason=None,
         tie_breaker_used=None,
         metadata={"bucket_size": 1},
@@ -79,4 +79,4 @@ def test_apply_records_string_mode_when_enum_input() -> None:
     )
 
     assert result.metrics.ci_meta["aggregate_mode"] == "consensus"
-    assert result.metrics.ci_meta["consensus"]["strategy"] == "majority"
+    assert result.metrics.ci_meta["consensus"]["strategy"] == "majority_vote"


### PR DESCRIPTION
## Summary
- update the aggregation controller mode test to expect the renamed majority_vote strategy metadata

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_controller_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9368323883219edbc6b5e7954553