### PR TITLE
Normalize stream flag handling in Ollama client

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/ollama_client.py
@@ -124,9 +124,13 @@ class OllamaClient:
         timeout: float | None = None,
         stream: bool = False,
     ) -> ResponseProtocol:
+        payload_stream = payload.get("stream")
+        stream_flag = stream
+        if payload_stream is not None:
+            stream_flag = bool(payload_stream)
         return self._ensure_success(
             "/api/chat",
-            self._post("/api/chat", payload, timeout=timeout, stream=stream),
+            self._post("/api/chat", payload, timeout=timeout, stream=stream_flag),
         )
 
     def _post(


### PR DESCRIPTION
## Summary
- normalize the stream flag in `OllamaClient.chat` using any `stream` value provided in the payload
- add a regression test to ensure non-boolean payload values trigger streaming requests

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_client.py::test_ollama_client_normalizes_payload_stream_flag
- pytest projects/04-llm-adapter-shadow/tests/providers/test_ollama_provider.py::test_ollama_provider_merges_request_options

------
https://chatgpt.com/codex/tasks/task_e_68dd1450c2948321a5dc47fc871ac987