### PR TITLE
Sort imports in OpenAI provider module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/providers/openai.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/providers/openai.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, MutableMapping
 import json
 import os
 import time
-from collections.abc import Iterable, Mapping, MutableMapping
 from typing import Any
 
 from ..errors import RateLimitError, RetriableError, TimeoutError
 from ..provider_spi import ProviderRequest, ProviderResponse, TokenUsage
-from ._requests_compat import SessionProtocol, create_session, requests_exceptions
+from ._requests_compat import create_session, requests_exceptions, SessionProtocol
 from .base import BaseProvider
 
 __all__ = ["OpenAIProvider"]


### PR DESCRIPTION
## Summary
- reorder the OpenAI provider imports to satisfy ruff import sorting

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/providers/openai.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68dd37d9538883219faff00d446a4ee5