### PR TITLE
Fix CI metrics pass rate to ignore skipped runs

### DIFF
--- a/tests/test_ci_metrics.py
+++ b/tests/test_ci_metrics.py
@@ -1,0 +1,34 @@
+import datetime as dt
+
+from tools.ci_metrics import RunMetrics, compute_run_history
+
+
+def _run_record(status: str, *, run_id: str = "run-1", ts: dt.datetime | None = None) -> dict:
+    timestamp = ts or dt.datetime(2024, 1, 1, tzinfo=dt.UTC)
+    return {
+        "run_id": run_id,
+        "ts": timestamp.isoformat().replace("+00:00", "Z"),
+        "status": status,
+    }
+
+
+def test_compute_run_history_excludes_other_statuses_from_pass_rate() -> None:
+    runs = [
+        _run_record("pass"),
+        _run_record("skipped", ts=dt.datetime(2024, 1, 1, 0, 1, tzinfo=dt.UTC)),
+    ]
+
+    history = compute_run_history(runs)
+
+    assert history == [
+        RunMetrics(
+            run_id="run-1",
+            timestamp=dt.datetime(2024, 1, 1, tzinfo=dt.UTC),
+            total=1,
+            passes=1,
+            fails=0,
+            errors=0,
+            pass_rate=1.0,
+            flaky_count=0,
+        )
+    ]

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -120,6 +120,7 @@ def compute_run_history(
             elif previous_flag and not is_flaky:
                 current_flaky_total = max(0, current_flaky_total - 1)
 
+        total = passes + fails + errors
         pass_rate = (passes / total) if total else None
         metrics.append(
             RunMetrics(


### PR DESCRIPTION
## Summary
- add a regression test covering compute_run_history pass rate expectations
- ensure compute_run_history excludes non-result statuses from pass rate totals

## Testing
- pytest tests/test_ci_metrics.py -k run_history

------
https://chatgpt.com/codex/tasks/task_e_68de7175e3108321abb1e0c896a557fb