### PR TITLE
Add weekly summary generation to report workflow

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,7 +46,14 @@ lint:
 	fi
 	./.venv/bin/python -m compileall projects/04-llm-adapter-shadow
 
+# 週次サマリ生成
+weekly-summary:
+        set -euo pipefail
+        python -m projects.04-llm-adapter-shadow.tools.weekly_summary --input artifacts/runs-metrics.jsonl --output docs/weekly-summary.md
+
 # Python プロジェクトのカバレッジ付きレポート生成
 report:
-	set -euo pipefail
-	./.venv/bin/pytest --cov=projects/04-llm-adapter-shadow --cov-report=xml --cov-report=term-missing projects/04-llm-adapter-shadow/tests
+        set -euo pipefail
+        just test
+        ./.venv/bin/pytest --cov=projects/04-llm-adapter-shadow --cov-report=xml --cov-report=term-missing projects/04-llm-adapter-shadow/tests
+        just weekly-summary


### PR DESCRIPTION
## Summary
- add a `weekly-summary` recipe that runs the weekly summary generator with the metrics artifact
- ensure the `report` recipe runs the full test suite before coverage and regenerates the weekly summary output

## Testing
- python -m pytest -q tests/tools/test_weekly_summary_io.py

------
https://chatgpt.com/codex/tasks/task_e_68de0c0c363c8321a46c407ae518ac47