### PR TITLE
Remove unused RunnerMode typing import

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -12,7 +12,7 @@ from .runner_execution import SingleRunResult
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .config import ProviderConfig
-    from .runner_api import RunnerConfig, RunnerMode
+    from .runner_api import RunnerConfig
 
 try:  # pragma: no cover - 実環境では src.* が存在する
     from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse  # type: ignore


### PR DESCRIPTION
## Summary
- remove the unused RunnerMode import from the TYPE_CHECKING block in aggregation_selector_components

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation_selector_components.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68dc984203508321b2f4e9899a761e8b