### PR TITLE
Reorder imports in compare task runner

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/compare_task_runner.py
+++ b/projects/04-llm-adapter/adapter/core/execution/compare_task_runner.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-import logging
 from enum import Enum
+import logging
 from typing import Any, TYPE_CHECKING
 
 from ..config import ProviderConfig


### PR DESCRIPTION
## Summary
- reorder the standard library imports in compare_task_runner to follow the import sorting convention

## Testing
- ruff check projects/04-llm-adapter/adapter/core/execution/compare_task_runner.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dc9840ea24832185259fa24552ea0d