### PR TITLE
style: organize metrics otlp imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from typing import Any
+
 ScopeAttrs = list[dict[str, Any]]
+
+
 def _timestamp_ns(value: Any) -> str:
     return str(int(float(value) * 1_000_000)) if isinstance(value, (int, float)) else "0"
 


### PR DESCRIPTION
## Summary
- insert a blank line after the import block in `metrics_otlp.py` to satisfy Ruff I001
- keep the top-level declarations separated to match standard layout

## Testing
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py --select I001`


------
https://chatgpt.com/codex/tasks/task_e_68dd37d7c98c8321808817307125e6d4