### PR TITLE
Add token usage metrics to provider call events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -154,6 +154,13 @@ def log_provider_call(
         return
 
     provider_name = _provider_name(provider)
+    prompt_tokens = int(tokens_in) if tokens_in is not None else 0
+    completion_tokens = int(tokens_out) if tokens_out is not None else 0
+    token_usage = {
+        "prompt": prompt_tokens,
+        "completion": completion_tokens,
+        "total": prompt_tokens + completion_tokens,
+    }
     event_logger.emit(
         "provider_call",
         {
@@ -170,6 +177,7 @@ def log_provider_call(
             "latency_ms": latency_ms,
             "tokens_in": tokens_in,
             "tokens_out": tokens_out,
+            "token_usage": token_usage,
             "error_type": type(error).__name__ if error is not None else None,
             "error_message": str(error) if error is not None else None,
             "error_family": error_family(error),


### PR DESCRIPTION
## Summary
- add coverage ensuring provider_call events include token usage details
- populate token_usage payload from tokens_in/out with zero fallbacks when logging provider calls

## Testing
- pytest -k runner_sync_invocation

------
https://chatgpt.com/codex/tasks/task_e_68de4926347c8321853ef38452bfe5eb