### PR TITLE
chore: tidy guards imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/execution/guards.py
+++ b/projects/04-llm-adapter/adapter/core/execution/guards.py
@@ -1,4 +1,5 @@
 """Execution guard utilities for runner execution."""
+
 from __future__ import annotations
 
 import importlib.util


### PR DESCRIPTION
## Summary
- add an empty line between the module docstring and future import in the guards module to keep the import block tidy

## Testing
- ruff check projects/04-llm-adapter/adapter/core/execution/guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1cf0c4832193f0ecd8b655ba95