### PR TITLE
Fix RunnerMode.from_raw return type annotation

### DIFF
--- a/projects/04-llm-adapter/adapter/run_compare.py
+++ b/projects/04-llm-adapter/adapter/run_compare.py
@@ -25,7 +25,7 @@ class RunnerMode(str, Enum):
     CONSENSUS = "consensus"
 
     @classmethod
-    def from_raw(cls, raw: str) -> "RunnerMode":
+    def from_raw(cls, raw: str) -> RunnerMode:
         """CLI から渡された値を RunnerMode に変換する."""
 
         candidate = raw.strip().lower().replace("-", "_")


### PR DESCRIPTION
## Summary
- annotate `RunnerMode.from_raw` to return `RunnerMode` directly to satisfy UP037

## Testing
- `ruff check projects/04-llm-adapter/adapter/run_compare.py --select UP037`


------
https://chatgpt.com/codex/tasks/task_e_68dc984642a88321ba94bd3f51f0e214