### PR TITLE
Normalize runner mode CLI choices to snake case

### DIFF
--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -20,16 +20,24 @@ class RunnerMode(str, Enum):
     """比較ランナーの実行モード."""
 
     SEQUENTIAL = "sequential"
-    PARALLEL_ANY = "parallel-any"
-    PARALLEL_ALL = "parallel-all"
+    PARALLEL_ANY = "parallel_any"
+    PARALLEL_ALL = "parallel_all"
     CONSENSUS = "consensus"
 
     @classmethod
     def from_raw(cls, raw: str) -> "RunnerMode":
         """CLI から渡された値を RunnerMode に変換する."""
 
-        candidate = raw.strip().lower().replace("_", "-")
+        candidate = raw.strip().lower().replace("-", "_")
         return cls(candidate)
+
+    @classmethod
+    def cli_choices(cls) -> list[str]:
+        """CLI に表示するモード選択肢."""
+
+        values = {mode.value for mode in cls}
+        hyphen_aliases = {value.replace("_", "-") for value in values}
+        return sorted(values | hyphen_aliases)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -52,7 +60,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--mode",
-        choices=[mode.value for mode in RunnerMode],
+        choices=RunnerMode.cli_choices(),
         default="sequential",
         help="比較実行モード",
     )

--- a/projects/04-llm-adapter/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter/tests/test_cli_runner_config.py
@@ -41,7 +41,7 @@ def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_pat
         providers=str(provider),
         prompts=str(prompts),
         repeat=2,
-        mode="parallel-any",
+        mode="parallel_any",
         budgets=None,
         metrics=None,
         log_level="DEBUG",
@@ -76,6 +76,7 @@ def test_cli_main_passes_parallel_flags(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert forwarded["tie_breaker"] == "min_cost"
     assert forwarded["provider_weights"] == {"openai": 1.5, "anthropic": 0.5}
     assert forwarded["mode"] is RunnerMode.PARALLEL_ANY
+    assert RunnerMode.from_raw("parallel-any") is RunnerMode.PARALLEL_ANY
 
 
 def test_run_compare_sanitizes_runner_config(
@@ -133,7 +134,8 @@ def test_run_compare_sanitizes_runner_config(
         rpm=0,
         provider_weights={"openai": 1.0},
     )
-    assert captured["mode"] == "parallel-any"
+    assert captured["mode"] is runner_api.RunnerMode.PARALLEL_ANY
+    assert captured["mode"].value.replace("-", "_") == "parallel_any"
     assert captured["quorum"] == 5
     assert captured["max_concurrency"] is None
     assert captured["rpm"] is None


### PR DESCRIPTION
## Summary
- normalize CLI runner mode enum values to snake case while keeping hyphen aliases
- expose combined snake and hyphen choices in the CLI parser
- adjust CLI runner configuration tests to assert normalized mode values and alias acceptance

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9360017883219e9c87aa8e77cfcd