### PR TITLE
Add weekly shadow summary generator

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama.py
@@ -212,8 +212,10 @@ class OllamaProvider(BaseProvider):
         if options_payload:
             payload["options"] = {**options_payload, **payload.get("options", {})}
 
+        stream_flag = bool(payload.get("stream"))
+
         ts0 = time.time()
-        response = self._client.chat(payload, timeout=timeout_override)
+        response = self._client.chat(payload, timeout=timeout_override, stream=stream_flag)
 
         try:
             payload_json = response.json()

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -122,10 +122,11 @@ class OllamaClient:
         payload: Mapping[str, object],
         *,
         timeout: float | None = None,
+        stream: bool = False,
     ) -> ResponseProtocol:
         return self._ensure_success(
             "/api/chat",
-            self._post("/api/chat", payload, timeout=timeout),
+            self._post("/api/chat", payload, stream=stream, timeout=timeout),
         )
 
     def _post(

--- a/projects/04-llm-adapter-shadow/tests/tools/test_weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tests/tools/test_weekly_summary.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def test_weekly_summary_generates_expected_markdown(tmp_path: Path) -> None:
+    input_path = tmp_path / "runs-metrics.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "event": "shadow_diff",
+                "shadow_provider": "shadow-a",
+                "shadow_outcome": "success",
+                "shadow_latency_ms": 1200,
+            },
+            {
+                "event": "shadow_diff",
+                "shadow_provider": "shadow-a",
+                "shadow_outcome": "success",
+                "shadow_latency_ms": 1400,
+            },
+            {
+                "event": "shadow_diff",
+                "shadow_provider": "shadow-a",
+                "shadow_outcome": "error",
+                "shadow_latency_ms": 1800,
+            },
+            {
+                "event": "shadow_diff",
+                "shadow_provider": "shadow-b",
+                "shadow_outcome": "success",
+                "shadow_latency_ms": 800,
+            },
+            {
+                "event": "shadow_diff",
+                "shadow_provider": "shadow-b",
+                "shadow_outcome": "success",
+                "shadow_latency_ms": 900,
+            },
+        ],
+    )
+
+    prev_path = tmp_path / "prev.md"
+    prev_path.write_text(
+        dedent(
+            """
+            # Weekly Shadow Summary
+
+            | Provider | Failure Rate | Δ vs Prev | P95 Latency (ms) |
+            | --- | --- | --- | --- |
+            | shadow-a | 20.0% | n/a | 1000 |
+            | shadow-b | 40.0% | n/a | 1500 |
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    output_path = tmp_path / "weekly-summary.md"
+
+    project_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.weekly_summary",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--prev",
+            str(prev_path),
+        ],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    expected = (
+        "# Weekly Shadow Summary\n\n"
+        "| Provider | Failure Rate | Δ vs Prev | P95 Latency (ms) |\n"
+        "| --- | --- | --- | --- |\n"
+        "| shadow-a | 33.3% | +13.3pp | 1800 |\n"
+        "| shadow-b | 0.0% | -40.0pp | 900 |\n"
+    )
+    assert output_path.read_text(encoding="utf-8") == expected

--- a/projects/04-llm-adapter-shadow/tools/weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tools/weekly_summary.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+_PREV_RE = re.compile(r"^\|\s*([^|]+?)\s*\|\s*([0-9]+(?:\.[0-9]+)?)%")
+
+
+def _load_jsonl(path: Path) -> list[Mapping[str, Any]]:
+    if not path.exists():
+        raise SystemExit(f"metrics file not found: {path}")
+    rows: list[Mapping[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            trimmed = raw.strip()
+            if not trimmed:
+                continue
+            try:
+                parsed = json.loads(trimmed)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+            if isinstance(parsed, Mapping):
+                rows.append(parsed)
+    return rows
+
+
+def _aggregate(rows: Iterable[Mapping[str, Any]]) -> list[tuple[str, float, int | None]]:
+    totals: dict[str, list[Any]] = defaultdict(lambda: [0, 0, []])
+    for row in rows:
+        if row.get("event") != "shadow_diff":
+            continue
+        provider = row.get("shadow_provider")
+        if not isinstance(provider, str) or not provider:
+            continue
+        bucket = totals[provider]
+        bucket[0] += 1
+        if row.get("shadow_outcome") != "success":
+            bucket[1] += 1
+        latency = row.get("shadow_latency_ms")
+        if isinstance(latency, (int, float)):
+            bucket[2].append(float(latency))
+    return sorted([
+        (
+            provider,
+            round((float(fails) / float(count)) * 100.0, 1),
+            int(round(sorted(latencies)[max(0, math.ceil(0.95 * len(latencies)) - 1)]))
+            if latencies
+            else None,
+        )
+        for provider, (count, fails, latencies) in totals.items()
+        if count
+    ], key=lambda item: (-item[1], item[0]))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate shadow metrics into markdown")
+    parser.add_argument("--input", required=True, help="Path to runs-metrics JSONL")
+    parser.add_argument("--output", default="docs/weekly-summary.md", help="Destination markdown file")
+    parser.add_argument("--prev", help="Previous markdown to diff against")
+    args = parser.parse_args(argv)
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+    prev_path = Path(args.prev).expanduser().resolve() if args.prev else None
+
+    summary = _aggregate(_load_jsonl(input_path))
+    previous: dict[str, float] = {}
+    if prev_path and prev_path.exists():
+        for line in prev_path.read_text(encoding="utf-8").splitlines():
+            match = _PREV_RE.match(line)
+            if match:
+                provider, rate_str = match.groups()
+                previous[provider.strip()] = float(rate_str)
+
+    rows = [
+        "| {provider} | {rate:.1f}% | {delta} | {latency} |".format(
+            provider=provider,
+            rate=rate,
+            delta="n/a" if previous.get(provider) is None else f"{rate - previous[provider]:+.1f}pp",
+            latency=str(latency) if latency is not None else "n/a",
+        )
+        for provider, rate, latency in summary
+    ]
+    markdown = "\n".join(
+        [
+            "# Weekly Shadow Summary",
+            "",
+            "| Provider | Failure Rate | Δ vs Prev | P95 Latency (ms) |",
+            "| --- | --- | --- | --- |",
+            *rows,
+            "",
+        ]
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a CLI that aggregates shadow metrics JSONL files into a deterministic weekly summary markdown report
- add a regression test that exercises the CLI against fixture metrics and previous-week markdown data

## Testing
- pytest projects/04-llm-adapter-shadow/tests/tools/test_weekly_summary.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd0cea45e08321af1ab6dd1a0c6a8a