### PR TITLE
Remove unused cast import in weekly summary test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
+++ b/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
@@ -5,7 +5,7 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
-from typing import cast, Protocol
+from typing import Protocol
 
 
 def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:


### PR DESCRIPTION
## Summary
- drop the unused cast import from the weekly summary tool test
- ensure typing remains satisfied by retaining the callable assertion on the loaded main function

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68de491165d48321976623c72fb6b0e7