### PR TITLE
Sort jsonschema imports in guard module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/guards.py
+++ b/projects/04-llm-adapter/adapter/core/execution/guards.py
@@ -6,8 +6,8 @@ import json
 from pathlib import Path
 from threading import Lock
 from time import perf_counter, sleep
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 _jsonschema_spec = importlib.util.find_spec("jsonschema")
 if _jsonschema_spec is None:
@@ -37,9 +37,7 @@ if _jsonschema_spec is None:
     jsonschema_exceptions = SimpleNamespace(ValidationError=_MissingValidationError)
     validators = SimpleNamespace(validator_for=_validator_for)
 else:
-    from jsonschema import exceptions as jsonschema_exceptions
-    from jsonschema import validators
-
+    from jsonschema import exceptions as jsonschema_exceptions, validators
 
 class _TokenBucket:
     def __init__(self, rpm: int | None) -> None:


### PR DESCRIPTION
## Summary
- consolidate the conditional jsonschema imports into a single, alphabetized statement
- ensure the module-level imports are sorted according to Ruff's expectations

## Testing
- ruff check projects/04-llm-adapter/adapter/core/execution/guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd7710de08321b47e91742ab3f5e6