### PR TITLE
Sort registry imports in builtin aggregation module

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation/builtin/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/builtin/__init__.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from .majority_vote import MajorityVoteStrategy
 from .max_score import MaxScoreStrategy
 from .registry import (
+    resolve_builtin_strategy,
     STRATEGY_ALIASES,
     STRATEGY_FACTORIES,
     StrategyFactory,
-    resolve_builtin_strategy,
 )
 from .tie_breakers import FirstTieBreaker, MaxScoreTieBreaker
 from .weighted_vote import WeightedVoteStrategy


### PR DESCRIPTION
## Summary
- reorder the relative imports from the builtin aggregation registry to satisfy Ruff's I001 rule

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation/builtin/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dd37f71aa88321a167ce25d1d6f9a5