### PR TITLE
Fix isinstance usage in OTLP metrics exporter

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
@@ -7,7 +7,11 @@ ScopeAttrs = list[dict[str, Any]]
 
 
 def _timestamp_ns(value: Any) -> str:
-    return str(int(float(value) * 1_000_000)) if isinstance(value, int | float) else "0"
+    return (
+        str(int(float(value) * 1_000_000))
+        if isinstance(value, (int, float)) and not isinstance(value, bool)  # noqa: UP038
+        else "0"
+    )
 
 
 def _encode_attrs(values: Mapping[str, Any]) -> ScopeAttrs:
@@ -25,6 +29,8 @@ def _encode_attrs(values: Mapping[str, Any]) -> ScopeAttrs:
             value = {"stringValue": str(raw)}
         attrs.append({"key": str(key), "value": value})
     return attrs
+
+
 def _gauge(name: str, timestamp: str, value: float, attrs: ScopeAttrs) -> dict[str, Any]:
     return {
         "name": name,
@@ -95,6 +101,6 @@ class OtlpJsonExporter:
         prefix = f"llm_adapter.{event_type}."
         for field in fields:
             value = record.get(field)
-            if isinstance(value, int | float) and not isinstance(value, bool):
+            if isinstance(value, (int, float)) and not isinstance(value, bool):  # noqa: UP038
                 metrics.append(_gauge(prefix + field, timestamp, float(value), attrs))
         return metrics


### PR DESCRIPTION
## Summary
- ensure OTLP metrics exporter ignores bools when formatting numeric timestamps and metrics
- document tuple-based isinstance checks with UP038 suppressions and normalize import spacing

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py --select I001,UP038

------
https://chatgpt.com/codex/tasks/task_e_68de4904fe7c8321926077ff2f7a68de