### PR TITLE
Add RunnerConfig metrics path normalization test

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -115,6 +115,9 @@ class RunnerConfig:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "mode", _normalize_mode(self.mode))
+        object.__setattr__(self, "schema", _resolve_optional_path(self.schema))
+        object.__setattr__(self, "judge", _resolve_optional_path(self.judge))
+        object.__setattr__(self, "metrics_path", _resolve_optional_path(self.metrics_path))
 
 
 def default_budgets_path() -> Path:

--- a/projects/04-llm-adapter/tests/test_runner_config_paths.py
+++ b/projects/04-llm-adapter/tests/test_runner_config_paths.py
@@ -1,0 +1,13 @@
+"""RunnerConfig path normalization tests."""
+
+from pathlib import Path
+
+from adapter.core.runner_api import RunnerConfig
+
+
+def test_metrics_path_accepts_str_and_normalizes_to_path() -> None:
+    config = RunnerConfig(mode="sequential", metrics_path="runs.jsonl")
+
+    expected = Path("runs.jsonl").expanduser().resolve()
+    assert config.metrics_path == expected
+    assert isinstance(config.metrics_path, Path)


### PR DESCRIPTION
## Summary
- add a regression test ensuring RunnerConfig normalizes string metrics paths
- normalize schema, judge, and metrics_path fields via `_resolve_optional_path` during RunnerConfig initialization

## Testing
- pytest projects/04-llm-adapter/tests/test_runner_config_paths.py


------
https://chatgpt.com/codex/tasks/task_e_68dcbf2937b083218aeb2110a9eb5e7a