### PR TITLE
Adjust majority vote strategy naming

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector.py
@@ -77,12 +77,19 @@ class AggregationSelector:
             )
         tiebreaker = self._tie_breaker_factory.create(config, lookup)
         decision = strategy.aggregate(candidates, tiebreaker=tiebreaker)
+        aggregate_kind = (config.aggregate or "").strip().lower().replace("-", "_")
+        alias_to_preferred = {
+            "majority_vote": "majority_vote",
+            "weighted_vote": "weighted_vote",
+            "weighted": "weighted_vote",
+        }
+        preferred_strategy = alias_to_preferred.get(aggregate_kind, strategy.name)
+        decision.strategy = preferred_strategy
         if score_metadata is not None:
             metadata = dict(decision.metadata) if decision.metadata else {}
             metadata["scores"] = score_metadata
             decision.metadata = metadata
         votes: float | int | None = None
-        aggregate_kind = (config.aggregate or "").strip().lower().replace("-", "_")
         is_weighted = aggregate_kind in {"weighted_vote", "weighted"}
         if mode_value == "consensus":
             if decision.metadata:

--- a/projects/04-llm-adapter/tests/test_aggregation_selector.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector.py
@@ -109,7 +109,7 @@ def test_select_accepts_cli_aggregate_aliases() -> None:
     )
 
     assert majority_decision is not None
-    assert majority_decision.decision.strategy == "majority"
+    assert majority_decision.decision.strategy == "majority_vote"
     assert majority_decision.decision.chosen.provider == "p1"
     assert majority_decision.votes == 2
 


### PR DESCRIPTION
## Summary
- normalize aggregation selector strategy names so CLI aliases like majority_vote map to the canonical label
- update the aggregation selector test expectation to reflect the majority_vote strategy name

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9366e0b08321ad25839188f58174