### PR TITLE
Add ParallelExecutionError to adapter core errors

### DIFF
--- a/projects/04-llm-adapter/adapter/core/errors.py
+++ b/projects/04-llm-adapter/adapter/core/errors.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any, Iterable
 
 
 class AdapterError(Exception):
@@ -76,6 +77,21 @@ class AllFailedError(FatalError):
     """Raised when all providers fail to produce a result."""
 
 
+class ParallelExecutionError(FatalError):
+    """Raised when a parallel execution encounters multiple failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failures: Iterable[Any] | None = None,
+        batch: Any | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failures = list(failures) if failures is not None else None
+        self.batch = batch
+
+
 __all__ = [
     "AdapterError",
     "RetryableError",
@@ -89,4 +105,5 @@ __all__ = [
     "SkipReason",
     "ConfigError",
     "AllFailedError",
+    "ParallelExecutionError",
 ]

--- a/projects/04-llm-adapter/tests/test_errors.py
+++ b/projects/04-llm-adapter/tests/test_errors.py
@@ -1,0 +1,20 @@
+"""Tests for adapter.core.errors module."""
+from __future__ import annotations
+
+import importlib
+
+
+def test_parallel_execution_error_exports_and_attrs() -> None:
+    module = importlib.import_module("adapter.core.errors")
+
+    assert hasattr(module, "ParallelExecutionError")
+
+    error = module.ParallelExecutionError(
+        "parallel execution failed",
+        failures=[{"id": 1, "error": "timeout"}],
+        batch={"job": "test"},
+    )
+
+    assert error.failures == [{"id": 1, "error": "timeout"}]
+    assert error.batch == {"job": "test"}
+    assert str(error) == "parallel execution failed"


### PR DESCRIPTION
## Summary
- add a regression test to ensure `ParallelExecutionError` is exported from `adapter.core.errors` and preserves failure metadata
- implement `ParallelExecutionError` so that it captures failure summaries and batch context

## Testing
- pytest projects/04-llm-adapter/tests/test_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68dca6ff55f08321bfe7436992a2d3de