### PR TITLE
fix: lazily expose CLI format helper

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli/__init__.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+from typing import Any
+
 from .args import parse_args
 from .config import build_runner_config
-from .io import _format_output
 from .runner import main, prepare_execution
 
 __all__ = ["parse_args", "build_runner_config", "prepare_execution", "main"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "_format_output":
+        from .io import _format_output as format_output
+
+        return format_output
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- remove the unused eager import of `_format_output`
- expose `_format_output` via `__getattr__` to preserve backwards compatibility

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/cli/__init__.py --select F401
- pytest projects/04-llm-adapter-shadow/tests

------
https://chatgpt.com/codex/tasks/task_e_68de7a9138308321a7e06d504737ace6