### PR TITLE
refactor: simplify ci report test imports

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -1,14 +1,7 @@
 import datetime as dt
 from pathlib import Path
-import sys
-
-import importlib
 
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-importlib.reload(importlib.import_module("tools.generate_ci_report"))
 
 from tools.ci_report.processing import compute_last_updated, normalize_flaky_rows
 from tools.ci_report.rendering import render_markdown


### PR DESCRIPTION
## Summary
- drop ad-hoc sys.path manipulation from the CI report test
- rely on the shared pytest configuration so the test only uses standard imports

## Testing
- ruff check tests/test_generate_ci_report.py --select I001,E402

------
https://chatgpt.com/codex/tasks/task_e_68dd37eabdb88321a054ee3afdb1ab92