### PR TITLE
Normalize runner mode enum values to snake case

### DIFF
--- a/projects/04-llm-adapter/tests/test_runner_mode_enum.py
+++ b/projects/04-llm-adapter/tests/test_runner_mode_enum.py
@@ -6,8 +6,8 @@ from adapter.core.runner_api import RunnerConfig, RunnerMode, _normalize_mode
 def test_runner_mode_values_and_aliases() -> None:
     assert [mode.value for mode in RunnerMode] == [
         "sequential",
-        "parallel-any",
-        "parallel-all",
+        "parallel_any",
+        "parallel_all",
         "consensus",
     ]
     assert _normalize_mode("parallel") is RunnerMode.PARALLEL_ANY
@@ -28,6 +28,7 @@ def test_runner_config_keeps_enum() -> None:
         (RunnerMode.SEQUENTIAL, RunnerMode.SEQUENTIAL),
         ("sequential", RunnerMode.SEQUENTIAL),
         ("parallel-any", RunnerMode.PARALLEL_ANY),
+        ("parallel-all", RunnerMode.PARALLEL_ALL),
         ("parallel_all", RunnerMode.PARALLEL_ALL),
         ("consensus", RunnerMode.CONSENSUS),
     ],


### PR DESCRIPTION
## Summary
- switch RunnerMode enum values to snake_case while keeping hyphenated aliases accepted via the normalization helper
- extend the RunnerMode normalization tests to cover snake_case expectations and hyphenated inputs

## Testing
- pytest projects/04-llm-adapter/tests/test_runner_mode_enum.py

------
https://chatgpt.com/codex/tasks/task_e_68dc935ff9ac832185f33405087a97cd