### PR TITLE
style: sort builtin aggregation imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from .builtin.majority_vote import MajorityVoteStrategy
 from .builtin.max_score import MaxScoreStrategy
+from .builtin.registry import resolve_builtin_strategy
 from .builtin.tie_breakers import FirstTieBreaker, MaxScoreTieBreaker
 from .builtin.weighted_vote import WeightedVoteStrategy
-from .builtin.registry import resolve_builtin_strategy
 
 __all__ = [
     "FirstTieBreaker",


### PR DESCRIPTION
## Summary
- reorder relative imports in strategies_builtin to satisfy Ruff's I001 check

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation/strategies_builtin.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dd37ecba0c8321880f044e4dc2a36a