### PR TITLE
Fix weekly summary latency isinstance tuple

### DIFF
--- a/projects/04-llm-adapter-shadow/tools/weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tools/weekly_summary.py
@@ -61,7 +61,7 @@ def _collect(path: Path) -> Summary:
             if outcome == "success":
                 success += 1
             latency = record.get("latency_ms")
-            if isinstance(latency, (int | float)) and latency >= 0:
+            if isinstance(latency, (int, float)) and latency >= 0:  # noqa: UP038
                 latencies.append(float(latency))
         elif event == "shadow_diff":
             diff_kind = record.get("diff_kind")


### PR DESCRIPTION
## Summary
- adjust the weekly summary latency type check to use tuple syntax and document the UP038 suppression

## Testing
- ruff check projects/04-llm-adapter-shadow/tools/weekly_summary.py --select I001,UP038

------
https://chatgpt.com/codex/tasks/task_e_68de48ff35e88321a375817550f1a879