### PR TITLE
Sort imports in sync metrics helper test module

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sync_metrics/helpers.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_metrics/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 import time
-from typing import Any, NamedTuple, cast
+from typing import Any, cast, NamedTuple
 
 from src.llm_adapter.observability import CompositeLogger, EventLogger, JsonlLogger
 from src.llm_adapter.parallel_exec import (
@@ -16,10 +16,10 @@ from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 from src.llm_adapter.runner_shared import MetricsPath
 from src.llm_adapter.runner_sync import Runner
 from src.llm_adapter.runner_sync_invocation import ProviderInvocationResult
-from src.llm_adapter.runner_sync_modes import SyncRunContext, get_sync_strategy
+from src.llm_adapter.runner_sync_modes import get_sync_strategy, SyncRunContext
 from src.llm_adapter.utils import content_hash
 
-from ..parallel_helpers import RecordingLogger, _read_metrics
+from ..parallel_helpers import _read_metrics, RecordingLogger
 
 
 class ExecutionResult(NamedTuple):


### PR DESCRIPTION
## Summary
- sort imports in the sync metrics helper test module to satisfy Ruff import ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sync_metrics/helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68de66f60dfc832197ec149513005a0a