### PR TITLE
Fix UP038 lint in run metric schema test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
+++ b/projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py
@@ -56,7 +56,7 @@ def test_sequential_run_metric_contains_required_fields(tmp_path: Path) -> None:
     assert event["providers"] == ["primary"]
     assert event["provider_id"] == event["provider"]
     cost_usd = event["cost_usd"]
-    assert isinstance(cost_usd, int | float)
+    assert isinstance(cost_usd, (int, float))  # noqa: UP038
     assert event["cost_estimate"] == pytest.approx(float(cost_usd))
 
     attempts = event["attempts"]


### PR DESCRIPTION
## Summary
- update the run metric schema test to use tuple-based isinstance check with a UP038 suppression

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_run_metric_schema.py --select UP038

------
https://chatgpt.com/codex/tasks/task_e_68de4901b1dc8321b581dd7fb3af46d7