### PR TITLE
Sort runner_sync imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -25,11 +25,11 @@ from .runner_shared import (
     resolve_rate_limiter,
 )
 from .runner_sync_invocation import (
+    _DEFAULT_RUN_WITH_SHADOW,
     CancelledResultsBuilder,
     ParallelResultLogger,
     ProviderInvocationResult,
     ProviderInvoker,
-    _DEFAULT_RUN_WITH_SHADOW,
 )
 from .runner_sync_modes import get_sync_strategy, SyncRunContext
 from .shadow import DEFAULT_METRICS_PATH


### PR DESCRIPTION
## Summary
- reorder `runner_sync.py` imports to follow standard-library-first, alphabetical sorting

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc983d32dc8321a43f61de54cdc111