### PR TITLE
Sort imports in execution guards test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
+++ b/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
-import sys
 from pathlib import Path
+import sys
 
 import pytest
-
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 ADAPTER_PATH = PROJECT_ROOT / "04-llm-adapter"


### PR DESCRIPTION
## Summary
- reorder standard library imports in the execution guard test to be alphabetical
- tidy spacing between the standard library and pytest imports to satisfy isort

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd75a966483219f17141e5bc0d708