### PR TITLE
Fix FakeSession annotation

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
+++ b/projects/04-llm-adapter-shadow/tests/helpers/fakes.py
@@ -57,7 +57,7 @@ class FakeResponse:
 
 class FakeSession:
     class _CallRecorder(list[tuple[str, dict[str, Any] | None, bool]]):
-        def __init__(self, session: "FakeSession") -> None:
+        def __init__(self, session: FakeSession) -> None:
             super().__init__()
             self._session = session
 


### PR DESCRIPTION
## Summary
- remove the string literal from the FakeSession type annotation in the call recorder helper

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/helpers/fakes.py --select UP037

------
https://chatgpt.com/codex/tasks/task_e_68dd37f923bc8321852db476afa34c71