### PR TITLE
Reorder imports in gemini provider test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from types import SimpleNamespace
-from typing import Any, NoReturn, cast
+from typing import Any, cast, NoReturn
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder typing imports alphabetically in the Gemini provider invoke test
- keep standard library, third-party, and local imports separated

## Testing
- `ruff check projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68de71585fcc8321880e219927e387fe