### PR TITLE
chore: tidy runners imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Sequence
 from enum import Enum
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast, TYPE_CHECKING
 
 from . import errors as core_errors
 from .aggregation_controller import AggregationController
@@ -39,7 +39,7 @@ ParallelExecutionError = cast(
     ),
 )
 if not hasattr(core_errors, "ParallelExecutionError"):
-    setattr(core_errors, "ParallelExecutionError", ParallelExecutionError)
+    core_errors.ParallelExecutionError = ParallelExecutionError
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from .runner_api import RunnerConfig


### PR DESCRIPTION
## Summary
- reorder imports in adapter core runners module to group standard library modules before local modules
- assign ParallelExecutionError directly on the core errors module to satisfy Ruff linting

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runners.py --select I001,B010

------
https://chatgpt.com/codex/tasks/task_e_68dc984307348321b9147345931b23e0