### PR TITLE
Handle tuple responses in shadow async tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_shadow_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow_async.py
@@ -69,6 +69,9 @@ async def test_run_with_shadow_async_success_records_metrics(tmp_path: Path) -> 
         metrics_path=metrics_path,
     )
 
+    if isinstance(response, tuple):
+        response, _ = response
+
     assert response.text == "primary"
     assert metrics_path.exists()
 
@@ -125,6 +128,9 @@ async def test_run_with_shadow_async_timeout_records_timeout(
         metrics_path=metrics_path,
     )
 
+    if isinstance(response, tuple):
+        response, _ = response
+
     assert response.text == "primary"
     assert metrics_path.exists()
 
@@ -160,6 +166,9 @@ async def test_run_with_shadow_async_records_shadow_error(tmp_path: Path) -> Non
         request,
         metrics_path=metrics_path,
     )
+
+    if isinstance(response, tuple):
+        response, _ = response
 
     assert response.text == "primary"
     assert metrics_path.exists()


### PR DESCRIPTION
## Summary
- unwrap tuple responses returned by run_with_shadow_async in async shadow tests before accessing response fields

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/tests/test_shadow_async.py
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68dcd7bf70008321be7401147d73f574