### PR TITLE
Fix lint issues in runner config and isinstance unions

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli.py
@@ -181,7 +181,9 @@ def prepare_execution(
             prompt_value = input_prompt if isinstance(input_prompt, str) else ""
         request_kwargs["prompt"] = prompt_value
         messages = raw_payload.get("messages")
-        if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes, bytearray)):
+        if isinstance(messages, Sequence) and not isinstance(
+            messages, str | bytes | bytearray
+        ):
             normalized = [dict(entry) for entry in messages if isinstance(entry, Mapping)]
             if normalized:
                 request_kwargs["messages"] = normalized

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
@@ -7,7 +7,7 @@ ScopeAttrs = list[dict[str, Any]]
 
 
 def _timestamp_ns(value: Any) -> str:
-    return str(int(float(value) * 1_000_000)) if isinstance(value, (int, float)) else "0"
+    return str(int(float(value) * 1_000_000)) if isinstance(value, int | float) else "0"
 
 
 def _encode_attrs(values: Mapping[str, Any]) -> ScopeAttrs:
@@ -95,6 +95,6 @@ class OtlpJsonExporter:
         prefix = f"llm_adapter.{event_type}."
         for field in fields:
             value = record.get(field)
-            if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if isinstance(value, int | float) and not isinstance(value, bool):
                 metrics.append(_gauge(prefix + field, timestamp, float(value), attrs))
         return metrics

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, FrozenInstanceError
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from typing import cast, TYPE_CHECKING
 
 from .shadow import DEFAULT_METRICS_PATH, MetricsPath
 

--- a/projects/04-llm-adapter/adapter/core/aggregation/builtin/majority_vote.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation/builtin/majority_vote.py
@@ -25,7 +25,7 @@ class MajorityVoteStrategy:
         if not isinstance(schema, Mapping):
             return frozenset()
         required = schema.get("required")
-        if isinstance(required, Sequence) and not isinstance(required, (str, bytes)):
+        if isinstance(required, Sequence) and not isinstance(required, str | bytes):
             keys = [key for key in required if isinstance(key, str)]
             return frozenset(keys)
         return frozenset()


### PR DESCRIPTION
## Summary
- sort the typing import in `runner_config.py`
- use `X | Y` syntax in `isinstance` guards to satisfy ruff's UP038 rule

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68dd477ddf288321854aeea51b33b36b