### PR TITLE
Handle "passed" status in weekly summary aggregation

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -31,6 +31,15 @@ def test_aggregate_status_counts_errored_as_error() -> None:
     assert aggregate_status(runs) == (1, 1, 1)
 
 
+def test_aggregate_status_counts_passed_as_pass() -> None:
+    runs = [
+        {"status": "pass"},
+        {"status": "passed"},
+    ]
+
+    assert aggregate_status(runs) == (2, 0, 0)
+
+
 def test_compute_last_updated(sample_runs: list[dict[str, object]]) -> None:
     assert compute_last_updated(sample_runs) == "2024-06-02T09:00:00Z"
 

--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -39,7 +39,7 @@ def aggregate_status(runs: Iterable[dict[str, object]]) -> tuple[int, int, int]:
         if status_raw is None:
             continue
         status = status_raw.lower()
-        if status == "pass":
+        if status in {"pass", "passed"}:
             passes += 1
         elif status in {"fail", "failed"}:
             fails += 1


### PR DESCRIPTION
## Summary
- add a regression test covering runs with status="passed" in the weekly summary aggregation tests
- treat both "pass" and "passed" as successful statuses within aggregate_status

## Testing
- pytest tests/test_generate_ci_report.py -k aggregate_status

------
https://chatgpt.com/codex/tasks/task_e_68de67044dac8321a187a4154ce4e9d1