### PR TITLE
Add consensus reason metadata to vote events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
@@ -102,6 +102,7 @@ class ConsensusRunStrategy(ParallelStrategyBase):
                 "consensus_vote",
                 {
                     "request_fingerprint": context.request_fingerprint,
+                    "reason": consensus.reason,
                     "strategy": consensus.strategy,
                     "tie_breaker": consensus.tie_breaker,
                     "quorum": consensus.min_votes,
@@ -160,6 +161,7 @@ class ConsensusRunStrategy(ParallelStrategyBase):
                     "tie_breaker_selected": consensus.tie_breaker_selected,
                     "judge": consensus.judge_name,
                     "judge_score": consensus.judge_score,
+                    "reason": consensus.reason,
                 }
             }
             if not shadow_payload.get("shadow_ok", True):

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
@@ -146,6 +146,7 @@ class ConsensusStrategy:
                     "consensus_vote",
                     {
                         "request_fingerprint": context.request_fingerprint,
+                        "reason": consensus.reason,
                         "strategy": consensus.strategy,
                         "tie_breaker": consensus.tie_breaker,
                         "quorum": consensus.min_votes,
@@ -186,6 +187,7 @@ class ConsensusStrategy:
                         "tie_breaker_selected": consensus.tie_breaker_selected,
                         "judge": consensus.judge_name,
                         "judge_score": consensus.judge_score,
+                        "reason": consensus.reason,
                     }
                 }
                 if not shadow_payload.get("shadow_ok", True):

--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_consensus.py
@@ -67,6 +67,7 @@ def test_async_consensus_vote_event(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert consensus_event["winner_provider"] == "agree_a"
     assert consensus_event["quorum"] == 2
     assert consensus_event["chosen_provider"] == "agree_a"
+    assert consensus_event["reason"] == "majority_vote quorum=2/3"
 
     winner_diff = next(
         item
@@ -75,6 +76,10 @@ def test_async_consensus_vote_event(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         and item.get("primary_provider") == "agree_a"
     )
     assert winner_diff["shadow_consensus_delta"]["votes_total"] == 3
+    assert (
+        winner_diff["shadow_consensus_delta"]["reason"]
+        == "majority_vote quorum=2/3"
+    )
 
 
 def test_async_consensus_quorum_failure() -> None:

--- a/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_parallel.py
@@ -766,6 +766,7 @@ def test_consensus_vote_event_and_shadow_delta(
     )
     assert consensus_event["strategy"] == "majority_vote"
     assert consensus_event["quorum"] == 2
+    assert consensus_event["reason"] == "majority_vote quorum=2/3"
     assert consensus_event["voters_total"] == 3
     assert consensus_event["votes_for"] == 2
     assert consensus_event["votes_against"] == 1
@@ -800,3 +801,7 @@ def test_consensus_vote_event_and_shadow_delta(
     )
     assert winner_diff["shadow_consensus_delta"]["votes_for"] == 2
     assert winner_diff["shadow_consensus_delta"]["votes_total"] == 3
+    assert (
+        winner_diff["shadow_consensus_delta"]["reason"]
+        == "majority_vote quorum=2/3"
+    )


### PR DESCRIPTION
## Summary
- extend consensus results with a human-readable reason string that includes strategy, quorum, and tie-break details
- propagate the reason to consensus vote telemetry and shadow metrics payloads
- verify the reason appears in synchronous and asynchronous consensus vote logs

## Testing
- pytest projects/04-llm-adapter-shadow/tests -k consensus_vote

------
https://chatgpt.com/codex/tasks/task_e_68de716cdccc8321bb7e3b092a869416