### PR TITLE
Extract parallel logging helpers and add regression tests

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -1,25 +1,29 @@
 """Helpers for synchronous runner invocations."""
+
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
-from concurrent.futures import CancelledError
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import time
-from typing import cast, Literal, overload, Protocol
+from typing import cast, Literal, overload, Protocol, TYPE_CHECKING
 
 from .errors import ProviderSkip
 from .observability import EventLogger
 from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_shared import (
-    estimate_cost,
     log_provider_call,
     log_provider_skipped,
-    log_run_metric,
     MetricsPath,
     RateLimiter,
 )
 from .shadow import DEFAULT_METRICS_PATH, run_with_shadow, ShadowMetrics
 from .utils import elapsed_ms
+
+if TYPE_CHECKING:
+    from .runner_sync_parallel_logging import (
+        CancelledResultsBuilder as _CancelledResultsBuilderType,
+        ParallelResultLogger as _ParallelResultLoggerType,
+    )
 
 
 class _RunWithShadowCallable(Protocol):
@@ -33,8 +37,7 @@ class _RunWithShadowCallable(Protocol):
         *,
         logger: EventLogger | None = None,
         capture_metrics: Literal[True],
-    ) -> tuple[ProviderResponse, ShadowMetrics | None]:
-        ...
+    ) -> tuple[ProviderResponse, ShadowMetrics | None]: ...
 
     @overload
     def __call__(
@@ -46,8 +49,7 @@ class _RunWithShadowCallable(Protocol):
         *,
         logger: EventLogger | None = None,
         capture_metrics: Literal[False] = False,
-    ) -> ProviderResponse:
-        ...
+    ) -> ProviderResponse: ...
 
     def __call__(
         self,
@@ -58,8 +60,7 @@ class _RunWithShadowCallable(Protocol):
         *,
         logger: EventLogger | None = None,
         capture_metrics: bool = False,
-    ) -> ProviderResponse | tuple[ProviderResponse, ShadowMetrics | None]:
-        ...
+    ) -> ProviderResponse | tuple[ProviderResponse, ShadowMetrics | None]: ...
 
 
 _DEFAULT_RUN_WITH_SHADOW = cast(_RunWithShadowCallable, run_with_shadow)
@@ -190,148 +191,21 @@ class ProviderInvoker:
         )
 
 
-class CancelledResultsBuilder:
-    """Construct cancelled results for providers that never executed."""
+def _load_parallel_logging() -> tuple[
+    type[_CancelledResultsBuilderType],
+    type[_ParallelResultLoggerType],
+]:
+    from .runner_sync_parallel_logging import (
+        CancelledResultsBuilder as _CancelledResultsBuilder,
+        ParallelResultLogger as _ParallelResultLogger,
+    )
 
