### PR TITLE
Adjust weekly summary isinstance tuple handling

### DIFF
--- a/tools/weekly_summary/io.py
+++ b/tools/weekly_summary/io.py
@@ -41,7 +41,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, int | float | bool):
+    if isinstance(value, (int, float, bool)):  # noqa: UP038 bool is intentionally grouped with numeric types.
         return str(value)
     return None
 


### PR DESCRIPTION
## Summary
- update `coerce_str` to use a tuple `isinstance` check and annotate the intentional grouping

## Testing
- ruff check tools/weekly_summary/io.py --select UP038

------
https://chatgpt.com/codex/tasks/task_e_68de490509688321bcd80837a61f0f00