### PR TITLE
Add cost estimate support in run metrics

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -113,8 +113,15 @@ class RunMetrics:
     ci_meta: Mapping[str, Any] = field(default_factory=dict)
     cost_estimate: float | None = None
 
+    def __post_init__(self) -> None:
+        if self.cost_estimate is None:
+            self.cost_estimate = self.cost_usd
+
     def to_json_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = asdict(self)
+        payload["cost_estimate"] = (
+            self.cost_estimate if self.cost_estimate is not None else self.cost_usd
+        )
         payload["eval"] = {k: v for k, v in payload["eval"].items() if v is not None}
         return payload
 


### PR DESCRIPTION
## Summary
- add `cost_estimate` coverage in metrics module tests to reflect new field defaults
- ensure `RunMetrics` populates and serializes `cost_estimate` alongside `cost_usd`

## Testing
- pytest projects/04-llm-adapter/tests/test_metrics_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68dc936446b8832188f7e9a6f951180e