### PR TITLE
Sort imports in CLI runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli/runner.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli/runner.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from ..parallel_exec import ParallelAllResult
 from ..provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
-from ..providers.factory import ProviderFactory, create_provider_from_spec, parse_provider_spec
+from ..providers.factory import create_provider_from_spec, parse_provider_spec, ProviderFactory
 from ..runner import AsyncRunner, Runner
 from ..shadow import MetricsPath
 from .args import parse_args


### PR DESCRIPTION
## Summary
- reorder the provider factory import members to satisfy Ruff's I001 import-sorting rule in the CLI runner module

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/cli/runner.py --select I001
- pytest projects/04-llm-adapter-shadow/tests/test_cli_runner_config.py

------
https://chatgpt.com/codex/tasks/task_e_68de7a91647c83219add089cca75b60f