### PR TITLE
Fix isinstance tuple usage in weekly summary

### DIFF
--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -101,7 +101,7 @@ def coerce_str(value: object | None) -> str | None:
     if isinstance(value, str):
         stripped = value.strip()
         return stripped or None
-    if isinstance(value, bool | int | float):
+    if isinstance(value, (bool, int, float)):  # noqa: UP038
         return str(value)
     return None
 
@@ -110,7 +110,7 @@ def to_float(value: object) -> float | None:
         return None
     if isinstance(value, bool):
         return float(value)
-    if isinstance(value, int | float):
+    if isinstance(value, (int, float)):  # noqa: UP038
         return float(value)
     if isinstance(value, str):
         s = value.strip()


### PR DESCRIPTION
## Summary
- switch the `isinstance` calls in the weekly summary helpers to tuple-based syntax
- silence UP038 lint locally while keeping the tuple usage

## Testing
- ruff check tools/weekly_summary/__init__.py --select UP038

------
https://chatgpt.com/codex/tasks/task_e_68de4903211c83219df76e378a97249e