### PR TITLE
Fix Mapping import in aggregation registry

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation/builtin/registry.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/builtin/registry.py
@@ -1,8 +1,8 @@
 """組み込みストラテジのレジストリ。"""
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, Mapping, cast
+from collections.abc import Callable, Mapping
+from typing import Any, cast
 
 from .. import AggregationStrategy
 from .majority_vote import MajorityVoteStrategy


### PR DESCRIPTION
## Summary
- import Mapping from collections.abc and reorder typing imports to satisfy lint

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation/builtin/registry.py --select I001,UP035

------
https://chatgpt.com/codex/tasks/task_e_68dd37ee28dc83219ce62768a0cdc201