### PR TITLE
Ensure tie break reason is validated before substring checks

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -256,7 +256,9 @@ def test_default_tie_break_order() -> None:
         assert result.response.text == expected
         assert result.tie_break_applied is True
         assert result.tie_breaker_selected == tie_breaker
-        assert fragment in result.tie_break_reason
+        tie_break_reason = result.tie_break_reason
+        assert tie_break_reason is not None
+        assert fragment in tie_break_reason
 
 
 def test_stable_order_makes_tie_resolution_deterministic() -> None:


### PR DESCRIPTION
## Summary
- ensure the consensus tie-break tests capture the reason before substring checks and validate it is present

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/tests/test_runner_consensus.py *(fails: existing arg-type errors unrelated to the new assertion change)*

------
https://chatgpt.com/codex/tasks/task_e_68dcadd1b4a08321997ae73d421047be