### PR TITLE
chore: sort imports in runner_sync

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py
@@ -35,7 +35,6 @@ from .runner_sync_modes import get_sync_strategy, SyncRunContext
 from .shadow import DEFAULT_METRICS_PATH
 from .utils import content_hash, elapsed_ms
 
-
 _CANCELLED_RESULT_WAIT_S = 0.05
 _CANCELLED_RESULT_POLL_S = 0.001
 


### PR DESCRIPTION
## Summary
- organize the imports in `runner_sync.py` so Ruff no longer flags an I001 issue

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68de715387b08321a5a4f3b8814b6591