### PR TITLE
Fix RunnerMode type annotations

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -40,7 +40,7 @@ class _ModeValue(str):
 
     __slots__ = ("_alias",)
 
-    def __new__(cls, canonical: str, alias: str | None = None) -> "_ModeValue":
+    def __new__(cls, canonical: str, alias: str | None = None) -> _ModeValue:
         obj = cast("_ModeValue", str.__new__(cls, canonical))
         obj._alias = alias or canonical.replace("_", "-")
         return obj
@@ -67,7 +67,7 @@ class _ModeValue(str):
 
 
 class RunnerMode(str, Enum):
-    def __new__(cls, canonical: str, alias: str | None = None) -> "RunnerMode":
+    def __new__(cls, canonical: str, alias: str | None = None) -> RunnerMode:
         mode_value = _ModeValue(canonical, alias)
         obj = cast("RunnerMode", str.__new__(cls, mode_value))
         obj._value_ = mode_value


### PR DESCRIPTION
## Summary
- update `_ModeValue.__new__` to return `_ModeValue` directly
- update `RunnerMode.__new__` to return `RunnerMode` directly

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runner_api.py --select UP037

------
https://chatgpt.com/codex/tasks/task_e_68dc9cd6a964832194424f2604ff8edf