### PR TITLE
Fix isinstance tuple handling in aggregation selector

### DIFF
--- a/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_selector_components.py
@@ -108,7 +108,7 @@ class JudgeScorer:
         raw = getattr(response, "raw", None)
         if isinstance(raw, Mapping):
             value = raw.get("quality_score")
-            if isinstance(value, int | float):
+            if isinstance(value, (int, float)):  # noqa: UP038
                 return float(value)
         text = getattr(response, "text", None)
         if isinstance(text, str):


### PR DESCRIPTION
## Summary
- switch the quality score type check to use a tuple-based isinstance for compatibility
- silence ruff UP038 for the tuple form

## Testing
- ruff check projects/04-llm-adapter/adapter/core/aggregation_selector_components.py --select UP038

------
https://chatgpt.com/codex/tasks/task_e_68de48ffebc88321ab43460693ea7629