### PR TITLE
chore: tidy weekly summary imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tools/weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tools/weekly_summary.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import argparse
-import json
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+import json
 from pathlib import Path
 from statistics import mean, median
 from typing import Any
@@ -61,7 +61,7 @@ def _collect(path: Path) -> Summary:
             if outcome == "success":
                 success += 1
             latency = record.get("latency_ms")
-            if isinstance(latency, (int, float)) and latency >= 0:
+            if isinstance(latency, int | float) and latency >= 0:
                 latencies.append(float(latency))
         elif event == "shadow_diff":
             diff_kind = record.get("diff_kind")


### PR DESCRIPTION
## Summary
- reorder weekly_summary imports to match Ruff's standard-library grouping
- modernize the latency type guard to use the union operator

## Testing
- ruff check projects/04-llm-adapter-shadow/tools/weekly_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68de1539af388321a19a747a2c846c1e