### PR TITLE
style: format CLI app with black

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/app.py
+++ b/projects/04-llm-adapter/adapter/cli/app.py
@@ -20,7 +20,9 @@ from .prompts import run_prompts
 def _cli_namespace() -> ModuleType:
     return import_module(__name__.rsplit(".", 1)[0])
 
+
 T = TypeVar("T")
+
 
 def _with_cli_namespace(accessor: Callable[[ModuleType], T]) -> T:
     namespace = _cli_namespace()
@@ -57,7 +59,9 @@ def _run_prompts_from_iterable(args: Iterable[str]) -> int:
 
 
 def _run_doctor_from_iterable(args: Iterable[str]) -> int:
-    return run_doctor(list(args), socket_module=_socket_module(), http_module=_http_module())
+    return run_doctor(
+        list(args), socket_module=_socket_module(), http_module=_http_module()
+    )
 
 
 if typer is not None:  # pragma: no branch - import-time decision
@@ -116,5 +120,5 @@ else:  # pragma: no cover - exercised when Typer is unavailable
             return doctor(args[1:])
         return run(args)
 
-__all__ = ["app", "doctor", "main", "run"]
 
+__all__ = ["app", "doctor", "main", "run"]


### PR DESCRIPTION
## Summary
- format `projects/04-llm-adapter/adapter/cli/app.py` using Black to match repository style

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py *(fails: TypeError in `DummyRunner.run`, also present before formatting)*
- black --check projects/04-llm-adapter/adapter/cli/app.py


------
https://chatgpt.com/codex/tasks/task_e_68de81ef19cc83218703927208ecbdd5