### PR TITLE
style: organize imports in base provider spi test

### DIFF
--- a/projects/04-llm-adapter/tests/test_base_provider_spi.py
+++ b/projects/04-llm-adapter/tests/test_base_provider_spi.py
@@ -1,3 +1,4 @@
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,8 +10,8 @@ from adapter.core.config import (
     RateLimitConfig,
     RetryConfig,
 )
-from adapter.core.providers import BaseProvider
 from adapter.core.provider_spi import ProviderRequest, ProviderResponse
+from adapter.core.providers import BaseProvider
 
 
 def _provider_config(tmp_path: Path, provider: str) -> ProviderConfig:


### PR DESCRIPTION
## Summary
- add a leading blank line and reorganize imports in `test_base_provider_spi.py`

## Testing
- ruff check projects/04-llm-adapter/tests/test_base_provider_spi.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc9844ff2083219a52b6b0716fbaa2