### PR TITLE
Fix Callable import in OpenAI provider tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/test_openai_provider.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/test_openai_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 


### PR DESCRIPTION
## Summary
- import Callable from collections.abc in the OpenAI provider tests
- drop the redundant typing import now that Callable moved

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/providers/test_openai_provider.py --select UP035

------
https://chatgpt.com/codex/tasks/task_e_68dd37f89cec8321b7ea6d4efac19499