### PR TITLE
Update M3 provider milestone status

### DIFF
--- a/04/ROADMAP.md
+++ b/04/ROADMAP.md
@@ -9,7 +9,7 @@
 | **M0 — SRS確定 & 骨子固定** | Week40: 2025-09-29〜10-05 | SRS最終化 | `04/llm-adapter-srs.md`最終版 / 参照アーキ図 / M1〜M6 Exit Criteria | ✅ 完了（2025-10-04 SRS v1.0確定・用語集統合完了） |
 | **M1 — Core SPI & Runner** | Week40-41: 〜10-12 | SPI/Runner骨格 | ProviderSPI/Request/Response安定化 / 直列Runner / 最小UT | ✅ 完了（SPI型定義確定・直列Runner/例外UTマージ済） |
 | **M2 — Shadow & Metrics** | Week41: 10-06〜10-12 | 影実行+計測 | `run_with_shadow` / `artifacts/runs-metrics.jsonl`スキーマ / 異常系テスト | ✅ 完了（影実行APIとJSONLスキーマv1安定化） |
-| **M3 — Providers** | Week42: 10-13〜10-19 | 実プロバイダ実装 | OpenAI互換/Ollama/OpenRouter / ストリーミング透過 / 契約テスト | 🟡 進行中（Gemini/Ollama完了、OpenRouter統合待ち） |
+| **M3 — Providers** | Week42: 10-13〜10-19 | 実プロバイダ実装 | OpenAI互換/Ollama/OpenRouter / ストリーミング透過 / 契約テスト | ✅ 完了（OpenRouter統合と共通例外マップ反映済、契約テストCI緑） |
 | **M4 — Parallel & Consensus** | Week43: 10-20〜10-26 | 並列実行＋合議 | `runner_parallel` / `ConsensusConfig` / 合議テスト | 🟡 進行中（並列Runner/Consensus骨格完成、評価シナリオ整備中） |
 | **M5 — Telemetry & QA Integration** | Week44: 10-27〜11-02 | 可視化＋QA連携 | OTLP/JSON変換 / `docs/weekly-summary.md`自動更新 / Evidence更新 | ⚪ 未着手（CI連携と自動更新スクリプト設計段階） |
 | **M6 — CLI/Docs/Release 0.1.0** | Week45: 11-03〜11-09 | デモ〜配布 | `just`/CLI / README(JP/EN) / `pyproject.toml` / CHANGELOG / v0.1.0 | ⚪ 未着手（CLI整理とリリース手順これから） |
@@ -29,8 +29,8 @@
 **成果物**: `run_with_shadow`、`artifacts/runs-metrics.jsonl`(timestamp/provider/latency_ms/token_usage/diff_kind等)、TIMEOUT/429/フォーマット不正テスト。 **Exit Criteria**: 影実行ON/OFFでプライマリ応答不変、JSONLスキーマ検証通過、破壊変更時にスキーマバージョン更新。 **タスク**: 影並走のキャンセル/タイムアウト安全化 / JSONL追記リトライ / スキーマ検証とE2Eデモ。
 
 ## M3 — Provider 実装
-**進捗**: 🟡 Gemini/Ollama実装と契約テストを完了。OpenRouter/汎用OpenAI互換レイヤは結合テスト前で待機。
-**成果物**: `providers/`配下にOpenAI互換・Ollama・OpenRouter、ストリーミング透過、レート制限/再試行/タイムアウト統一、契約テスト。 **Exit Criteria**: 同一SPIで3種動作、ストリーミング指定を下層へ伝播(アサート)、429/5xx/ネットワークを共通例外へ正規化。 **タスク**: OpenAI互換(チャット/補完) / Ollama pull&stream透過 / OpenRouterルーティング差異吸収。
+**進捗**: ✅ OpenRouter/汎用OpenAI互換レイヤを統合し、Gemini/Ollamaと合わせて契約テストをCIに通過させた。
+**成果物**: `providers/`配下にOpenAI互換・Ollama・OpenRouter、ストリーミング透過、レート制限/再試行/タイムアウト統一、契約テスト。 **Exit Criteria**: 同一SPIで3種動作、ストリーミング指定を下層へ伝播(アサート)、429/5xx/ネットワークを共通例外へ正規化。 **タスク**: 共通リトライポリシーの閾値調整 / OpenRouter差分ログ出力整備 / 429バックオフベンチ継続。
 
 ## M4 — Parallel & Consensus
 **進捗**: 🟡 `runner_parallel`/`runner_sync_consensus`を追加済。性能ベンチと差分メトリクス記録の自動化が残課題。


### PR DESCRIPTION
## Summary
- mark the M3 provider milestone as complete in the roadmap
- record the OpenRouter integration and follow-up tasks in the M3 section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3cf5a3d883218acdb95dce11ec8c