### PR TITLE
Refactor Gemini provider tests into dedicated package

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from types import SimpleNamespace
-from typing import Any, cast, NoReturn
+from typing import Any, NoReturn, cast
 
 import pytest
 
-pytest.importorskip("adapter.core.errors")
 pytest.importorskip("adapter.core.providers.gemini_support")
 
-from adapter.core.errors import RateLimitError as CoreRateLimitError
-from adapter.core.providers import gemini_support
 from src.llm_adapter.errors import (
     AuthError,
     ProviderSkip,
@@ -201,7 +198,7 @@ def test_gemini_provider_translates_rate_limit_status_object(
         def __init__(self, name: str) -> None:
             self.name = name
 
-        def __str__(self) -> str:  # pragma: no cover - defensive normalization
+        def __str__(self) -> str:
             return f"StatusCode.{self.name}"
 
     class _RateLimitedError(Exception):
@@ -265,7 +262,7 @@ def test_gemini_provider_translates_timeout_status_object(
         def __init__(self, name: str) -> None:
             self.name = name
 
-        def __str__(self) -> str:  # pragma: no cover - defensive normalization
+        def __str__(self) -> str:
             return f"StatusCode.{self.name}"
 
     class _DeadlineExceededError(Exception):
@@ -359,56 +356,3 @@ def test_gemini_provider_translates_http_errors(
 
     with pytest.raises(expected):
         provider.invoke(ProviderRequest(prompt="hello", model=provider_request_model))
-
-
-def test_normalize_gemini_exception_status_mapping() -> None:
-    class _ResourceExhaustedError(Exception):
-        def __init__(self) -> None:
-            super().__init__("rate limited")
-            self.status_code = 429
-
-    normalized = gemini_support.normalize_gemini_exception(_ResourceExhaustedError())
-
-    assert isinstance(normalized, CoreRateLimitError)
-    assert str(normalized) == "Gemini API のクォータ制限に達しました"
-
-
-def test_extract_usage_prefers_usage_metadata() -> None:
-    response = SimpleNamespace(
-        usage_metadata=SimpleNamespace(input_tokens=11, output_tokens=5)
-    )
-
-    prompt_tokens, output_tokens = gemini_support.extract_usage(
-        response, "ignored", "response text"
-    )
-
-    assert prompt_tokens == 11
-    assert output_tokens == 5
-
-
-def test_extract_usage_estimates_when_missing_metadata() -> None:
-    response = SimpleNamespace(usage_metadata=None)
-
-    prompt_tokens, output_tokens = gemini_support.extract_usage(
-        response, "prompt with four words", "three tokens here"
-    )
-
-    assert prompt_tokens == 4
-    assert output_tokens == 3
-
-
-def test_extract_output_text_prefers_text_field() -> None:
-    response = SimpleNamespace(text=" direct text ")
-
-    assert gemini_support.extract_output_text(response) == " direct text "
-
-
-def test_extract_output_text_falls_back_to_candidates() -> None:
-    response = SimpleNamespace(
-        candidates=[
-            {"text": ""},
-            SimpleNamespace(text="candidate text"),
-        ]
-    )
-
-    assert gemini_support.extract_output_text(response) == "candidate text"

--- a/projects/04-llm-adapter-shadow/tests/providers/gemini/test_support_utils.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/gemini/test_support_utils.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("adapter.core.errors")
+pytest.importorskip("adapter.core.providers.gemini_support")
+
+from adapter.core.errors import RateLimitError as CoreRateLimitError
+from adapter.core.providers import gemini_support
+
+
+def test_normalize_gemini_exception_status_mapping() -> None:
+    class _ResourceExhaustedError(Exception):
+        def __init__(self) -> None:
+            super().__init__("rate limited")
+            self.status_code = 429
+
+    normalized = gemini_support.normalize_gemini_exception(_ResourceExhaustedError())
+
+    assert isinstance(normalized, CoreRateLimitError)
+    assert str(normalized) == "Gemini API のクォータ制限に達しました"
+
+
+def test_extract_usage_prefers_usage_metadata() -> None:
+    response = SimpleNamespace(
+        usage_metadata=SimpleNamespace(input_tokens=11, output_tokens=5)
+    )
+
+    prompt_tokens, output_tokens = gemini_support.extract_usage(
+        response, "ignored", "response text"
+    )
+
+    assert prompt_tokens == 11
+    assert output_tokens == 5
+
+
+def test_extract_usage_estimates_when_missing_metadata() -> None:
+    response = SimpleNamespace(usage_metadata=None)
+
+    prompt_tokens, output_tokens = gemini_support.extract_usage(
+        response, "prompt with four words", "three tokens here"
+    )
+
+    assert prompt_tokens == 4
+    assert output_tokens == 3
+
+
+def test_extract_output_text_prefers_text_field() -> None:
+    response = SimpleNamespace(text=" direct text ")
+
+    assert gemini_support.extract_output_text(response) == " direct text "
+
+
+def test_extract_output_text_falls_back_to_candidates() -> None:
+    response = SimpleNamespace(
+        candidates=[
+            {"text": ""},
+            SimpleNamespace(text="candidate text"),
+        ]
+    )
+
+    assert gemini_support.extract_output_text(response) == "candidate text"


### PR DESCRIPTION
## Summary
- reorganize Gemini provider tests under tests/providers/gemini/
- separate provider invocation/error translation cases from gemini_support utility assertions

## Testing
- pytest projects/04-llm-adapter-shadow/tests/providers/gemini

------
https://chatgpt.com/codex/tasks/task_e_68de6705dadc8321889e7abc065b3e95