### PR TITLE
Fix type annotations for parallel logging

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -192,8 +192,8 @@ class ProviderInvoker:
 
 
 def _load_parallel_logging() -> tuple[
-    type["CancelledResultsBuilder"],
-    type["ParallelResultLogger"],
+    type[CancelledResultsBuilder],
+    type[ParallelResultLogger],
 ]:
     from .runner_sync_parallel_logging import (
         CancelledResultsBuilder as _CancelledResultsBuilder,


### PR DESCRIPTION
## Summary
- remove redundant string literals around type annotations for parallel logging helpers

## Testing
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py`


------
https://chatgpt.com/codex/tasks/task_e_68de8ab682b88321bb16e6e885b2d9f8