### PR TITLE
Refactor runner execution helpers and extend shadow metrics tests

### DIFF
--- a/projects/04-llm-adapter/adapter/core/_parallel_shim.py
+++ b/projects/04-llm-adapter/adapter/core/_parallel_shim.py
@@ -1,0 +1,55 @@
+"""並列実行のフォールバック実装。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.parallel_exec import (  # type: ignore[import-not-found]
+        ParallelExecutionError as _ParallelExecutionError,
+        run_parallel_all_sync as _run_parallel_all_sync,
+        run_parallel_any_sync as _run_parallel_any_sync,
+    )
+
+    ParallelExecutionError = _ParallelExecutionError
+    run_parallel_all_sync = _run_parallel_all_sync
+    run_parallel_any_sync = _run_parallel_any_sync
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.parallel_exec import (  # type: ignore[import-not-found]
+            ParallelExecutionError,
+            run_parallel_all_sync,
+            run_parallel_any_sync,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+        T = TypeVar("T")
+
+        class ParallelExecutionError(RuntimeError):
+            """並列実行時エラーのフォールバック。"""
+
+        def run_parallel_all_sync(
+            workers: Sequence[Callable[[], T]], *, max_concurrency: int | None = None
+        ) -> list[T]:
+            return [worker() for worker in workers]
+
+        def run_parallel_any_sync(
+            workers: Sequence[Callable[[], T]], *, max_concurrency: int | None = None
+        ) -> T:
+            last_error: Exception | None = None
+            for worker in workers:
+                try:
+                    return worker()
+                except Exception as exc:  # pragma: no cover - テスト環境でのみ到達
+                    last_error = exc
+            if last_error is not None:
+                raise ParallelExecutionError(str(last_error)) from last_error
+            raise ParallelExecutionError("no worker executed successfully")
+
+
+__all__ = [
+    "ParallelExecutionError",
+    "run_parallel_all_sync",
+    "run_parallel_any_sync",
+]
+

--- a/projects/04-llm-adapter/adapter/core/_provider_execution.py
+++ b/projects/04-llm-adapter/adapter/core/_provider_execution.py
@@ -1,0 +1,240 @@
+"""プロバイダ呼び出しの補助。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter, sleep
+from typing import TYPE_CHECKING
+
+from .config import ProviderConfig
+from .errors import (
+    AuthError,
+    ConfigError,
+    ProviderSkip,
+    RateLimitError,
+    RetriableError,
+    TimeoutError,
+)
+from .providers import BaseProvider, ProviderResponse
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from .runner_api import BackoffPolicy
+else:  # pragma: no cover - 実行時フォールバック
+    BackoffPolicy = object
+
+
+@dataclass(slots=True)
+class _ProviderCallResult:
+    response: ProviderResponse
+    status: str
+    failure_kind: str | None
+    error_message: str | None
+    latency_ms: int
+    retries: int
+    error: Exception | None = None
+    backoff_next_provider: bool = False
+
+
+class ProviderCallExecutor:
+    """プロバイダ呼び出しの結果を構築する。"""
+
+    def __init__(self, backoff: BackoffPolicy | None) -> None:
+        self._backoff = backoff
+
+    def execute(
+        self, provider_config: ProviderConfig, provider: BaseProvider, prompt: str
+    ) -> _ProviderCallResult:
+        result = self._invoke_provider(provider_config, provider, prompt)
+        status, failure_kind = self._check_timeout(
+            provider_config, result.latency_ms, result.status, result.failure_kind
+        )
+        status, failure_kind = self._enforce_output_guard(
+            result.response.output_text, status, failure_kind
+        )
+        result.status = status
+        result.failure_kind = failure_kind
+        return result
+
+    def _invoke_provider(
+        self, provider_config: ProviderConfig, provider: BaseProvider, prompt: str
+    ) -> _ProviderCallResult:
+        start = perf_counter()
+        try:
+            response = provider.generate(prompt)
+        except ProviderSkip as exc:
+            latency_ms = int((perf_counter() - start) * 1000)
+            response = self._build_error_response(prompt, latency_ms)
+            return _ProviderCallResult(
+                response=response,
+                status="skip",
+                failure_kind="skip",
+                error_message=str(exc),
+                latency_ms=latency_ms,
+                retries=1,
+                error=exc,
+                backoff_next_provider=True,
+            )
+        except AuthError as exc:
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="auth",
+                advance=True,
+            )
+        except ConfigError as exc:
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="config",
+                advance=True,
+            )
+        except RateLimitError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="rate_limit",
+                default_advance=True,
+            )
+        except TimeoutError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="timeout",
+                default_advance=False,
+            )
+        except RetriableError as exc:
+            return self._handle_backoff_error(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="retryable",
+                default_advance=False,
+            )
+        except Exception as exc:  # pragma: no cover - 実プロバイダ利用時の防御
+            return self._build_error_result(
+                prompt,
+                start,
+                exc,
+                status="error",
+                failure_kind="provider_error",
+                advance=False,
+            )
+        latency_ms = response.latency_ms
+        return _ProviderCallResult(
+            response=response,
+            status="ok",
+            failure_kind=None,
+            error_message=None,
+            latency_ms=latency_ms,
+            retries=1,
+        )
+
+    def _build_error_result(
+        self,
+        prompt: str,
+        started_at: float,
+        error: Exception,
+        *,
+        status: str,
+        failure_kind: str,
+        advance: bool,
+    ) -> _ProviderCallResult:
+        latency_ms = int((perf_counter() - started_at) * 1000)
+        response = self._build_error_response(prompt, latency_ms)
+        return _ProviderCallResult(
+            response=response,
+            status=status,
+            failure_kind=failure_kind,
+            error_message=str(error),
+            latency_ms=latency_ms,
+            retries=1,
+            error=error,
+            backoff_next_provider=advance,
+        )
+
+    def _handle_backoff_error(
+        self,
+        prompt: str,
+        started_at: float,
+        error: Exception,
+        *,
+        status: str,
+        failure_kind: str,
+        default_advance: bool,
+    ) -> _ProviderCallResult:
+        advance = self._apply_backoff(error)
+        if not advance:
+            advance = default_advance
+        return self._build_error_result(
+            prompt,
+            started_at,
+            error,
+            status=status,
+            failure_kind=failure_kind,
+            advance=advance,
+        )
+
+    @staticmethod
+    def _build_error_response(prompt: str, latency_ms: int) -> ProviderResponse:
+        return ProviderResponse(
+            output_text="",
+            input_tokens=len(prompt.split()),
+            output_tokens=0,
+            latency_ms=latency_ms,
+        )
+
+    def _apply_backoff(self, error: Exception) -> bool:
+        policy = self._backoff
+        if policy is None:
+            return False
+        should_advance = False
+        delay = 0.0
+        if isinstance(error, RateLimitError):
+            delay = float(policy.rate_limit_sleep_s or 0.0)
+            should_advance = True
+        elif isinstance(error, TimeoutError):
+            should_advance = bool(policy.timeout_next_provider)
+        elif isinstance(error, RetriableError):
+            should_advance = bool(policy.retryable_next_provider)
+        if delay > 0.0:
+            sleep(delay)
+        return should_advance
+
+    @staticmethod
+    def _check_timeout(
+        provider_config: ProviderConfig,
+        latency_ms: int,
+        status: str,
+        failure_kind: str | None,
+    ) -> tuple[str, str | None]:
+        if (
+            provider_config.timeout_s > 0
+            and latency_ms > provider_config.timeout_s * 1000
+            and status == "ok"
+        ):
+            return "error", "timeout"
+        return status, failure_kind
+
+    @staticmethod
+    def _enforce_output_guard(
+        output_text: str | None, status: str, failure_kind: str | None
+    ) -> tuple[str, str | None]:
+        if (output_text is None or not output_text.strip()) and status == "ok":
+            return "error", failure_kind or "guard_violation"
+        return status, failure_kind
+
+
+__all__ = [
+    "ProviderCallExecutor",
+    "_ProviderCallResult",
+]
+

