### PR TITLE
Sort imports in Gemini provider test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
+++ b/projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from types import SimpleNamespace
-from typing import Any, NoReturn, cast
+from typing import Any, cast, NoReturn
 
 import pytest
 


### PR DESCRIPTION
## Summary
- sort typing imports in the Gemini provider test to satisfy Ruff I001

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/providers/gemini/test_provider_invoke.py --select I001


------
https://chatgpt.com/codex/tasks/task_e_68de71549c208321ae0d409a6942ec06