### PR TITLE
Fix ruff warning in runner_sync_invocation type annotations

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py
@@ -192,8 +192,8 @@ class ProviderInvoker:
 
 
 def _load_parallel_logging() -> tuple[
-    type["CancelledResultsBuilder"],
-    type["ParallelResultLogger"],
+    type[CancelledResultsBuilder],
+    type[ParallelResultLogger],
 ]:
     from .runner_sync_parallel_logging import (
         CancelledResultsBuilder as _CancelledResultsBuilder,


### PR DESCRIPTION
## Summary
- remove unnecessary string literal wrapping around type annotations returned by `_load_parallel_logging`

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_invocation.py

------
https://chatgpt.com/codex/tasks/task_e_68de8afa682c8321af80f1c7ba7eaca9