### PR TITLE
chore: sort imports in consensus test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -5,19 +5,11 @@ import pytest
 
 from src.llm_adapter.errors import RetriableError, TimeoutError
 from src.llm_adapter.parallel_exec import ParallelExecutionError
-from src.llm_adapter.provider_spi import (
-    ProviderRequest,
-    ProviderResponse,
-    TokenUsage,
-)
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 import src.llm_adapter.runner_parallel as runner_parallel
-from src.llm_adapter.runner_parallel import (
-    compute_consensus,
-    ConsensusObservation,
-    ConsensusResult,
-)
+from src.llm_adapter.runner_parallel import compute_consensus, ConsensusObservation, ConsensusResult
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 
 


### PR DESCRIPTION
## Summary
- reorder the imports in `test_runner_consensus.py` to follow Ruff's import sorting rules

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1add1c83218acc4c3d95ab7a22