### PR TITLE
Handle errored attempts as failures

### DIFF
--- a/tests/projects/test_ci_flaky_analyzer.mjs
+++ b/tests/projects/test_ci_flaky_analyzer.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import { computeAggregates, isFailureStatus } from '../../projects/03-ci-flaky/src/analyzer.js';
+
+test('errored attempts are treated as failures', () => {
+  assert.strictEqual(isFailureStatus({ status: 'errored' }), true);
+
+  const runId = 'run-1';
+  const attempt = {
+    canonical_id: 'suite.class.test',
+    suite: 'suite',
+    class: 'class',
+    name: 'test',
+    status: 'errored',
+    duration_ms: 10,
+  };
+  const runs = new Map([[runId, { attempts: [attempt] }]]);
+  const runOrder = [runId];
+
+  const { results } = computeAggregates(runs, runOrder, {});
+  assert.equal(results.length, 1);
+  assert.equal(results[0].fails, 1);
+});


### PR DESCRIPTION
## Summary
- add a node:test case to cover errored attempts in the CI flaky analyzer
- treat "errored" statuses as failures across aggregation helpers

## Testing
- node --test tests/projects/test_ci_flaky_analyzer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68de81e4b5d08321ad752f0bff1faf7b