### PR TITLE
Add latency and cost constraints to ConsensusConfig

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -31,6 +31,8 @@ class ConsensusConfig:
     judge: str | None = None
     max_rounds: int | None = None
     provider_weights: dict[str, float] | None = None
+    max_latency_ms: int | None = None
+    max_cost_usd: float | None = None
 
 
 @dataclass(frozen=True)

--- a/projects/04-llm-adapter-shadow/tests/test_consensus_config_constraints.py
+++ b/projects/04-llm-adapter-shadow/tests/test_consensus_config_constraints.py
@@ -1,0 +1,27 @@
+import dataclasses
+
+import pytest
+
+from src.llm_adapter.runner_config import ConsensusConfig
+
+
+def test_consensus_config_defaults_include_constraints() -> None:
+    config = ConsensusConfig()
+
+    assert config.max_latency_ms is None
+    assert config.max_cost_usd is None
+
+
+def test_consensus_config_equality_accounts_for_constraints() -> None:
+    base = ConsensusConfig()
+    with_overrides = ConsensusConfig(max_latency_ms=100, max_cost_usd=1.5)
+
+    assert base == ConsensusConfig()
+    assert base != with_overrides
+
+
+def test_consensus_config_is_frozen() -> None:
+    config = ConsensusConfig()
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        config.max_latency_ms = 1


### PR DESCRIPTION
## Summary
- add regression tests covering ConsensusConfig defaults, equality, and immutability for latency and cost constraints
- extend ConsensusConfig with optional max_latency_ms and max_cost_usd fields while preserving defaults

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_consensus_config_constraints.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd345f10808321af7557a8531c0073