### PR TITLE
Remove unused RunnerConfig fallback import

### DIFF
--- a/projects/04-llm-adapter/tests/parallel/conftest.py
+++ b/projects/04-llm-adapter/tests/parallel/conftest.py
@@ -22,10 +22,8 @@ from adapter.core.runner_execution_parallel import (
 )
 
 try:  # pragma: no cover - 型補完と後方互換用
-    from adapter.core.runner_api import RunnerConfig, RunnerMode
+    from adapter.core.runner_api import RunnerMode
 except ImportError:  # pragma: no cover - RunnerMode 未導入環境向け
-    from adapter.core.runner_api import RunnerConfig
-
     class RunnerMode(str, Enum):  # type: ignore[misc]
         PARALLEL_ANY = "parallel_any"
 


### PR DESCRIPTION
## Summary
- drop the unused RunnerConfig import from the parallel test fixture fallback
- retain the local RunnerMode definition for environments without RunnerMode

## Testing
- ruff check projects/04-llm-adapter/tests/parallel/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68de1539f278832188560ce021dbb0c6