### PR TITLE
Ensure consensus config immutability

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -1,7 +1,7 @@
 """Configuration objects for runner orchestration behavior."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import FrozenInstanceError, dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -20,19 +20,85 @@ class RunnerMode(str, Enum):
     CONSENSUS = "consensus"
 
 
-@dataclass(frozen=True)
+class _FrozenField:
+    """Descriptor that exposes a read-only attribute backed by a private slot."""
+
+    def __init__(self, name: str) -> None:
+        self._private_name = f"_{name}"
+        self._public_name = name
+
+    def __set_name__(self, owner: type[object], name: str) -> None:
+        self._private_name = f"_{name}"
+        self._public_name = name
+
+    def __get__(self, instance: object | None, owner: type[object]) -> object:
+        if instance is None:
+            return self
+        return getattr(instance, self._private_name)
+
+    def __set__(self, instance: object, value: object) -> None:  # pragma: no cover - defensive
+        raise FrozenInstanceError(
+            f"Cannot mutate '{self._public_name}' on ConsensusConfig"
+        )
+
+
+@dataclass(eq=True, repr=True, init=False)
 class ConsensusConfig:
     """Configuration for consensus style orchestrations."""
 
-    strategy: str = "majority_vote"
-    quorum: int = 2
-    tie_breaker: str | None = None
-    schema: str | None = None
-    judge: str | None = None
-    max_rounds: int | None = None
-    provider_weights: dict[str, float] | None = None
-    max_latency_ms: int | None = None
-    max_cost_usd: float | None = None
+    strategy: str = field(default="majority_vote", init=False)
+    quorum: int = field(default=2, init=False)
+    tie_breaker: str | None = field(default=None, init=False)
+    schema: str | None = field(default=None, init=False)
+    judge: str | None = field(default=None, init=False)
+    max_rounds: int | None = field(default=None, init=False)
+    provider_weights: dict[str, float] | None = field(default=None, init=False)
+    max_latency_ms: int | None = field(default=None, init=False)
+    max_cost_usd: float | None = field(default=None, init=False)
+
+    __slots__ = (
+        "_strategy",
+        "_quorum",
+        "_tie_breaker",
+        "_schema",
+        "_judge",
+        "_max_rounds",
+        "_provider_weights",
+        "_max_latency_ms",
+        "_max_cost_usd",
+    )
+
+    strategy = _FrozenField("strategy")
+    quorum = _FrozenField("quorum")
+    tie_breaker = _FrozenField("tie_breaker")
+    schema = _FrozenField("schema")
+    judge = _FrozenField("judge")
+    max_rounds = _FrozenField("max_rounds")
+    provider_weights = _FrozenField("provider_weights")
+    max_latency_ms = _FrozenField("max_latency_ms")
+    max_cost_usd = _FrozenField("max_cost_usd")
+
+    def __init__(
+        self,
+        strategy: str = "majority_vote",
+        quorum: int = 2,
+        tie_breaker: str | None = None,
+        schema: str | None = None,
+        judge: str | None = None,
+        max_rounds: int | None = None,
+        provider_weights: dict[str, float] | None = None,
+        max_latency_ms: int | None = None,
+        max_cost_usd: float | None = None,
+    ) -> None:
+        object.__setattr__(self, "_strategy", strategy)
+        object.__setattr__(self, "_quorum", quorum)
+        object.__setattr__(self, "_tie_breaker", tie_breaker)
+        object.__setattr__(self, "_schema", schema)
+        object.__setattr__(self, "_judge", judge)
+        object.__setattr__(self, "_max_rounds", max_rounds)
+        object.__setattr__(self, "_provider_weights", provider_weights)
+        object.__setattr__(self, "_max_latency_ms", max_latency_ms)
+        object.__setattr__(self, "_max_cost_usd", max_cost_usd)
 
 
 @dataclass(frozen=True)

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+import dataclasses
 from typing import cast
 
 import pytest
@@ -227,9 +228,11 @@ def test_constraints_filter_candidates_before_consensus() -> None:
         _observation("fast-1", "B", 12, cost_estimate=0.05),
         _observation("fast-2", "B", 14, cost_estimate=0.08),
     ]
-    config = ConsensusConfig(strategy="majority", quorum=2)
-    object.__setattr__(config, "max_latency_ms", 20)
-    object.__setattr__(config, "max_cost_usd", 0.2)
+    config = dataclasses.replace(
+        ConsensusConfig(strategy="majority", quorum=2),
+        max_latency_ms=20,
+        max_cost_usd=0.2,
+    )
 
     result = compute_consensus(observations, config=config)
 
@@ -245,9 +248,11 @@ def test_constraints_exhaust_candidates_with_failures() -> None:
         _observation("pricy", "B", 18, cost_estimate=0.5),
         _observation("both", "C", 60, cost_estimate=0.45),
     ]
-    config = ConsensusConfig(strategy="majority", quorum=2)
-    object.__setattr__(config, "max_latency_ms", 20)
-    object.__setattr__(config, "max_cost_usd", 0.2)
+    config = dataclasses.replace(
+        ConsensusConfig(strategy="majority", quorum=2),
+        max_latency_ms=20,
+        max_cost_usd=0.2,
+    )
 
     with pytest.raises(ParallelExecutionError) as excinfo:
         compute_consensus(observations, config=config)


### PR DESCRIPTION
## Summary
- harden `ConsensusConfig` by backing fields with private slots and read-only descriptors so even `object.__setattr__` cannot mutate them
- adjust consensus tests to clone configs with overrides via `dataclasses.replace`

## Testing
- pytest --cov=projects/04-llm-adapter-shadow --cov-report=xml:projects/04-llm-adapter-shadow/coverage.xml --cov-report=html:projects/04-llm-adapter-shadow/htmlcov projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68dd3f3d61cc8321b4b1558562a15dbd