### PR TITLE
Update tie breaker display names to min_* labels

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -120,7 +120,11 @@ class JudgeScorer:
 
 
 class _CompositeTieBreaker(TieBreaker):
-    _DISPLAY_NAMES = {"latency": "latency", "cost": "cost", "stable_order": "stable_order"}
+    _DISPLAY_NAMES = {
+        "latency": "min_latency",
+        "cost": "min_cost",
+        "stable_order": "stable_order",
+    }
 
     def __init__(
         self,

--- a/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
+++ b/projects/04-llm-adapter/tests/test_aggregation_selector_components.py
@@ -144,7 +144,7 @@ def test_tie_breaker_falls_back_to_latency_cost_stable_order() -> None:
     decision = selector.select("consensus", config, batch, default_judge_config=None)
 
     assert decision is not None
-    assert decision.decision.tie_breaker_used == "latency"
+    assert decision.decision.tie_breaker_used == "min_latency"
     assert decision.decision.chosen.provider == "p2"
 
 
@@ -247,5 +247,5 @@ def test_tie_breaker_falls_back_to_cost_when_latency_equal() -> None:
     decision = selector.select("consensus", config, batch, default_judge_config=None)
 
     assert decision is not None
-    assert decision.decision.tie_breaker_used == "cost"
+    assert decision.decision.tie_breaker_used == "min_cost"
     assert decision.decision.chosen.provider == "p2"


### PR DESCRIPTION
## Summary
- update composite tie breaker display names to use min_latency and min_cost while keeping internal keys unchanged
- adjust aggregation selector component tests to expect the new tie breaker labels

## Testing
- pytest projects/04-llm-adapter/tests/test_aggregation_selector_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dc936529d883219834fc2dc8276ff6