### PR TITLE
fix: tidy adapter core imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/errors.py
+++ b/projects/04-llm-adapter/adapter/core/errors.py
@@ -1,4 +1,5 @@
 """Normalized exception hierarchy for adapter core."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable


### PR DESCRIPTION
## Summary
- add a separating newline between the module docstring and imports in the adapter core errors module

## Testing
- ruff check projects/04-llm-adapter/adapter/core/errors.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1d2d688321b76704b89899d2df