### PR TITLE
Reorder imports in runner sync invocation

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import CancelledError
 from dataclasses import dataclass
 import time
-from typing import Literal, Protocol, overload, cast
+from typing import cast, Literal, overload, Protocol
 
 from .errors import ProviderSkip
 from .observability import EventLogger


### PR DESCRIPTION
## Summary
- reorder the standard library imports in runner_sync_invocation to follow Ruff's grouping rules
- alphabetize the typing imports for consistency

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc983ea3d48321b55fddcd6bdf1150