### PR TITLE
Refactor CI report imports for package usage

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -2,9 +2,13 @@ import datetime as dt
 from pathlib import Path
 import sys
 
+import importlib
+
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+importlib.reload(importlib.import_module("tools.generate_ci_report"))
 
 from tools.ci_report.processing import compute_last_updated, normalize_flaky_rows
 from tools.ci_report.rendering import render_markdown

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 import datetime as dt
 from pathlib import Path
 
-import weekly_summary
-from weekly_summary import coerce_str, load_runs
+from tools import weekly_summary
+from tools.weekly_summary import coerce_str, load_runs
 
 PASS_STATUSES = {"pass", "passed"}
 FAIL_STATUSES = {"fail", "failed"}

--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -9,14 +9,8 @@ from pathlib import Path
 import sys
 
 try:
-    from ci_metrics import compute_recent_deltas, compute_run_history
-    from weekly_summary import (
-        aggregate_status,
-        filter_by_window,
-        load_flaky,
-        load_runs,
-        select_flaky_rows,
-    )
+    from tools.ci_metrics import compute_recent_deltas, compute_run_history
+    from tools import weekly_summary
 
     from tools.ci_report.processing import (
         compute_last_updated,
@@ -29,14 +23,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
     if str(REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(REPO_ROOT))
 
-    from ci_metrics import compute_recent_deltas, compute_run_history
-    from weekly_summary import (
-        aggregate_status,
-        filter_by_window,
-        load_flaky,
-        load_runs,
-        select_flaky_rows,
-    )
+    from tools.ci_metrics import compute_recent_deltas, compute_run_history
+    from tools import weekly_summary
 
     from tools.ci_report.processing import (
         compute_last_updated,
@@ -103,16 +91,16 @@ def main() -> None:
     window = dt.timedelta(days=max(args.days, 1))
     start = now - window
 
-    runs = load_runs(args.runs) if args.runs.exists() else []
-    flaky_rows = load_flaky(args.flaky) if args.flaky.exists() else []
+    runs = weekly_summary.load_runs(args.runs) if args.runs.exists() else []
+    flaky_rows = weekly_summary.load_flaky(args.flaky) if args.flaky.exists() else []
 
-    filtered_runs = filter_by_window(runs, start, now)
+    filtered_runs = weekly_summary.filter_by_window(runs, start, now)
     run_history = compute_run_history(runs)
     recent_runs = compute_recent_deltas(run_history, limit=3)
-    passes, fails, errors = aggregate_status(filtered_runs)
+    passes, fails, errors = weekly_summary.aggregate_status(filtered_runs)
     failure_kinds = summarize_failure_kinds(filtered_runs)
 
-    selected_flaky = select_flaky_rows(flaky_rows, start, now)
+    selected_flaky = weekly_summary.select_flaky_rows(flaky_rows, start, now)
     normalized_flaky = normalize_flaky_rows(selected_flaky)
 
     last_updated = compute_last_updated(filtered_runs)

--- a/tools/plot_ci_metrics.py
+++ b/tools/plot_ci_metrics.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 import argparse
 from collections.abc import Iterable
 from pathlib import Path
+import sys
 
-from ci_metrics import load_run_history
+try:
+    from tools.ci_metrics import load_run_history
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    REPO_ROOT = Path(__file__).resolve().parents[1]
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+    from tools.ci_metrics import load_run_history
 
 WIDTH = 960
 HEIGHT = 540


### PR DESCRIPTION
## Summary
- update generate_ci_report imports to use the tools package paths for ci_metrics and weekly_summary
- adjust supporting modules and tests to align with the new import locations and verify module loading

## Testing
- pytest tests/test_generate_ci_report.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2b5644bc8321991e269e4ff2fea3