### PR TITLE
Fix ruff import ordering in llm adapter tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/consensus/test_consensus_algorithms.py
+++ b/projects/04-llm-adapter-shadow/tests/consensus/test_consensus_algorithms.py
@@ -4,10 +4,10 @@ from typing import cast
 
 import pytest
 
-import src.llm_adapter.runner_parallel as runner_parallel
 from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import ProviderResponse, TokenUsage
 from src.llm_adapter.runner_config import ConsensusConfig
+import src.llm_adapter.runner_parallel as runner_parallel
 from src.llm_adapter.runner_parallel import (
     compute_consensus,
     ConsensusObservation,

--- a/projects/04-llm-adapter-shadow/tests/sync_invocation/test_cancelled_results.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_invocation/test_cancelled_results.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from concurrent.futures import CancelledError
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 

--- a/projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 import time
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import pytest
 

--- a/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
+++ b/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
@@ -6,7 +6,7 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
-from typing import Protocol, cast, runtime_checkable
+from typing import cast, Protocol, runtime_checkable
 
 
 def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:


### PR DESCRIPTION
## Summary
- reorder test imports to satisfy Ruff auto-sorting expectations across consensus and weekly summary suites
- switch Callable hints in sync invocation tests to collections.abc for modern typing compliance

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68de8843b96c8321b33f7474697d7571