### PR TITLE
Add CLI flags for consensus latency and cost limits

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
+++ b/projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py
@@ -146,6 +146,33 @@ def test_build_runner_config_with_consensus(tmp_path: Path) -> None:
     )
 
 
+def test_build_runner_config_with_consensus_constraints(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("payload", encoding="utf-8")
+
+    args = cli.parse_args(
+        [
+            "--mode",
+            "consensus",
+            "--providers",
+            "mock:alpha,mock:beta",
+            "--input",
+            str(prompt_path),
+            "--max-latency-ms",
+            "250",
+            "--max-cost-usd",
+            "1.75",
+        ]
+    )
+
+    config = cli.build_runner_config(args)
+
+    assert config.consensus == ConsensusConfig(
+        max_latency_ms=250,
+        max_cost_usd=1.75,
+    )
+
+
 def test_cli_prepare_execution_with_consensus(tmp_path: Path) -> None:
     prompt_path = tmp_path / "prompt.txt"
     prompt_path.write_text("hello world\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add CLI support for configuring consensus latency and cost limits
- propagate the parsed values into ConsensusConfig construction
- document the new options directly in the CLI help text

## Testing
- pytest -k cli_runner_config

------
https://chatgpt.com/codex/tasks/task_e_68de0bfe3f9483218950b5371f2ab3a3