### PR TITLE
Use datetime UTC constant in flaky rows test

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -78,8 +78,8 @@ def test_render_markdown_formats_numeric_strings() -> None:
 
 
 def test_select_flaky_rows_includes_end_date() -> None:
-    start = dt.datetime(2024, 6, 2, tzinfo=dt.timezone.utc)
-    end = dt.datetime(2024, 6, 9, tzinfo=dt.timezone.utc)
+    start = dt.datetime(2024, 6, 2, tzinfo=dt.UTC)
+    end = dt.datetime(2024, 6, 9, tzinfo=dt.UTC)
     rows = [
         {"canonical_id": "kept", "as_of": "2024-06-09T10:00:00Z"},
         {"canonical_id": "excluded", "as_of": "2024-06-10T00:00:00Z"},


### PR DESCRIPTION
## Summary
- replace datetime.timezone.utc with datetime.UTC in the flaky rows selection test

## Testing
- ruff check tests/test_generate_ci_report.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3d9296a88321ad828807981b5658