### PR TITLE
Add stream recording to FakeSession

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -56,8 +56,19 @@ class FakeResponse:
 
 
 class FakeSession:
+    class _CallRecorder(list[tuple[str, dict[str, Any] | None, bool]]):
+        def __init__(self, session: "FakeSession") -> None:
+            super().__init__()
+            self._session = session
+
+        def append(self, call: tuple[str, dict[str, Any] | None, bool]) -> None:
+            _, _, stream = call
+            self._session.last_stream = stream
+            super().append(call)
+
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any] | None, bool]] = []
+        self.last_stream: bool | None = None
+        self.calls: list[tuple[str, dict[str, Any] | None, bool]] = self._CallRecorder(self)
         self._show_calls = 0
 
     def post(

--- a/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py
@@ -156,6 +156,7 @@ def test_ollama_provider_merges_request_options() -> None:
     )
     assert chat_payload is not None
     assert chat_payload["stream"] is True
+    assert session.last_stream is True
     assert chat_payload["model"] == "gemma3"
     options_payload = chat_payload["options"]
     assert options_payload["num_predict"] == 32


### PR DESCRIPTION
## Summary
- extend FakeSession so that test doubles record the last stream argument received
- tighten the Ollama provider merge options test to require stream=True be passed through

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py::test_ollama_provider_merges_request_options

------
https://chatgpt.com/codex/tasks/task_e_68dd0ce5bf10832181957bb26d4d5155