### PR TITLE
Reorder test imports

### DIFF
--- a/projects/04-llm-adapter/tests/test_runner_mode_enum.py
+++ b/projects/04-llm-adapter/tests/test_runner_mode_enum.py
@@ -1,6 +1,6 @@
 import pytest
 
-from adapter.core.runner_api import RunnerConfig, RunnerMode, _normalize_mode
+from adapter.core.runner_api import _normalize_mode, RunnerConfig, RunnerMode
 
 
 def test_runner_mode_values_and_aliases() -> None:


### PR DESCRIPTION
## Summary
- reorder the runner mode enum test imports to follow third-party then local convention

## Testing
- ruff check projects/04-llm-adapter/tests/test_runner_mode_enum.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc984711408321beb1a1c1a66aaddc