### PR TITLE
Fix CI pass rate calculation to ignore skipped results

### DIFF
--- a/tests/test_ci_metrics.py
+++ b/tests/test_ci_metrics.py
@@ -1,0 +1,21 @@
+from tools.ci_metrics import compute_run_history
+
+
+def test_compute_run_history_excludes_other_statuses_from_pass_rate():
+    runs = [
+        {
+            "run_id": "1",
+            "status": "pass",
+            "ts": "2024-01-01T00:00:00Z",
+        },
+        {
+            "run_id": "1",
+            "status": "skipped",
+            "ts": "2024-01-01T00:01:00Z",
+        },
+    ]
+
+    history = compute_run_history(runs)
+
+    assert len(history) == 1
+    assert history[0].pass_rate == 1.0

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -91,7 +91,6 @@ def compute_run_history(
             or run.timestamp
             or dt.datetime.min.replace(tzinfo=dt.UTC),
         ):
-            total += 1
             status = normalize_status(coerce_str(record.get("status")))
             if status == "pass":
                 passes += 1
@@ -120,6 +119,7 @@ def compute_run_history(
             elif previous_flag and not is_flaky:
                 current_flaky_total = max(0, current_flaky_total - 1)
 
+        total = passes + fails + errors
         pass_rate = (passes / total) if total else None
         metrics.append(
             RunMetrics(


### PR DESCRIPTION
## Summary
- add a regression test for compute_run_history ensuring skipped runs do not reduce pass rate
- recompute run totals from pass/fail/error statuses so pass rate ignores other outcomes

## Testing
- pytest tests/test_ci_metrics.py -k run_history

------
https://chatgpt.com/codex/tasks/task_e_68de7174aae483219cd06fa3dafbb73f