### PR TITLE
Fix import sorting in runner sync modes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import cast, Protocol, TYPE_CHECKING
 
 from .observability import EventLogger
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
@@ -12,11 +12,11 @@ from .provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from .runner_config import RunnerMode
 from .runner_shared import MetricsPath
 from .runner_sync_parallel_any import (
-    ParallelAnyCallable,
-    ParallelAnyStrategy,
     _collect_parallel_failures,
     _limited_providers,
     _raise_no_attempts,
+    ParallelAnyCallable,
+    ParallelAnyStrategy,
 )
 from .runner_sync_sequential import SequentialStrategy
 


### PR DESCRIPTION
## Summary
- reorder typing imports alphabetically
- sort relative imports within the parallel-any block

## Testing
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py --select I001`


------
https://chatgpt.com/codex/tasks/task_e_68dd37d9e7f88321a19d7983c770f0c5