### PR TITLE
Fix import order in CLI IO module

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/cli/io.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/cli/io.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
+import json
 from json import JSONDecodeError
 from typing import Any
 


### PR DESCRIPTION
## Summary
- reorder the llm_adapter CLI I/O imports to satisfy Ruff's I001 rule

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/cli/io.py --select I001
- pytest projects/04-llm-adapter-shadow/tests/cli *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de7a9130d8832199ddd7ec471ac660