### PR TITLE
Fix runner_config import ordering

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -1,9 +1,10 @@
 """Configuration objects for runner orchestration behavior."""
+
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError, dataclass, field
+from dataclasses import dataclass, field, FrozenInstanceError
 from enum import Enum
-from typing import Mapping, NamedTuple, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .shadow import DEFAULT_METRICS_PATH, MetricsPath
 


### PR DESCRIPTION
## Summary
- reorder runner_config imports per Ruff recommendations
- remove unused typing imports

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py


------
https://chatgpt.com/codex/tasks/task_e_68dd429332a883218789a4bd4e02495e