### PR TITLE
Add token usage payload to run metric events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -209,6 +209,13 @@ def log_run_metric(
     retries = attempts - 1 if attempts > 0 else 0
     outcome = _normalize_outcome(status)
     cost_estimate = float(cost_usd)
+    prompt_tokens = tokens_in if tokens_in is not None else 0
+    completion_tokens = tokens_out if tokens_out is not None else 0
+    token_usage = {
+        "prompt": prompt_tokens,
+        "completion": completion_tokens,
+        "total": prompt_tokens + completion_tokens,
+    }
     event_logger.emit(
         "run_metric",
         {
@@ -224,6 +231,7 @@ def log_run_metric(
             "latency_ms": latency_ms,
             "tokens_in": tokens_in,
             "tokens_out": tokens_out,
+            "token_usage": token_usage,
             "cost_usd": cost_estimate,
             "cost_estimate": cost_estimate,
             "error_type": type(error).__name__ if error is not None else None,

--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -25,6 +25,23 @@ def _run_and_fetch_event(
     return events
 
 
+def test_run_metric_includes_token_usage(tmp_path: Path) -> None:
+    provider = _SuccessProvider("primary")
+    logger = FakeLogger()
+    runner = Runner([provider], logger=logger)
+    request = ProviderRequest(prompt="hello", model="demo-token-usage")
+
+    events = _run_and_fetch_event(runner, request, metrics_path=tmp_path / "usage.jsonl")
+    event = events[0]
+
+    token_usage = event.get("token_usage")
+    assert isinstance(token_usage, dict)
+    assert set(token_usage) == {"prompt", "completion", "total"}
+    for key in ("prompt", "completion", "total"):
+        value = token_usage[key]
+        assert isinstance(value, int)
+
+
 def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
     provider = _SuccessProvider("primary")
     logger = FakeLogger()


### PR DESCRIPTION
## Summary
- add coverage ensuring run_metric events include token_usage details
- populate run_metric events with token_usage derived from token counters while keeping legacy fields

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68de151258608321b28ec8b05d345822