### PR TITLE
Ensure consensus configuration is fully immutable

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping, NamedTuple
 
 from .shadow import DEFAULT_METRICS_PATH, MetricsPath
 
@@ -20,8 +20,7 @@ class RunnerMode(str, Enum):
     CONSENSUS = "consensus"
 
 
-@dataclass(frozen=True)
-class ConsensusConfig:
+class ConsensusConfig(NamedTuple):
     """Configuration for consensus style orchestrations."""
 
     strategy: str = "majority_vote"
@@ -30,7 +29,7 @@ class ConsensusConfig:
     schema: str | None = None
     judge: str | None = None
     max_rounds: int | None = None
-    provider_weights: dict[str, float] | None = None
+    provider_weights: Mapping[str, float] | None = None
     max_latency_ms: int | None = None
     max_cost_usd: float | None = None
 

--- a/projects/04-llm-adapter-shadow/tests/test_consensus_config_constraints.py
+++ b/projects/04-llm-adapter-shadow/tests/test_consensus_config_constraints.py
@@ -23,5 +23,5 @@ def test_consensus_config_equality_accounts_for_constraints() -> None:
 def test_consensus_config_is_frozen() -> None:
     config = ConsensusConfig()
 
-    with pytest.raises(dataclasses.FrozenInstanceError):
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
         object.__setattr__(config, "max_latency_ms", 1)

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -227,9 +227,9 @@ def test_constraints_filter_candidates_before_consensus() -> None:
         _observation("fast-1", "B", 12, cost_estimate=0.05),
         _observation("fast-2", "B", 14, cost_estimate=0.08),
     ]
-    config = ConsensusConfig(strategy="majority", quorum=2)
-    object.__setattr__(config, "max_latency_ms", 20)
-    object.__setattr__(config, "max_cost_usd", 0.2)
+    config = ConsensusConfig(
+        strategy="majority", quorum=2, max_latency_ms=20, max_cost_usd=0.2
+    )
 
     result = compute_consensus(observations, config=config)
 
@@ -245,9 +245,9 @@ def test_constraints_exhaust_candidates_with_failures() -> None:
         _observation("pricy", "B", 18, cost_estimate=0.5),
         _observation("both", "C", 60, cost_estimate=0.45),
     ]
-    config = ConsensusConfig(strategy="majority", quorum=2)
-    object.__setattr__(config, "max_latency_ms", 20)
-    object.__setattr__(config, "max_cost_usd", 0.2)
+    config = ConsensusConfig(
+        strategy="majority", quorum=2, max_latency_ms=20, max_cost_usd=0.2
+    )
 
     with pytest.raises(ParallelExecutionError) as excinfo:
         compute_consensus(observations, config=config)


### PR DESCRIPTION
## Summary
- switch ConsensusConfig to a NamedTuple so attempts to mutate it now fail
- adjust consensus-related tests to set constraints via constructor and accept the new AttributeError semantics

## Testing
- pytest -vv -s --maxfail=1 --durations=20 --disable-socket projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68dd3f40bf608321bb1d6e63818ca861