### PR TITLE
Handle errored JUnit statuses in CI report summary

### DIFF
--- a/tests/scripts/test_build_ci_reports.mjs
+++ b/tests/scripts/test_build_ci_reports.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { summariseJUnit } from '../../scripts/build-ci-reports.mjs';
+
+test('summariseJUnit counts errored status as error', (t) => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-reports-'));
+  t.after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const inputPath = path.join(tmpDir, 'junit.xml');
+  const outputDir = path.join(tmpDir, 'out');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="Dummy">\n  <testcase classname="Example" name="errored case" status="errored" time="0.1" />\n</testsuite>\n`;
+  fs.writeFileSync(inputPath, xml, 'utf8');
+
+  const summary = summariseJUnit(inputPath, outputDir);
+
+  assert.equal(summary.errors, 1);
+});


### PR DESCRIPTION
## Summary
- add a node:test case covering summariseJUnit with an errored status testcase
- export summariseJUnit for reuse and guard the CLI entrypoint from running on import
- normalise error counting so both `error` and `errored` statuses increment the summary

## Testing
- node --test tests/scripts/test_build_ci_reports.mjs

------
https://chatgpt.com/codex/tasks/task_e_68de7ad917408321bf7f1e4e767f49c8