### PR TITLE
Fix mypy typing for lazy parallel logging exports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -21,8 +21,8 @@ from .utils import elapsed_ms
 
 if TYPE_CHECKING:
     from .runner_sync_parallel_logging import (
-        CancelledResultsBuilder as _CancelledResultsBuilderType,
-        ParallelResultLogger as _ParallelResultLoggerType,
+        CancelledResultsBuilder,
+        ParallelResultLogger,
     )
 
 
@@ -192,8 +192,8 @@ class ProviderInvoker:
 
 
 def _load_parallel_logging() -> tuple[
-    type[_CancelledResultsBuilderType],
-    type[_ParallelResultLoggerType],
+    type["CancelledResultsBuilder"],
+    type["ParallelResultLogger"],
 ]:
     from .runner_sync_parallel_logging import (
         CancelledResultsBuilder as _CancelledResultsBuilder,
@@ -203,9 +203,8 @@ def _load_parallel_logging() -> tuple[
     return _CancelledResultsBuilder, _ParallelResultLogger
 
 
-CancelledResultsBuilder: type[_CancelledResultsBuilderType]
-ParallelResultLogger: type[_ParallelResultLoggerType]
-CancelledResultsBuilder, ParallelResultLogger = _load_parallel_logging()
+if not TYPE_CHECKING:
+    CancelledResultsBuilder, ParallelResultLogger = _load_parallel_logging()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- ensure the lazy exports for CancelledResultsBuilder and ParallelResultLogger are compatible with mypy by importing the classes when type checking
- keep the runtime lazy loading path while providing precise return annotations for the loader helper

## Testing
- mypy --config-file pyproject.toml projects/04-llm-adapter-shadow/src projects/04-llm-adapter-shadow/tests tools

------
https://chatgpt.com/codex/tasks/task_e_68de885072288321926a4cc8ef1dafee