--- a/projects/04-llm-adapter/adapter/core/_shadow_helpers.py
+++ b/projects/04-llm-adapter/adapter/core/_shadow_helpers.py
@@ -1,0 +1,54 @@
+"""ShadowRunner 補助。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .config import ProviderConfig
+from .execution.shadow_runner import ShadowRunner, ShadowRunnerResult
+
+if TYPE_CHECKING:  # pragma: no cover - 型補完用
+    from src.llm_adapter.provider_spi import ProviderSPI  # type: ignore[import-not-found]
+else:  # pragma: no cover - 実行時フォールバック
+    try:
+        from src.llm_adapter.provider_spi import ProviderSPI  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - テスト用フォールバック
+
+        class ProviderSPI:  # pragma: no cover - 型補完不要
+            """プロバイダ SPI フォールバック."""
+
+
+@dataclass(slots=True)
+class ShadowSession:
+    """シャドウ呼び出しのライフサイクル管理。"""
+
+    runner: ShadowRunner
+    fallback_provider_id: str | None
+
+
+def start_shadow_session(
+    shadow_provider: ProviderSPI | None, provider_config: ProviderConfig, prompt: str
+) -> ShadowSession | None:
+    if shadow_provider is None:
+        return None
+    runner = ShadowRunner(shadow_provider)
+    runner.start(provider_config, prompt)
+    return ShadowSession(runner=runner, fallback_provider_id=runner.provider_id)
+
+
+def finalize_shadow_session(
+    session: ShadowSession | None,
+) -> tuple[ShadowRunnerResult | None, str | None]:
+    if session is None:
+        return None, None
+    result = session.runner.finalize()
+    return result, session.fallback_provider_id
+
+
+__all__ = [
+    "ShadowSession",
+    "start_shadow_session",
+    "finalize_shadow_session",
+]
+

--- a/tests/test_runner_shadow_metrics.py
+++ b/tests/test_runner_shadow_metrics.py
@@ -2,17 +2,26 @@
 from __future__ import annotations
 
 import contextlib
-from dataclasses import replace
 import logging
+from dataclasses import replace
 from pathlib import Path
 import sys
 from types import SimpleNamespace
+from typing import Callable
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "projects" / "04-llm-adapter"))
 
+from adapter.core.errors import RateLimitError
 from adapter.core.metrics import RunMetrics
+from adapter.core.models import (
+    PricingConfig,
+    ProviderConfig,
+    QualityGatesConfig,
+    RateLimitConfig,
+    RetryConfig,
+)
 from adapter.core.runner_execution import RunnerExecution
 
 BASE_METRICS = RunMetrics(
@@ -38,23 +47,26 @@ BASE_METRICS = RunMetrics(
     output_hash=None,
 )
 
-
-CONFIG = SimpleNamespace(
+BASE_CONFIG = ProviderConfig(
+    path=Path("provider.yaml"),
+    schema_version=1,
     provider="main",
+    endpoint=None,
     model="model",
+    auth_env=None,
     seed=0,
     temperature=0.0,
     top_p=1.0,
     max_tokens=16,
     timeout_s=30,
+    retries=RetryConfig(),
     persist_output=True,
-    pricing=SimpleNamespace(
-        prompt_usd=0.0,
-        completion_usd=0.0,
-        input_per_million=0.0,
-        output_per_million=0.0,
-    ),
+    pricing=PricingConfig(),
+    rate_limit=RateLimitConfig(),
+    quality_gates=QualityGatesConfig(),
+    raw={},
 )
+
 RESPONSE = SimpleNamespace(
     output_text="PRIMARY",
     input_tokens=3,
@@ -62,16 +74,31 @@ RESPONSE = SimpleNamespace(
     latency_ms=12,
     token_usage=SimpleNamespace(prompt=3, completion=2, total=5),
 )
-TASK = type("Task", (), {"task_id": "task-1", "name": "task", "render_prompt": lambda self: "say hi"})()
+
+TASK = type(
+    "Task",
+    (),
+    {"task_id": "task-1", "name": "task", "render_prompt": lambda self: "say hi"},
+)()
 
 
-def _run_shadow(shadow, *, expect_error: bool, caplog: pytest.LogCaptureFixture):
-    config = CONFIG
-    response = RESPONSE
-    task = TASK
-
-    def build_metrics(cfg, task_obj, _attempt, mode, resp, status, failure, error, latency, _budget, cost):
+def _build_metrics() -> Callable:
+    def build_metrics(
+        cfg,
+        task_obj,
+        _attempt,
+        mode,
+        resp,
+        status,
+        failure,
+        error,
+        latency,
+        _budget,
+        cost,
+    ):
         metrics = replace(BASE_METRICS)
+        metrics.provider = cfg.provider
+        metrics.model = cfg.model
         metrics.mode = mode
         metrics.input_tokens = resp.input_tokens
         metrics.output_tokens = resp.output_tokens
@@ -83,7 +110,11 @@ def _run_shadow(shadow, *, expect_error: bool, caplog: pytest.LogCaptureFixture)
         metrics.output_text = resp.output_text
         return metrics, resp.output_text
 
-    execution = RunnerExecution(
+    return build_metrics
+
+
+def _make_execution(shadow) -> RunnerExecution:
+    return RunnerExecution(
         token_bucket=None,
         schema_validator=None,
         evaluate_budget=lambda cfg, cost, status, failure, error: (
@@ -93,17 +124,27 @@ def _run_shadow(shadow, *, expect_error: bool, caplog: pytest.LogCaptureFixture)
             failure,
             error,
         ),
-        build_metrics=build_metrics,
+        build_metrics=_build_metrics(),
         normalize_concurrency=lambda total, limit: total,
         backoff=None,
         shadow_provider=shadow,
         metrics_path=None,
         provider_weights=None,
     )
-    provider = SimpleNamespace(generate=lambda _prompt: response)
+
+
+def _run_single(
+    *,
+    provider,
+    shadow,
+    config: ProviderConfig | None,
+    expect_error: bool,
+    caplog: pytest.LogCaptureFixture,
+):
+    execution = _make_execution(shadow)
     context = caplog.at_level(logging.ERROR) if expect_error else contextlib.nullcontext()
     with context:
-        return execution._run_single(config, provider, task, 0, "compare")
+        return execution._run_single(config or BASE_CONFIG, provider, TASK, 0, "compare")
 
 
 @pytest.mark.parametrize(
@@ -133,8 +174,22 @@ def _run_shadow(shadow, *, expect_error: bool, caplog: pytest.LogCaptureFixture)
         ),
     ],
 )
-def test_shadow_metrics_capture(shadow_factory, expected_status, expected_outcome, expected_error, expect_log, caplog):
-    result = _run_shadow(shadow_factory(), expect_error=expect_log, caplog=caplog)
+def test_shadow_metrics_capture(
+    shadow_factory,
+    expected_status,
+    expected_outcome,
+    expected_error,
+    expect_log,
+    caplog,
+):
+    provider = SimpleNamespace(generate=lambda _prompt: RESPONSE)
+    result = _run_single(
+        provider=provider,
+        shadow=shadow_factory(),
+        config=None,
+        expect_error=expect_log,
+        caplog=caplog,
+    )
     metrics = result.metrics
     assert metrics.shadow_provider_id == "shadow-probe"
     assert metrics.shadow_status == expected_status
@@ -144,3 +199,47 @@ def test_shadow_metrics_capture(shadow_factory, expected_status, expected_outcom
         assert metrics.shadow_latency_ms == 7
     if expect_log:
         assert "Shadow provider shadow-probe failed" in caplog.text
+
+
+def test_run_single_retries_rate_limit_preserves_shadow_metrics(caplog: pytest.LogCaptureFixture):
+    config = replace(BASE_CONFIG, retries=RetryConfig(max=1, backoff_s=0.0))
+    shadow_calls: list[object] = []
+
+    class ShadowProvider:
+        def name(self) -> str:
+            return "shadow-probe"
+
+        def capabilities(self) -> set[str]:
+            return set()
+
+        def invoke(self, request):
+            shadow_calls.append(request)
+            return SimpleNamespace(latency_ms=11)
+
+    call_count = 0
+
+    def generate(prompt: str):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RateLimitError("rate limited")
+        return RESPONSE
+
+    provider = SimpleNamespace(generate=generate)
+    result = _run_single(
+        provider=provider,
+        shadow=ShadowProvider(),
+        config=config,
+        expect_error=False,
+        caplog=caplog,
+    )
+
+    metrics = result.metrics
+    assert call_count == 2
+    assert len(shadow_calls) == 1
+    assert metrics.status == "ok"
+    assert metrics.retries == 1
+    assert metrics.shadow_provider_id == "shadow-probe"
+    assert metrics.shadow_status == "ok"
+    assert metrics.shadow_outcome == "success"
+    assert metrics.shadow_latency_ms == 11


### PR DESCRIPTION
## Summary
- extract parallel fallback, provider call, and shadow lifecycle helpers to slim down `RunnerExecution`
- update the runner to rely on the new helper modules without changing public behavior
- extend the shadow metrics test suite to cover retry scenarios and richer assertions

## Testing
- pytest tests/test_runner_shadow_metrics.py
- pytest tests/test_update_readme_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dd361fd26883219eeea0113af3bf08