### PR TITLE
Refactor sync invocation tests into dedicated modules

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sync_invocation/conftest.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_invocation/conftest.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import pytest
+
+from src.llm_adapter.observability import EventLogger
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
+from src.llm_adapter.shadow import ShadowMetrics
+
+
+class RecorderLogger(EventLogger):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, event_type: str, record: dict[str, Any]) -> None:  # type: ignore[override]
+        self.events.append((event_type, dict(record)))
+
+
+class StubProvider:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def capabilities(self) -> set[str]:  # pragma: no cover - protocol compat
+        return set()
+
+    def invoke(self, request: ProviderRequest) -> ProviderResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+class FakeMetrics(ShadowMetrics):
+    def __init__(self) -> None:
+        super().__init__(payload={}, logger=None)
+        self.emitted: list[Mapping[str, Any] | None] = []
+
+    def emit(self, extra: Mapping[str, Any] | None = None) -> None:
+        self.emitted.append(extra)
+
+
+@pytest.fixture
+def recorder_logger() -> RecorderLogger:
+    return RecorderLogger()
+
+
+@pytest.fixture
+def stub_provider_factory() -> Callable[[str], StubProvider]:
+    def factory(name: str) -> StubProvider:
+        return StubProvider(name)
+
+    return factory
+
+
+@pytest.fixture
+def provider_request() -> ProviderRequest:
+    return ProviderRequest(model="gpt", prompt="hi")
+
+
+@pytest.fixture
+def provider_response() -> ProviderResponse:
+    return ProviderResponse(
+        "ok",
+        latency_ms=42,
+        token_usage=TokenUsage(prompt=3, completion=5),
+    )
+
+
+@pytest.fixture
+def fake_metrics_factory() -> Callable[[], FakeMetrics]:
+    return FakeMetrics

--- a/projects/04-llm-adapter-shadow/tests/sync_invocation/test_cancelled_results.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_invocation/test_cancelled_results.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from concurrent.futures import CancelledError
+from typing import Any, Callable
+
+import pytest
+
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.runner_sync_invocation import (
+    CancelledResultsBuilder,
+    ParallelResultLogger,
+    ProviderInvocationResult,
+)
+
+from .conftest import RecorderLogger, StubProvider
+
+
+@pytest.fixture
+def cancelled_builder() -> CancelledResultsBuilder:
+    return CancelledResultsBuilder(run_started=1.0, elapsed_ms=lambda start: 99)
+
+
+@pytest.fixture
+def parallel_logger() -> ParallelResultLogger:
+    return ParallelResultLogger(
+        log_provider_call=lambda *a, **k: None,
+        log_run_metric=lambda *a, **k: None,
+        estimate_cost=lambda provider, tokens_in, tokens_out: 0.0,
+        elapsed_ms=lambda start: 13,
+    )
+
+
+def test_cancelled_results_skip_metrics(
+    stub_provider_factory: Callable[[str], StubProvider],
+    cancelled_builder: CancelledResultsBuilder,
+    parallel_logger: ParallelResultLogger,
+    provider_request: ProviderRequest,
+    recorder_logger: RecorderLogger,
+) -> None:
+    providers = [stub_provider_factory("primary"), stub_provider_factory("secondary")]
+    results: list[ProviderInvocationResult | None] = [None, None]
+
+    cancelled_builder.apply(results, providers=providers, cancelled_indices=[0, 1], total_providers=2)
+
+    assert all(isinstance(entry, ProviderInvocationResult) for entry in results)
+    assert all(isinstance(entry.error, CancelledError) for entry in results if entry is not None)
+
+    log_run_metric_calls: list[dict[str, Any]] = []
+
+    def fake_log_run_metric(*_: Any, **kwargs: Any) -> None:
+        log_run_metric_calls.append(dict(kwargs))
+
+    logger = ParallelResultLogger(
+        log_provider_call=lambda *a, **k: None,
+        log_run_metric=fake_log_run_metric,
+        estimate_cost=lambda provider, tokens_in, tokens_out: 0.0,
+        elapsed_ms=lambda start: 13,
+    )
+
+    logger.log_results(
+        results,
+        event_logger=recorder_logger,
+        request=provider_request,
+        request_fingerprint="fp",
+        metadata={},
+        run_started=0.0,
+        shadow_used=False,
+        skip=tuple(result for result in results if result is not None),
+    )
+
+    assert log_run_metric_calls == []
+    assert all(isinstance(entry.error, CancelledError) for entry in results if entry is not None)


### PR DESCRIPTION
## Summary
- group sync invocation test helpers into a dedicated conftest module
- split ProviderInvoker and cancellation logging coverage into focused test modules under tests/sync_invocation
- ensure pytest projects/04-llm-adapter-shadow/tests/sync_invocation continues to pass

## Testing
- pytest projects/04-llm-adapter-shadow/tests/sync_invocation

------
https://chatgpt.com/codex/tasks/task_e_68de81e550ac83218bd12d0031ea3996