-    def __init__(
-        self,
-        *,
-        run_started: float,
-        elapsed_ms: Callable[[float], int] = elapsed_ms,
-    ) -> None:
-        self._run_started = run_started
-        self._elapsed_ms = elapsed_ms
-
-    def build(
-        self,
-        *,
-        provider: ProviderSPI,
-        attempt: int,
-        total_providers: int,
-    ) -> ProviderInvocationResult:
-        latency_ms = self._elapsed_ms(self._run_started)
-        return ProviderInvocationResult(
-            provider=provider,
-            attempt=attempt,
-            total_providers=total_providers,
-            response=None,
-            error=CancelledError(),
-            latency_ms=latency_ms,
-            tokens_in=None,
-            tokens_out=None,
-            shadow_metrics=None,
-            shadow_metrics_extra=None,
-            provider_call_logged=False,
-        )
-
-    def apply(
-        self,
-        results: list[ProviderInvocationResult | None],
-        *,
-        providers: Sequence[ProviderSPI],
-        cancelled_indices: Sequence[int],
-        total_providers: int,
-    ) -> None:
-        for index in cancelled_indices:
-            if index < 0 or index >= len(providers):
-                continue
-            if index >= len(results):
-                continue
-            if results[index] is not None:
-                continue
-            provider = providers[index]
-            results[index] = self.build(
-                provider=provider,
-                attempt=index + 1,
-                total_providers=total_providers,
-            )
+    return _CancelledResultsBuilder, _ParallelResultLogger
 
 
-class ParallelResultLogger:
-    """Emit provider call and metric events for parallel execution results."""
-
-    def __init__(
-        self,
-        *,
-        log_provider_call: Callable[..., None] = log_provider_call,
-        log_run_metric: Callable[..., None] = log_run_metric,
-        estimate_cost: Callable[[object, int, int], float] = estimate_cost,
-        elapsed_ms: Callable[[float], int] = elapsed_ms,
-    ) -> None:
-        self._log_provider_call = log_provider_call
-        self._log_run_metric = log_run_metric
-        self._estimate_cost = estimate_cost
-        self._elapsed_ms = elapsed_ms
-
-    def log_results(
-        self,
-        results: Sequence[ProviderInvocationResult | None],
-        *,
-        event_logger: EventLogger | None,
-        request: ProviderRequest,
-        request_fingerprint: str,
-        metadata: Mapping[str, object],
-        run_started: float,
-        shadow_used: bool,
-        skip: tuple[ProviderInvocationResult, ...] | None = None,
-        attempts_override: Mapping[int, int] | None = None,
-    ) -> None:
-        skipped = skip or ()
-        attempts_map = dict(attempts_override or {})
-        for result in results:
-            if result is None:
-                continue
-            if result.shadow_metrics is not None:
-                result.shadow_metrics.emit(result.shadow_metrics_extra)
-            if any(result is skipped_result for skipped_result in skipped):
-                continue
-            status = "ok" if result.response is not None else "error"
-            if status == "ok":
-                tokens_in = result.tokens_in if result.tokens_in is not None else 0
-                tokens_out = result.tokens_out if result.tokens_out is not None else 0
-                cost_usd = self._estimate_cost(result.provider, tokens_in, tokens_out)
-                error_for_metric: Exception | None = None
-            else:
-                tokens_in = None
-                tokens_out = None
-                cost_usd = 0.0
-                error_for_metric = result.error
-            latency_ms = result.latency_ms
-            if latency_ms is None:
-                latency_ms = self._elapsed_ms(run_started)
-            if not result.provider_call_logged:
-                self._log_provider_call(
-                    event_logger,
-                    request_fingerprint=request_fingerprint,
-                    provider=result.provider,
-                    request=request,
-                    attempt=result.attempt,
-                    total_providers=result.total_providers,
-                    status=status,
-                    latency_ms=latency_ms,
-                    tokens_in=tokens_in,
-                    tokens_out=tokens_out,
-                    error=error_for_metric,
-                    metadata=metadata,
-                    shadow_used=shadow_used,
-                )
-                result.provider_call_logged = True
-            attempts_value = attempts_map.get(result.attempt, result.attempt)
-            self._log_run_metric(
-                event_logger,
-                request_fingerprint=request_fingerprint,
-                request=request,
-                provider=result.provider,
-                status=status,
-                attempts=attempts_value,
-                latency_ms=latency_ms,
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                cost_usd=cost_usd,
-                error=error_for_metric,
-                metadata=metadata,
-                shadow_used=shadow_used,
-            )
+CancelledResultsBuilder: type[_CancelledResultsBuilderType]
+ParallelResultLogger: type[_ParallelResultLoggerType]
+CancelledResultsBuilder, ParallelResultLogger = _load_parallel_logging()
 
 
 __all__ = [
@@ -340,4 +214,3 @@ __all__ = [
     "CancelledResultsBuilder",
     "ParallelResultLogger",
 ]
-

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_logging.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_logging.py
@@ -1,0 +1,162 @@
+"""Helpers for logging parallel synchronous provider execution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import CancelledError
+
+from .observability import EventLogger
+from .provider_spi import ProviderRequest, ProviderSPI
+from .runner_shared import estimate_cost, log_provider_call, log_run_metric
+from .runner_sync_invocation import ProviderInvocationResult
+from .utils import elapsed_ms
+
+
+class CancelledResultsBuilder:
+    """Construct cancelled results for providers that never executed."""
+
+    def __init__(
+        self,
+        *,
+        run_started: float,
+        elapsed_ms: Callable[[float], int] = elapsed_ms,
+    ) -> None:
+        self._run_started = run_started
+        self._elapsed_ms = elapsed_ms
+
+    def build(
+        self,
+        *,
+        provider: ProviderSPI,
+        attempt: int,
+        total_providers: int,
+    ) -> ProviderInvocationResult:
+        latency_ms = self._elapsed_ms(self._run_started)
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=None,
+            error=CancelledError(),
+            latency_ms=latency_ms,
+            tokens_in=None,
+            tokens_out=None,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=False,
+        )
+
+    def apply(
+        self,
+        results: list[ProviderInvocationResult | None],
+        *,
+        providers: Sequence[ProviderSPI],
+        cancelled_indices: Sequence[int],
+        total_providers: int,
+    ) -> None:
+        for index in cancelled_indices:
+            if index < 0 or index >= len(providers):
+                continue
+            if index >= len(results):
+                continue
+            if results[index] is not None:
+                continue
+            provider = providers[index]
+            results[index] = self.build(
+                provider=provider,
+                attempt=index + 1,
+                total_providers=total_providers,
+            )
+
+
+class ParallelResultLogger:
+    """Emit provider call and metric events for parallel execution results."""
+
+    def __init__(
+        self,
+        *,
+        log_provider_call: Callable[..., None] = log_provider_call,
+        log_run_metric: Callable[..., None] = log_run_metric,
+        estimate_cost: Callable[[object, int, int], float] = estimate_cost,
+        elapsed_ms: Callable[[float], int] = elapsed_ms,
+    ) -> None:
+        self._log_provider_call = log_provider_call
+        self._log_run_metric = log_run_metric
+        self._estimate_cost = estimate_cost
+        self._elapsed_ms = elapsed_ms
+
+    def log_results(
+        self,
+        results: Sequence[ProviderInvocationResult | None],
+        *,
+        event_logger: EventLogger | None,
+        request: ProviderRequest,
+        request_fingerprint: str,
+        metadata: Mapping[str, object],
+        run_started: float,
+        shadow_used: bool,
+        skip: tuple[ProviderInvocationResult, ...] | None = None,
+        attempts_override: Mapping[int, int] | None = None,
+    ) -> None:
+        skipped = skip or ()
+        attempts_map = dict(attempts_override or {})
+        for result in results:
+            if result is None:
+                continue
+            if result.shadow_metrics is not None:
+                result.shadow_metrics.emit(result.shadow_metrics_extra)
+            if any(result is skipped_result for skipped_result in skipped):
+                continue
+            status = "ok" if result.response is not None else "error"
+            if status == "ok":
+                tokens_in = result.tokens_in if result.tokens_in is not None else 0
+                tokens_out = result.tokens_out if result.tokens_out is not None else 0
+                cost_usd = self._estimate_cost(result.provider, tokens_in, tokens_out)
+                error_for_metric: Exception | None = None
+            else:
+                tokens_in = None
+                tokens_out = None
+                cost_usd = 0.0
+                error_for_metric = result.error
+            latency_ms = result.latency_ms
+            if latency_ms is None:
+                latency_ms = self._elapsed_ms(run_started)
+            if not result.provider_call_logged:
+                self._log_provider_call(
+                    event_logger,
+                    request_fingerprint=request_fingerprint,
+                    provider=result.provider,
+                    request=request,
+                    attempt=result.attempt,
+                    total_providers=result.total_providers,
+                    status=status,
+                    latency_ms=latency_ms,
+                    tokens_in=tokens_in,
+                    tokens_out=tokens_out,
+                    error=error_for_metric,
+                    metadata=metadata,
+                    shadow_used=shadow_used,
+                )
+                result.provider_call_logged = True
+            attempts_value = attempts_map.get(result.attempt, result.attempt)
+            self._log_run_metric(
+                event_logger,
+                request_fingerprint=request_fingerprint,
+                request=request,
+                provider=result.provider,
+                status=status,
+                attempts=attempts_value,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=cost_usd,
+                error=error_for_metric,
+                metadata=metadata,
+                shadow_used=shadow_used,
+            )
+
+
+__all__ = [
+    "CancelledResultsBuilder",
+    "ParallelResultLogger",
+]

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping, Sequence
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 import json
 from pathlib import Path
 import threading
@@ -33,6 +33,11 @@ from src.llm_adapter.runner_parallel import (
     ConsensusConfig,
 )
 from src.llm_adapter.runner_sync import Runner
+from src.llm_adapter.runner_sync_invocation import (
+    CancelledResultsBuilder,
+    ParallelResultLogger,
+    ProviderInvocationResult,
+)
 from src.llm_adapter.shadow import run_with_shadow
 
 
@@ -204,6 +209,142 @@ def test_run_parallel_any_sync_cancels_pending_futures(
     assert executor.submitted[2] in cancelled_futures
 
     slow_gate.set()
+
+
+def test_cancelled_results_builder_populates_cancelled_slots() -> None:
+    run_started = 100.0
+    builder = CancelledResultsBuilder(run_started=run_started, elapsed_ms=lambda _: 42)
+    providers = [
+        _StaticProvider("cancel-a", text="unused", latency_ms=1),
+        _StaticProvider("cancel-b", text="unused", latency_ms=1),
+    ]
+    results: list[ProviderInvocationResult | None] = [None, None]
+
+    builder.apply(
+        results,
+        providers=providers,
+        cancelled_indices=(0, 1),
+        total_providers=len(providers),
+    )
+
+    for index, result in enumerate(results, start=1):
+        assert result is not None
+        assert result.provider.name() == providers[index - 1].name()
+        assert isinstance(result.error, CancelledError)
+        assert result.latency_ms == 42
+        assert result.provider_call_logged is False
+        assert result.attempt == index
+        assert result.total_providers == len(providers)
+
+
+def test_parallel_result_logger_skips_and_avoids_duplicate_logging() -> None:
+    provider = _StaticProvider("logger", text="ok", latency_ms=5)
+    request = ProviderRequest(prompt="hello", model="m")
+    metadata: dict[str, object] = {"trace": "abc"}
+    request_fingerprint = "fingerprint"
+    shadow_used = False
+    run_started = 0.0
+    elapsed_calls: list[float] = []
+
+    def _elapsed(_: float) -> int:
+        elapsed_calls.append(1.0)
+        return 99
+
+    provider_call_log: list[dict[str, object]] = []
+    run_metric_log: list[dict[str, object]] = []
+
+    def _log_provider_call(event_logger: object, **record: object) -> None:
+        provider_call_log.append(record)
+
+    def _log_run_metric(event_logger: object, **record: object) -> None:
+        run_metric_log.append(record)
+
+    success_result = ProviderInvocationResult(
+        provider=provider,
+        attempt=2,
+        total_providers=3,
+        response=ProviderResponse(
+            text="done",
+            latency_ms=7,
+            token_usage=TokenUsage(prompt=1, completion=2),
+            model="m",
+            finish_reason="stop",
+        ),
+        error=None,
+        latency_ms=7,
+        tokens_in=1,
+        tokens_out=2,
+        shadow_metrics=None,
+        shadow_metrics_extra=None,
+        provider_call_logged=False,
+    )
+    skipped_result = ProviderInvocationResult(
+        provider=provider,
+        attempt=1,
+        total_providers=3,
+        response=None,
+        error=CancelledError(),
+        latency_ms=None,
+        tokens_in=None,
+        tokens_out=None,
+        shadow_metrics=None,
+        shadow_metrics_extra=None,
+        provider_call_logged=False,
+    )
+    already_logged_result = ProviderInvocationResult(
+        provider=provider,
+        attempt=3,
+        total_providers=3,
+        response=None,
+        error=TimeoutError("boom"),
+        latency_ms=None,
+        tokens_in=None,
+        tokens_out=None,
+        shadow_metrics=None,
+        shadow_metrics_extra=None,
+        provider_call_logged=True,
+    )
+
+    logger = ParallelResultLogger(
+        log_provider_call=_log_provider_call,
+        log_run_metric=_log_run_metric,
+        elapsed_ms=_elapsed,
+    )
+
+    logger.log_results(
+        [skipped_result, success_result, already_logged_result],
+        event_logger=None,
+        request=request,
+        request_fingerprint=request_fingerprint,
+        metadata=metadata,
+        run_started=run_started,
+        shadow_used=shadow_used,
+        skip=(skipped_result,),
+    )
+
+    assert provider_call_log == [
+        {
+            "request_fingerprint": request_fingerprint,
+            "provider": provider,
+            "request": request,
+            "attempt": success_result.attempt,
+            "total_providers": success_result.total_providers,
+            "status": "ok",
+            "latency_ms": success_result.latency_ms,
+            "tokens_in": success_result.tokens_in,
+            "tokens_out": success_result.tokens_out,
+            "error": None,
+            "metadata": metadata,
+            "shadow_used": shadow_used,
+        }
+    ]
+    assert len(run_metric_log) == 2
+    attempts = {entry["attempts"] for entry in run_metric_log}
+    assert attempts == {success_result.attempt, already_logged_result.attempt}
+    assert skipped_result.provider_call_logged is False
+    assert success_result.provider_call_logged is True
+    assert already_logged_result.provider_call_logged is True
+    assert elapsed_calls == [1.0]
 
 
 def test_parallel_primitives(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add regression coverage for cancelled result building and skip logging cases in the parallel runner tests
- factor CancelledResultsBuilder and ParallelResultLogger into a new runner_sync_parallel_logging module and lazy-load them from runner_sync_invocation to keep the public API stable

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_logging.py
- black projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_logging.py
- mypy --strict projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_logging.py *(fails with pre-existing issues in unrelated modules)*
- pytest projects/04-llm-adapter-shadow/tests/test_runner_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68dca70253a883218e27d647c39eb770