### PR TITLE
Fix parallel-any attempt accounting for cancelled providers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_any.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_any.py
@@ -159,6 +159,13 @@ class ParallelAnyStrategy:
                     failures=failures or None,
                 )
             attempts_final = sum(1 for item in results if item is not None)
+            if cancelled_slots:
+                cancelled_count = sum(
+                    1
+                    for index in cancelled_slots
+                    if 0 <= index < len(results) and results[index] is None
+                )
+                attempts_final += cancelled_count
             if attempts_final == 0:
                 attempts_final = winner.attempt
             attempts_override = {winner.attempt: attempts_final}


### PR DESCRIPTION
## Summary
- ensure the parallel-any runner counts cancelled provider slots only when their results were not recorded so metrics track the total attempts consistently

## Testing
- pytest --cov=projects/04-llm-adapter-shadow --cov-report=xml:projects/04-llm-adapter-shadow/coverage.xml --cov-report=html:projects/04-llm-adapter-shadow/htmlcov projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68dd427b2a588321a08018d878a41472