### PR TITLE
Fix import ordering in execution guards test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
+++ b/projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import importlib.machinery
 import importlib.util
-from collections.abc import Sequence
 from pathlib import Path
 import sys
 from types import ModuleType
-
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder the standard library imports in test_execution_guards.py
- ensure a single separator line before the third-party pytest import

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/core/test_execution_guards.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1a8b6483218724512423a35418