### PR TITLE
Add OTLP metrics exporter

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+ScopeAttrs = list[dict[str, Any]]
+def _timestamp_ns(value: Any) -> str:
+    return str(int(float(value) * 1_000_000)) if isinstance(value, (int, float)) else "0"
+
+
+def _encode_attrs(values: Mapping[str, Any]) -> ScopeAttrs:
+    attrs: ScopeAttrs = []
+    for key, raw in values.items():
+        if raw is None:
+            continue
+        if isinstance(raw, bool):
+            value: dict[str, Any] = {"boolValue": raw}
+        elif isinstance(raw, int) and not isinstance(raw, bool):
+            value = {"intValue": str(raw)}
+        elif isinstance(raw, float):
+            value = {"doubleValue": raw}
+        else:
+            value = {"stringValue": str(raw)}
+        attrs.append({"key": str(key), "value": value})
+    return attrs
+def _gauge(name: str, timestamp: str, value: float, attrs: ScopeAttrs) -> dict[str, Any]:
+    return {
+        "name": name,
+        "gauge": {"dataPoints": [{"timeUnixNano": timestamp, "asDouble": value, "attributes": attrs}]},
+    }
+
+
+class OtlpJsonExporter:
+    _SCOPE = {"name": "llm-adapter.metrics"}
+    def __init__(
+        self,
+        emit: Callable[[dict[str, Any]], None],
+        *,
+        service_name: str = "llm-adapter",
+        resource_attributes: Mapping[str, Any] | None = None,
+    ) -> None:
+        attrs: dict[str, Any] = {"service.name": service_name}
+        if resource_attributes:
+            attrs.update(resource_attributes)
+        self._emit = emit
+        self._resource = {"attributes": _encode_attrs(attrs)}
+
+    def handle_event(self, event_type: str, record: Mapping[str, Any]) -> None:
+        if event_type not in {"provider_call", "run_metric"}:
+            return
+        timestamp = _timestamp_ns(record.get("ts"))
+        attrs = _encode_attrs({k: v for k, v in record.items() if k not in {"ts", "event"}})
+        log_record = {
+            "timeUnixNano": timestamp,
+            "observedTimeUnixNano": timestamp,
+            "severityText": event_type,
+            "body": {"stringValue": event_type},
+            "attributes": attrs,
+        }
+        payload: dict[str, Any] = {
+            "resourceLogs": [
+                {
+                    "resource": self._resource,
+                    "scopeLogs": [{"scope": self._SCOPE, "logRecords": [log_record]}],
+                }
+            ]
+        }
+        metrics = self._metrics(event_type, record, timestamp, attrs)
+        if metrics:
+            payload["resourceMetrics"] = [
+                {
+                    "resource": self._resource,
+                    "scopeMetrics": [{"scope": self._SCOPE, "metrics": metrics}],
+                }
+            ]
+        self._emit(payload)
+
+    def _metrics(
+        self,
+        event_type: str,
+        record: Mapping[str, Any],
+        timestamp: str,
+        attrs: ScopeAttrs,
+    ) -> list[dict[str, Any]]:
+        numeric_fields = {
+            "provider_call": ("latency_ms", "tokens_in", "tokens_out"),
+            "run_metric": ("latency_ms", "tokens_in", "tokens_out", "cost_usd"),
+        }
+        fields = numeric_fields.get(event_type)
+        if fields is None:
+            return []
+        metrics = [_gauge(f"llm_adapter.{event_type}.count", timestamp, 1.0, attrs)]
+        prefix = f"llm_adapter.{event_type}."
+        for field in fields:
+            value = record.get(field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                metrics.append(_gauge(prefix + field, timestamp, float(value), attrs))
+        return metrics

--- a/projects/04-llm-adapter-shadow/tests/test_metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_otlp.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.llm_adapter.metrics_otlp import OtlpJsonExporter
+
+
+def _collect(event: str, record: dict[str, Any]) -> dict[str, Any]:
+    sink: list[dict[str, Any]] = []
+    OtlpJsonExporter(sink.append, resource_attributes={"deployment.environment": "test"}).handle_event(event, record)
+    assert sink
+    return sink[-1]
+
+
+def _attr(items: list[dict[str, Any]], key: str) -> dict[str, Any]:
+    return next(item["value"] for item in items if item["key"] == key)
+
+
+def _metric(payload: dict[str, Any], name: str) -> dict[str, Any]:
+    metrics = payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+    return next(metric for metric in metrics if metric["name"] == name)
+
+
+def test_otlp_payloads_cover_provider_and_run_metrics() -> None:
+    provider_record: dict[str, Any] = {
+        "ts": 1_700_000_000_000,
+        "provider": "primary",
+        "status": "success",
+        "latency_ms": 42,
+        "tokens_in": 10,
+        "tokens_out": 20,
+        "shadow_used": True,
+    }
+    payload = _collect("provider_call", provider_record)
+    attrs = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+    assert _attr(attrs, "provider")["stringValue"] == "primary"
+    assert _attr(attrs, "status")["stringValue"] == "success"
+    latency = _metric(payload, "llm_adapter.provider_call.latency_ms")["gauge"]["dataPoints"][0]
+    assert pytest.approx(latency["asDouble"], rel=1e-6) == 42.0
+
+    run_record = {
+        "ts": 1_700_000_000_500,
+        "provider": "primary",
+        "status": "success",
+        "attempts": 2,
+        "latency_ms": 123,
+        "tokens_in": 50,
+        "tokens_out": 60,
+        "cost_usd": 0.25,
+        "shadow_used": False,
+    }
+    payload = _collect("run_metric", run_record)
+    attrs = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+    assert _attr(attrs, "attempts")["intValue"] == "2"
+    assert _attr(attrs, "shadow_used")["boolValue"] is False
+    cost = _metric(payload, "llm_adapter.run_metric.cost_usd")["gauge"]["dataPoints"][0]
+    assert pytest.approx(cost["asDouble"], rel=1e-6) == 0.25


### PR DESCRIPTION
## Summary
- add an OTLP JSON exporter that converts provider and run metrics into OTLP log and metric payloads
- add regression coverage that verifies provider_call and run_metric events are exported correctly

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_metrics_otlp.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd0cea94d4832199c2abc703e09e10