### PR TITLE
Handle optional jsonschema dependency

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
+++ b/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+ADAPTER_PATH = PROJECT_ROOT / "04-llm-adapter"
+GUARDS_PATH = ADAPTER_PATH / "adapter" / "core" / "execution" / "guards.py"
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_schema_validator_imports_without_jsonschema(monkeypatch: pytest.MonkeyPatch) -> None:
+    module_name = "_guards_missing_jsonschema"
+    sys.modules.pop(module_name, None)
+
+    path_finder = importlib.machinery.PathFinder
+
+    def _fake_find_spec(name: str, *args: object, **kwargs: object):
+        if name == "jsonschema":
+            return None
+        return path_finder.find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+    spec = importlib.util.spec_from_file_location(module_name, GUARDS_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    validator = module._SchemaValidator(None)
+    validator.validate("  ")
+


### PR DESCRIPTION
## Summary
- provide a graceful fallback in `adapter.core.execution.guards` when `jsonschema` is not installed
- add a regression test ensuring `_SchemaValidator` can be imported without the optional dependency

## Testing
- pytest -vv -s --maxfail=1 --durations=20 --disable-socket projects/04-llm-adapter-shadow/tests


------
https://chatgpt.com/codex/tasks/task_e_68dcd1204c7083218c643d3769bd50a0