### PR TITLE
Handle errored status in CI aggregate summary

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -9,7 +9,7 @@ from tools.ci_report.processing import (
     summarize_failure_kinds,
 )
 from tools.ci_report.rendering import render_markdown
-from tools.weekly_summary import select_flaky_rows
+from tools.weekly_summary import aggregate_status, select_flaky_rows
 
 
 @pytest.fixture
@@ -19,6 +19,16 @@ def sample_runs() -> list[dict[str, object]]:
         {"ts": "2024-06-02T09:00:00Z", "status": "fail"},
         {"ts": None, "status": "error"},
     ]
+
+
+def test_aggregate_status_counts_errored_as_error() -> None:
+    runs = [
+        {"status": "pass"},
+        {"status": "fail"},
+        {"status": "errored"},
+    ]
+
+    assert aggregate_status(runs) == (1, 1, 1)
 
 
 def test_compute_last_updated(sample_runs: list[dict[str, object]]) -> None:

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -43,7 +43,7 @@ def aggregate_status(runs: Iterable[dict[str, object]]) -> tuple[int, int, int]:
             passes += 1
         elif status in {"fail", "failed"}:
             fails += 1
-        elif status == "error":
+        elif status in {"error", "errored"}:
             errors += 1
     return passes, fails, errors
 


### PR DESCRIPTION
## Summary
- add a regression test covering `aggregate_status` with an `errored` run status
- treat `errored` statuses as errors when aggregating weekly CI results

## Testing
- pytest tests/test_generate_ci_report.py -k aggregate_status

------
https://chatgpt.com/codex/tasks/task_e_68de12e0b7f08321b421a56f1e030438