### PR TITLE
test: normalize runner mode input in compare runner orchestration test

### DIFF
--- a/projects/04-llm-adapter/tests/test_compare_runner_orchestration.py
+++ b/projects/04-llm-adapter/tests/test_compare_runner_orchestration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -72,16 +71,12 @@ def _provider_config(tmp_path_factory: pytest.TempPathFactory) -> ProviderConfig
         raw={},
     )
 
-class _RunnerMode(Enum):
-    PARALLEL_ANY = "parallel-any"
-
-
 @pytest.fixture(name="runner_config")
 def _runner_config(tmp_path_factory: pytest.TempPathFactory) -> RunnerConfig:
     metrics_dir = tmp_path_factory.mktemp("metrics")
     metrics_path = metrics_dir / "runs.jsonl"
     return RunnerConfig(
-        mode=_RunnerMode.PARALLEL_ANY,
+        mode="parallel_any",
         metrics_path=metrics_path,
         backoff=BackoffPolicy(),
     )


### PR DESCRIPTION
## Summary
- update the compare runner orchestration test to supply the runner mode using snake_case so normalization handles hyphenated aliases

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_orchestration.py

------
https://chatgpt.com/codex/tasks/task_e_68dc936293d0832197c2deb27b94f66c