### PR TITLE
Handle errored statuses in failure summary

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from tools.ci_report.processing import compute_last_updated, normalize_flaky_rows
+from tools.ci_report.processing import (
+    compute_last_updated,
+    normalize_flaky_rows,
+    summarize_failure_kinds,
+)
 from tools.ci_report.rendering import render_markdown
 from tools.weekly_summary import select_flaky_rows
 
@@ -33,6 +37,17 @@ def test_normalize_flaky_rows_sorts_and_limits() -> None:
     assert [row["canonical_id"] for row in normalized] == ["b", "a"]
     assert normalized[0]["rank"] == 1
     assert normalized[1]["attempts"] == 2
+
+
+def test_summarize_failure_kinds_counts_errored() -> None:
+    runs = [
+        {"status": "fail", "failure_kind": "infra"},
+        {"status": "errored", "failure_kind": "infra"},
+    ]
+
+    summary = summarize_failure_kinds(runs)
+
+    assert {"kind": "infra", "count": 2} in summary
 
 
 def test_render_markdown_includes_summary(sample_runs: list[dict[str, object]]) -> None:

--- a/tools/ci_report/processing.py
+++ b/tools/ci_report/processing.py
@@ -5,6 +5,7 @@ from collections import Counter
 from collections.abc import Iterable
 import datetime as dt
 
+from tools.ci_metrics import normalize_status
 from tools.weekly_summary import coerce_str, parse_iso8601, to_float
 
 
@@ -27,10 +28,8 @@ def summarize_failure_kinds(
     counter: Counter[str] = Counter()
     for run in runs:
         status_raw = coerce_str(run.get("status"))
-        if status_raw is None:
-            continue
-        status = status_raw.lower()
-        if status not in {"fail", "failed", "error"}:
+        status = normalize_status(status_raw)
+        if status not in {"fail", "error"}:
             continue
         kind = coerce_str(run.get("failure_kind")) or "unknown"
         counter[kind] += 1


### PR DESCRIPTION
## Summary
- add a regression test ensuring summarize_failure_kinds counts errored statuses
- normalize CI failure summarization to use normalize_status so errored runs are tracked

## Testing
- pytest tests/test_generate_ci_report.py -k failure_kinds

------
https://chatgpt.com/codex/tasks/task_e_68de0c14735c8321bf7f8c6a380255d1