### PR TITLE
chore: sort imports in consensus runner test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -14,9 +14,9 @@ from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 import src.llm_adapter.runner_parallel as runner_parallel
 from src.llm_adapter.runner_parallel import (
+    compute_consensus,
     ConsensusObservation,
     ConsensusResult,
-    compute_consensus,
 )
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 


### PR DESCRIPTION
## Summary
- reorder the test imports in `test_runner_consensus.py` to follow the project ruff/isort configuration

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_consensus.py


------
https://chatgpt.com/codex/tasks/task_e_68dcd75a886c83218758b380c30ec22b