### PR TITLE
Align parallel-any mode handling with snake case

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -54,6 +54,11 @@ else:
     _BuildSummary = Callable[[int, ProviderConfig, object], ProviderFailureSummary]
 
 
+_PARALLEL_ANY_SNAKE = "parallel_any"
+_PARALLEL_ANY_LEGACY = "parallel-any"
+_PARALLEL_ANY_FAILED_MESSAGE = "parallel_any failed"
+
+
 class ParallelAnyState:
     def __init__(self, cancel_event: Event) -> None:
         self._cancel_event = cancel_event
@@ -103,7 +108,7 @@ class ParallelAnyState:
             summary = build_summary(index, provider_config, cast("SingleRunResult", result))
             self._failure_indices.add(index)
             self._failure_summaries.append(summary)
-        error = error_factory("parallel-any failed")
+        error = error_factory(_PARALLEL_ANY_FAILED_MESSAGE)
         error_any = cast(Any, error)
         error_any.failures = self._failure_summaries
         error_any.batch = [
@@ -128,6 +133,8 @@ def build_cancelled_result(
         mode_value = mode.value if isinstance(mode.value, str) else str(mode.value)
     else:
         mode_value = cast(str, mode)
+    if mode_value == _PARALLEL_ANY_LEGACY:
+        mode_value = _PARALLEL_ANY_SNAKE
 
     metrics = RunMetrics(
         ts=now_ts(),

--- a/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution_parallel.py
@@ -10,6 +10,7 @@ from .config import ProviderConfig
 from .datasets import GoldenTask
 from .parallel.coordinators import (
     _is_parallel_any_mode,
+    _normalize_mode_value,
     _ParallelAllCoordinator,
     _ParallelAnyCoordinator,
     _ParallelCoordinatorBase,
@@ -83,7 +84,8 @@ class ParallelAttemptExecutor:
     ) -> tuple[list[tuple[int, SingleRunResult]], str | None]:
         if not providers:
             return [], None
-        if _is_parallel_any_mode(config.mode):
+        normalized_mode = _normalize_mode_value(config.mode)
+        if _is_parallel_any_mode(normalized_mode):
             coordinator: _ParallelCoordinatorBase = _ParallelAnyCoordinator(
                 self,
                 providers,


### PR DESCRIPTION
## Summary
- update the parallel-any executor tests to expect snake_case naming and cover hyphen input compatibility
- normalize the parallel runner helpers so mode checks, cancellation messaging, and failure errors emit snake_case values while accepting legacy hyphenated inputs
- ensure parallel state bookkeeping produces snake_case run metadata and error messages for parallel_any runs

## Testing
- pytest projects/04-llm-adapter/tests/test_parallel_any_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9360ce8c8321baadc87874558c77