### PR TITLE
Fix import order in parallel coordinators

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
@@ -15,10 +15,10 @@ from ..parallel_state import (
     ParallelAnyState,
     ProviderFailureSummary,
 )
+from ..providers import BaseProvider
 
 _PARALLEL_ANY_SNAKE = "parallel_any"
 _PARALLEL_ANY_LEGACY = "parallel-any"
-from ..providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from ..runner_api import RunnerConfig


### PR DESCRIPTION
## Summary
- move BaseProvider import into top-level import block in parallel coordinators

## Testing
- ruff check projects/04-llm-adapter/adapter/core/parallel/coordinators.py --select E402,I001

------
https://chatgpt.com/codex/tasks/task_e_68dc9cd681088321b28f767dd41d0696