### PR TITLE
Fix jsonschema import ordering in guards

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/guards.py
+++ b/projects/04-llm-adapter/adapter/core/execution/guards.py
@@ -37,7 +37,10 @@ if _jsonschema_spec is None:
     jsonschema_exceptions = SimpleNamespace(ValidationError=_MissingValidationError)
     validators = SimpleNamespace(validator_for=_validator_for)
 else:
-    from jsonschema import exceptions as jsonschema_exceptions, validators
+    from jsonschema import (
+        exceptions as jsonschema_exceptions,
+        validators,
+    )
 
 
 class _TokenBucket:


### PR DESCRIPTION
## Summary
- align the conditional jsonschema imports with Ruff's formatting requirements

## Testing
- ruff check projects/04-llm-adapter/adapter/core/execution/guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1de3f4832197487a3bb64bfca5