### PR TITLE
Sort imports in parallel_state module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from threading import Event, Lock
-from typing import Any, TYPE_CHECKING, cast
+from typing import Any, cast, TYPE_CHECKING
 from uuid import uuid4
 
 from .config import ProviderConfig


### PR DESCRIPTION
## Summary
- reorder the typing import symbols alphabetically
- keep standard library and local imports separated to satisfy linting

## Testing
- ruff check projects/04-llm-adapter/adapter/core/parallel_state.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc9841d0fc83219f19e29c658085ff