### PR TITLE
Align execution guard spec lookup call

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
+++ b/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
@@ -27,7 +27,7 @@ def test_schema_validator_imports_without_jsonschema(monkeypatch: pytest.MonkeyP
     ) -> importlib.machinery.ModuleSpec | None:
         if name == "jsonschema":
             return None
-        return path_finder.find_spec(name, path, target)
+        return path_finder.find_spec(name, path=path, target=target)
 
     monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
 


### PR DESCRIPTION
## Summary
- pass the fake PathFinder spec lookup parameters as explicit keyword arguments to mirror the official signature

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1301d3808321aa7f05275c2f1a26