### PR TITLE
Refactor sync sequential strategy into dedicated module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -1,27 +1,18 @@
 """Synchronous runner strategy implementations."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-import time
-from typing import cast, NoReturn, Protocol, TYPE_CHECKING
+from typing import cast, Protocol, TYPE_CHECKING
 
-from .errors import (
-    AllFailedError,
-    AuthError,
-    ConfigError,
-    FatalError,
-    ProviderSkip,
-    RateLimitError,
-    RetryableError,
-    SkipError,
-    TimeoutError,
-)
+from .errors import AllFailedError
 from .observability import EventLogger
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerMode
-from .runner_shared import error_family, estimate_cost, log_run_metric, MetricsPath
+from .runner_shared import log_run_metric, MetricsPath
+from .runner_sync_sequential import SequentialStrategy
 from .utils import elapsed_ms
 
 if TYPE_CHECKING:
@@ -34,8 +25,7 @@ class ParallelAllCallable(Protocol):
         workers: Sequence[Callable[[], ProviderInvocationResult]],
         *,
         max_concurrency: int | None = ...,
-    ) -> Sequence[ProviderInvocationResult]:
-        ...
+    ) -> Sequence[ProviderInvocationResult]: ...
 
 
 class ParallelAnyCallable(Protocol):
@@ -45,8 +35,7 @@ class ParallelAnyCallable(Protocol):
         *,
         max_concurrency: int | None = ...,
         on_cancelled: Callable[[Sequence[int]], None] | None = ...,
-    ) -> ProviderInvocationResult:
-        ...
+    ) -> ProviderInvocationResult: ...
 
 
 @dataclass(slots=True)
@@ -67,10 +56,9 @@ class SyncRunContext:
 class SyncRunStrategy(Protocol):
     def execute(
         self, context: SyncRunContext
-    ) -> ProviderResponse | ParallelAllResult[
-        ProviderInvocationResult, ProviderResponse
-    ]:
-        ...
+    ) -> (
+        ProviderResponse | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+    ): ...
 
 
 def _limited_providers(
@@ -117,191 +105,21 @@ def _raise_no_attempts(context: SyncRunContext) -> None:
     raise error
 
 
-class _SequentialRunTracker:
-    def __init__(self, context: SyncRunContext) -> None:
-        self._context = context
-        self._runner = context.runner
-        self._config = context.runner._config
-        self._event_logger = context.event_logger
-        self._last_error: Exception | None = None
-        self._failure_details: list[dict[str, str]] = []
-        self.attempt_count = 0
-
-    def record_attempt(self, attempt: int) -> None:
-        self.attempt_count = attempt
-
-    def handle_success(
-        self,
-        provider: ProviderSPI,
-        attempt: int,
-        result: ProviderInvocationResult,
-    ) -> ProviderResponse | None:
-        response = result.response
-        if response is None:
-            return None
-        tokens_in = result.tokens_in if result.tokens_in is not None else 0
-        tokens_out = result.tokens_out if result.tokens_out is not None else 0
-        cost_usd = estimate_cost(provider, tokens_in, tokens_out)
-        log_run_metric(
-            self._event_logger,
-            request_fingerprint=self._context.request_fingerprint,
-            request=self._context.request,
-            provider=provider,
-            status="ok",
-            attempts=attempt,
-            latency_ms=elapsed_ms(self._context.run_started),
-            tokens_in=tokens_in,
-            tokens_out=tokens_out,
-            cost_usd=cost_usd,
-            error=None,
-            metadata=self._context.metadata,
-            shadow_used=self._context.shadow_used,
-        )
-        return response
-
-    def handle_failure(
-        self,
-        provider: ProviderSPI,
-        attempt: int,
-        error: Exception,
-    ) -> None:
-        self._last_error = error
-        summary = f"{type(error).__name__}: {error}"
-        self._failure_details.append(
-            {
-                "provider": provider.name(),
-                "attempt": str(attempt),
-                "summary": summary,
-            }
-        )
-        if isinstance(error, FatalError):
-            if isinstance(error, AuthError | ConfigError):
-                if self._event_logger is not None:
-                    self._event_logger.emit(
-                        "provider_fallback",
-                        {
-                            "request_fingerprint": self._context.request_fingerprint,
-                            "provider": provider.name(),
-                            "attempt": attempt,
-                            "error_type": type(error).__name__,
-                            "error_message": str(error),
-                        },
-                    )
-                return
-            raise error
-        if isinstance(error, RateLimitError):
-            sleep_duration = self._config.backoff.rate_limit_sleep_s
-            if sleep_duration > 0:
-                time.sleep(sleep_duration)
-            return
-        if isinstance(error, RetryableError):
-            if isinstance(error, TimeoutError):
-                if not self._config.backoff.timeout_next_provider:
-                    raise error
-                return
-            if self._config.backoff.retryable_next_provider:
-                return
-            raise error
-        if isinstance(error, SkipError | ProviderSkip):
-            return
-        raise error
-
-    def finalize_and_raise(self) -> NoReturn:
-        event_logger = self._event_logger
-        if event_logger is not None:
-            event_logger.emit(
-                "provider_chain_failed",
-                {
-                    "request_fingerprint": self._context.request_fingerprint,
-                    "provider_attempts": self.attempt_count,
-                    "providers": [provider.name() for provider in self._runner.providers],
-                    "last_error_type": type(self._last_error).__name__ if self._last_error else None,
-                    "last_error_message": str(self._last_error) if self._last_error else None,
-                    "last_error_family": error_family(self._last_error),
-                },
-            )
-        detail_text = "; ".join(
-            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
-            for item in self._failure_details
-        )
-        message = "all providers failed"
-        if detail_text:
-            message = f"{message}: {detail_text}"
-        failure_error = AllFailedError(message, failures=self._failure_details)
-        metric_error = self._last_error if self._last_error is not None else failure_error
-        log_run_metric(
-            event_logger,
-            request_fingerprint=self._context.request_fingerprint,
-            request=self._context.request,
-            provider=None,
-            status="error",
-            attempts=self.attempt_count,
-            latency_ms=elapsed_ms(self._context.run_started),
-            tokens_in=None,
-            tokens_out=None,
-            cost_usd=0.0,
-            error=metric_error,
-            metadata=self._context.metadata,
-            shadow_used=self._context.shadow_used,
-        )
-        if self._last_error is not None:
-            raise failure_error from self._last_error
-        raise failure_error
-
-
-class SequentialStrategy:
-    def execute(
-        self, context: SyncRunContext
-    ) -> ProviderResponse | ParallelAllResult[
-        ProviderInvocationResult, ProviderResponse
-    ]:
-        runner = context.runner
-        config = runner._config
-        max_attempts = config.max_attempts
-        tracker = _SequentialRunTracker(context)
-
-        for loop_index, provider in enumerate(runner.providers, start=1):
-            if max_attempts is not None and loop_index > max_attempts:
-                break
-            attempt_index = loop_index
-            tracker.record_attempt(attempt_index)
-            result = runner._invoke_provider_sync(
-                provider,
-                context.request,
-                attempt=attempt_index,
-                total_providers=len(runner.providers),
-                event_logger=context.event_logger,
-                request_fingerprint=context.request_fingerprint,
-                metadata=context.metadata,
-                shadow=context.shadow,
-                metrics_path=context.metrics_path,
-                capture_shadow_metrics=False,
-            )
-            response = tracker.handle_success(provider, attempt_index, result)
-            if response is not None:
-                return response
-
-            error = result.error
-            if error is None:
-                continue
-            tracker.handle_failure(provider, attempt_index, error)
-
-        tracker.finalize_and_raise()
-
-
 class ParallelAnyStrategy:
     def execute(
         self, context: SyncRunContext
-    ) -> ProviderResponse | ParallelAllResult[
-        ProviderInvocationResult, ProviderResponse
-    ]:
+    ) -> (
+        ProviderResponse | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+    ):
         runner = context.runner
         total_providers = len(runner.providers)
         results: list[ProviderInvocationResult | None] = [None] * total_providers
         max_attempts = runner._config.max_attempts
         providers = _limited_providers(runner.providers, max_attempts)
 
-        def make_worker(index: int, provider: ProviderSPI) -> Callable[[], ProviderInvocationResult]:
+        def make_worker(
+            index: int, provider: ProviderSPI
+        ) -> Callable[[], ProviderInvocationResult]:
             def worker() -> ProviderInvocationResult:
                 result = runner._invoke_provider_sync(
                     provider,
@@ -387,16 +205,18 @@ class ParallelAnyStrategy:
 class ParallelAllStrategy:
     def execute(
         self, context: SyncRunContext
-    ) -> ProviderResponse | ParallelAllResult[
-        ProviderInvocationResult, ProviderResponse
-    ]:
+    ) -> (
+        ProviderResponse | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+    ):
         runner = context.runner
         total_providers = len(runner.providers)
         results: list[ProviderInvocationResult | None] = [None] * total_providers
         max_attempts = runner._config.max_attempts
         providers = _limited_providers(runner.providers, max_attempts)
 
-        def make_worker(index: int, provider: ProviderSPI) -> Callable[[], ProviderInvocationResult]:
+        def make_worker(
+            index: int, provider: ProviderSPI
+        ) -> Callable[[], ProviderInvocationResult]:
             def worker() -> ProviderInvocationResult:
                 result = runner._invoke_provider_sync(
                     provider,
@@ -481,5 +301,6 @@ __all__ = [
     "SyncRunStrategy",
     "_limited_providers",
     "_raise_no_attempts",
+    "SequentialStrategy",
     "get_sync_strategy",
 ]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
@@ -1,0 +1,209 @@
+"""Sequential synchronous runner strategy implementation."""
+
+from __future__ import annotations
+
+import time
+from typing import NoReturn, TYPE_CHECKING
+
+from .errors import (
+    AllFailedError,
+    AuthError,
+    ConfigError,
+    FatalError,
+    ProviderSkip,
+    RateLimitError,
+    RetryableError,
+    SkipError,
+    TimeoutError,
+)
+from .parallel_exec import ParallelAllResult
+from .provider_spi import ProviderResponse, ProviderSPI
+from .runner_shared import error_family, estimate_cost, log_run_metric
+from .utils import elapsed_ms
+
+if TYPE_CHECKING:
+    from .runner_sync import ProviderInvocationResult
+    from .runner_sync_modes import SyncRunContext
+
+
+class _SequentialRunTracker:
+    def __init__(self, context: SyncRunContext) -> None:
+        self._context = context
+        self._runner = context.runner
+        self._config = context.runner._config
+        self._event_logger = context.event_logger
+        self._last_error: Exception | None = None
+        self._failure_details: list[dict[str, str]] = []
+        self.attempt_count = 0
+
+    def record_attempt(self, attempt: int) -> None:
+        self.attempt_count = attempt
+
+    def handle_success(
+        self,
+        provider: ProviderSPI,
+        attempt: int,
+        result: ProviderInvocationResult,
+    ) -> ProviderResponse | None:
+        response = result.response
+        if response is None:
+            return None
+        tokens_in = result.tokens_in if result.tokens_in is not None else 0
+        tokens_out = result.tokens_out if result.tokens_out is not None else 0
+        cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+        log_run_metric(
+            self._event_logger,
+            request_fingerprint=self._context.request_fingerprint,
+            request=self._context.request,
+            provider=provider,
+            status="ok",
+            attempts=attempt,
+            latency_ms=elapsed_ms(self._context.run_started),
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+            error=None,
+            metadata=self._context.metadata,
+            shadow_used=self._context.shadow_used,
+        )
+        return response
+
+    def handle_failure(
+        self,
+        provider: ProviderSPI,
+        attempt: int,
+        error: Exception,
+    ) -> None:
+        self._last_error = error
+        summary = f"{type(error).__name__}: {error}"
+        self._failure_details.append(
+            {
+                "provider": provider.name(),
+                "attempt": str(attempt),
+                "summary": summary,
+            }
+        )
+        if isinstance(error, FatalError):
+            if isinstance(error, AuthError | ConfigError):
+                if self._event_logger is not None:
+                    self._event_logger.emit(
+                        "provider_fallback",
+                        {
+                            "request_fingerprint": self._context.request_fingerprint,
+                            "provider": provider.name(),
+                            "attempt": attempt,
+                            "error_type": type(error).__name__,
+                            "error_message": str(error),
+                        },
+                    )
+                return
+            raise error
+        if isinstance(error, RateLimitError):
+            sleep_duration = self._config.backoff.rate_limit_sleep_s
+            if sleep_duration > 0:
+                time.sleep(sleep_duration)
+            return
+        if isinstance(error, RetryableError):
+            if isinstance(error, TimeoutError):
+                if not self._config.backoff.timeout_next_provider:
+                    raise error
+                return
+            if self._config.backoff.retryable_next_provider:
+                return
+            raise error
+        if isinstance(error, SkipError | ProviderSkip):
+            return
+        raise error
+
+    def finalize_and_raise(self) -> NoReturn:
+        event_logger = self._event_logger
+        if event_logger is not None:
+            event_logger.emit(
+                "provider_chain_failed",
+                {
+                    "request_fingerprint": self._context.request_fingerprint,
+                    "provider_attempts": self.attempt_count,
+                    "providers": [
+                        provider.name() for provider in self._runner.providers
+                    ],
+                    "last_error_type": (
+                        type(self._last_error).__name__ if self._last_error else None
+                    ),
+                    "last_error_message": (
+                        str(self._last_error) if self._last_error else None
+                    ),
+                    "last_error_family": error_family(self._last_error),
+                },
+            )
+        detail_text = "; ".join(
+            f"{item['provider']} (attempt {item['attempt']}): {item['summary']}"
+            for item in self._failure_details
+        )
+        message = "all providers failed"
+        if detail_text:
+            message = f"{message}: {detail_text}"
+        failure_error = AllFailedError(message, failures=self._failure_details)
+        metric_error = (
+            self._last_error if self._last_error is not None else failure_error
+        )
+        log_run_metric(
+            event_logger,
+            request_fingerprint=self._context.request_fingerprint,
+            request=self._context.request,
+            provider=None,
+            status="error",
+            attempts=self.attempt_count,
+            latency_ms=elapsed_ms(self._context.run_started),
+            tokens_in=None,
+            tokens_out=None,
+            cost_usd=0.0,
+            error=metric_error,
+            metadata=self._context.metadata,
+            shadow_used=self._context.shadow_used,
+        )
+        if self._last_error is not None:
+            raise failure_error from self._last_error
+        raise failure_error
+
+
+class SequentialStrategy:
+    def execute(
+        self, context: SyncRunContext
+    ) -> (
+        ProviderResponse | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+    ):
+        runner = context.runner
+        config = runner._config
+        max_attempts = config.max_attempts
+        tracker = _SequentialRunTracker(context)
+
+        for loop_index, provider in enumerate(runner.providers, start=1):
+            if max_attempts is not None and loop_index > max_attempts:
+                break
+            attempt_index = loop_index
+            tracker.record_attempt(attempt_index)
+            result = runner._invoke_provider_sync(
+                provider,
+                context.request,
+                attempt=attempt_index,
+                total_providers=len(runner.providers),
+                event_logger=context.event_logger,
+                request_fingerprint=context.request_fingerprint,
+                metadata=context.metadata,
+                shadow=context.shadow,
+                metrics_path=context.metrics_path,
+                capture_shadow_metrics=False,
+            )
+            response = tracker.handle_success(provider, attempt_index, result)
+            if response is not None:
+                return response
+
+            error = result.error
+            if error is None:
+                continue
+            tracker.handle_failure(provider, attempt_index, error)
+
+        tracker.finalize_and_raise()
+
+
+__all__ = ["_SequentialRunTracker", "SequentialStrategy"]

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -234,7 +234,7 @@ def test_sequential_strategy_all_failed_logs_once(monkeypatch: pytest.MonkeyPatc
         log_calls.append((args, kwargs))
 
     monkeypatch.setattr(
-        "src.llm_adapter.runner_sync_modes.log_run_metric",
+        "src.llm_adapter.runner_sync_sequential.log_run_metric",
         fake_log_run_metric,
     )
 

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sync_strategy_metrics.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sync_strategy_metrics.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+import time
+from typing import Any, cast, NamedTuple
+
+import pytest
+
+from src.llm_adapter.errors import AllFailedError, TimeoutError
+from src.llm_adapter.observability import CompositeLogger, EventLogger, JsonlLogger
+from src.llm_adapter.parallel_exec import (
+    ParallelAllResult,
+    ParallelExecutionError,
+    run_parallel_all_sync,
+    run_parallel_any_sync,
+)
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
+from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
+from src.llm_adapter.runner_shared import MetricsPath
+from src.llm_adapter.runner_sync import Runner
+from src.llm_adapter.runner_sync_invocation import ProviderInvocationResult
+from src.llm_adapter.runner_sync_modes import get_sync_strategy, SyncRunContext
+from src.llm_adapter.utils import content_hash
+
+from .test_runner_parallel import _read_metrics, _StaticProvider, RecordingLogger
+
+
+class _DelayedProvider(_StaticProvider):
+    def __init__(self, name: str, text: str, latency_ms: int, delay: float) -> None:
+        super().__init__(name, text, latency_ms)
+        self._delay = delay
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        time.sleep(self._delay)
+        return super().invoke(request)
+
+
+class _FailingProvider:
+    def __init__(self, name: str, error: Exception) -> None:
+        self._name = name
+        self._error = error
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:
+        raise self._error
+
+
+class _ExecutionResult(NamedTuple):
+    logger: RecordingLogger
+    metrics: list[dict[str, Any]]
+    result: (
+        ProviderResponse
+        | ProviderInvocationResult
+        | ParallelAllResult[ProviderInvocationResult, ProviderResponse]
+        | None
+    )
+    error: Exception | None
+
+
+def _build_context(
+    runner: Runner,
+    request: ProviderRequest,
+    *,
+    event_logger: EventLogger | None,
+    metrics_path: MetricsPath,
+) -> SyncRunContext:
+    request_fingerprint = content_hash(
+        "runner",
+        request.prompt_text,
+        request.options,
+        request.max_tokens,
+    )
+    mode_value = getattr(runner._config.mode, "value", str(runner._config.mode))
+    metadata = {
+        "run_id": request_fingerprint,
+        "mode": mode_value,
+        "providers": [provider.name() for provider in runner.providers],
+        "shadow_used": False,
+        "shadow_provider_id": None,
+    }
+    return SyncRunContext(
+        runner=runner,
+        request=request,
+        event_logger=event_logger,
+        metadata=metadata,
+        run_started=time.time(),
+        request_fingerprint=request_fingerprint,
+        shadow=None,
+        shadow_used=False,
+        metrics_path=str(metrics_path),
+        run_parallel_all=run_parallel_all_sync,
+        run_parallel_any=run_parallel_any_sync,
+    )
+
+
+def _execute_strategy(
+    mode: RunnerMode,
+    providers: Sequence[ProviderSPI],
+    *,
+    tmp_path: Path,
+    request: ProviderRequest,
+) -> _ExecutionResult:
+    metrics_path = tmp_path / f"{mode.value}-metrics.jsonl"
+    config = RunnerConfig(mode=mode, metrics_path=metrics_path)
+    recording_logger = RecordingLogger()
+    json_logger = JsonlLogger(metrics_path)
+    composite_logger = CompositeLogger((recording_logger, json_logger))
+    runner = Runner(providers, logger=composite_logger, config=config)
+    context = _build_context(
+        runner,
+        request,
+        event_logger=composite_logger,
+        metrics_path=metrics_path,
+    )
+    mode_enum = cast(RunnerMode, config.mode)
+    strategy = get_sync_strategy(mode_enum)
+
+    try:
+        result = strategy.execute(context)
+        error: Exception | None = None
+    except Exception as exc:  # pragma: no cover - exercised by error cases
+        result = None
+        error = exc
+
+    metrics = _read_metrics(metrics_path) if metrics_path.exists() else []
+    return _ExecutionResult(
+        logger=recording_logger, metrics=metrics, result=result, error=error
+    )
+
+
+def _run_metric_records_from_logger(logger: RecordingLogger) -> list[dict[str, Any]]:
+    return [
+        {
+            "provider": record.get("provider"),
+            "status": record.get("status"),
+            "attempts": record.get("attempts"),
+            "error_type": record.get("error_type"),
+        }
+        for record in logger.of_type("run_metric")
+    ]
+
+
+def _run_metric_records_from_metrics(
+    metrics: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "provider": record.get("provider"),
+            "status": record.get("status"),
+            "attempts": record.get("attempts"),
+            "error_type": record.get("error_type"),
+        }
+        for record in metrics
+        if record.get("event") == "run_metric"
+    ]
+
+
+def _sorted_records(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        records,
+        key=lambda item: (
+            "" if item["provider"] is None else str(item["provider"]),
+            item["attempts"],
+            item["status"],
+            item["error_type"] or "",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "providers_factory", "expected_statuses"),
+    [
+        (
+            RunnerMode.SEQUENTIAL,
+            lambda: [_StaticProvider("seq", "sequential-ok", latency_ms=3)],
+            [("seq", "ok", 1, None)],
+        ),
+        (
+            RunnerMode.PARALLEL_ANY,
+            lambda: [
+                _StaticProvider("fast", "fast-ok", latency_ms=2),
+                _DelayedProvider("slow", "slow-ok", latency_ms=10, delay=0.05),
+            ],
+            [
+                ("fast", "ok", 2, None),
+                ("slow", "ok", 2, None),
+            ],
+        ),
+        (
+            RunnerMode.PARALLEL_ALL,
+            lambda: [
+                _StaticProvider("all-a", "A", latency_ms=3),
+                _StaticProvider("all-b", "B", latency_ms=4),
+            ],
+            [
+                ("all-a", "ok", 1, None),
+                ("all-b", "ok", 2, None),
+            ],
+        ),
+    ],
+)
+def test_get_sync_strategy_happy_paths(
+    mode: RunnerMode,
+    providers_factory: Callable[[], Sequence[ProviderSPI]],
+    expected_statuses: Sequence[tuple[str, str, int, str | None]],
+    tmp_path: Path,
+) -> None:
+    request = ProviderRequest(prompt="hello", model="gpt-test")
+    result = _execute_strategy(
+        mode, providers_factory(), tmp_path=tmp_path, request=request
+    )
+
+    assert result.error is None
+    assert result.result is not None
+
+    logger_records = _sorted_records(_run_metric_records_from_logger(result.logger))
+    metrics_records = _sorted_records(_run_metric_records_from_metrics(result.metrics))
+    assert logger_records == metrics_records
+    expected_records = _sorted_records(
+        [
+            {
+                "provider": name,
+                "status": status,
+                "attempts": attempts,
+                "error_type": error_type,
+            }
+            for name, status, attempts, error_type in expected_statuses
+        ]
+    )
+    assert logger_records == expected_records
+
+
+@pytest.mark.parametrize(
+    ("mode", "providers_factory", "expected_error", "expected_statuses"),
+    [
+        (
+            RunnerMode.SEQUENTIAL,
+            lambda: [
+                _FailingProvider("seq-fail-1", TimeoutError("slow")),
+                _FailingProvider("seq-fail-2", TimeoutError("boom")),
+            ],
+            AllFailedError,
+            [(None, "error", 2, "TimeoutError")],
+        ),
+        (
+            RunnerMode.PARALLEL_ANY,
+            lambda: [
+                _FailingProvider("p-any-a", TimeoutError("slow")),
+                _FailingProvider("p-any-b", TimeoutError("boom")),
+            ],
+            ParallelExecutionError,
+            [
+                ("p-any-a", "error", 1, "TimeoutError"),
+                ("p-any-b", "error", 2, "TimeoutError"),
+            ],
+        ),
+        (
+            RunnerMode.PARALLEL_ALL,
+            lambda: [
+                _StaticProvider("all-ok", "ok", latency_ms=3),
+                _FailingProvider("all-fail", TimeoutError("boom")),
+            ],
+            TimeoutError,
+            [
+                ("all-ok", "ok", 1, None),
+                ("all-fail", "error", 2, "TimeoutError"),
+            ],
+        ),
+    ],
+)
+def test_get_sync_strategy_error_paths(
+    mode: RunnerMode,
+    providers_factory: Callable[[], Sequence[ProviderSPI]],
+    expected_error: type[Exception],
+    expected_statuses: Sequence[tuple[str | None, str, int, str | None]],
+    tmp_path: Path,
+) -> None:
+    request = ProviderRequest(prompt="[TIMEOUT] trigger", model="gpt-test")
+    result = _execute_strategy(
+        mode, providers_factory(), tmp_path=tmp_path, request=request
+    )
+
+    assert result.error is not None
+    assert isinstance(result.error, expected_error)
+    assert result.result is None
+
+    logger_records = _sorted_records(_run_metric_records_from_logger(result.logger))
+    metrics_records = _sorted_records(_run_metric_records_from_metrics(result.metrics))
+    assert logger_records == metrics_records
+    expected_records = _sorted_records(
+        [
+            {
+                "provider": name,
+                "status": status,
+                "attempts": attempts,
+                "error_type": error_type,
+            }
+            for name, status, attempts, error_type in expected_statuses
+        ]
+    )
+    assert logger_records == expected_records


### PR DESCRIPTION
## Summary
- add regression coverage ensuring `get_sync_strategy` records identical metrics across sequential and parallel sync modes using the existing mock runner fixtures
- extract the sequential sync tracker/strategy into a new `runner_sync_sequential` module and explicitly export it
- slim `runner_sync_modes` down to the shared context, parallel strategies, and strategy factory while re-exporting the sequential strategy

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter projects/04-llm-adapter-shadow/tests
- black projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py projects/04-llm-adapter-shadow/tests/test_runner_sync_strategy_metrics.py
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src/llm_adapter
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/tests/test_runner_sync_strategy_metrics.py
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sync_strategy_metrics.py


------
https://chatgpt.com/codex/tasks/task_e_68dc9bfc159483219f6238ae5f156037