### PR TITLE
Add diff_kind classification to shadow metrics events

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_shadow_metrics_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow_metrics_schema.py
@@ -45,3 +45,45 @@ def test_shadow_metrics_include_provider_id_and_outcome_error(tmp_path: Path) ->
     assert event["shadow_provider"] == "shadow"
     assert event["shadow_provider_id"] == "shadow"
     assert event["shadow_outcome"] == "error"
+
+
+def test_shadow_metrics_diff_kind_match(tmp_path: Path) -> None:
+    primary = MockProvider("mirror", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("mirror", base_latency_ms=5, error_markers=set())
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    request = ProviderRequest(prompt="hello", model="primary-model")
+    runner.run(request, shadow=shadow, shadow_metrics_path=metrics_path)
+
+    event = _load_shadow_diff(metrics_path)
+    assert event["shadow_outcome"] == "success"
+    assert event["diff_kind"] == "match"
+
+
+def test_shadow_metrics_diff_kind_mismatch(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers=set())
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    request = ProviderRequest(prompt="hello", model="primary-model")
+    runner.run(request, shadow=shadow, shadow_metrics_path=metrics_path)
+
+    event = _load_shadow_diff(metrics_path)
+    assert event["shadow_outcome"] == "success"
+    assert event["diff_kind"] == "mismatch"
+
+
+def test_shadow_metrics_diff_kind_shadow_error(tmp_path: Path) -> None:
+    primary = MockProvider("primary", base_latency_ms=5, error_markers=set())
+    shadow = MockProvider("shadow", base_latency_ms=5, error_markers={"[TIMEOUT]"})
+    runner = Runner([primary])
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    request = ProviderRequest(prompt="[TIMEOUT] boom", model="primary-model")
+    runner.run(request, shadow=shadow, shadow_metrics_path=metrics_path)
+
+    event = _load_shadow_diff(metrics_path)
+    assert event["shadow_outcome"] == "error"
+    assert event["diff_kind"] == "shadow_error"


### PR DESCRIPTION
## Summary
- classify shadow metric events with a diff_kind field covering match, mismatch, and shadow_error cases
- extend schema tests to assert diff_kind values for successful, mismatched, and failing shadow responses

## Testing
- pytest -k shadow_metrics_schema -q


------
https://chatgpt.com/codex/tasks/task_e_68de0bfc7a248321bf988eec68c0b5e2