### PR TITLE
Ensure consensus honors cost constraints

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_consensus.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .parallel_exec import ParallelAllResult, ParallelExecutionError
-from .provider_spi import ProviderResponse, ProviderSPI
-from .runner_parallel import compute_consensus
+from .provider_spi import ProviderResponse, ProviderSPI, TokenUsage
+from .runner_parallel import ConsensusObservation, compute_consensus
 from .runner_sync_modes import _limited_providers, _raise_no_attempts
 from .shadow import ShadowMetrics
+from .runner_shared import estimate_cost
 from .utils import content_hash
 
 if TYPE_CHECKING:
@@ -73,20 +74,42 @@ class ConsensusStrategy:
             candidates: list[
                 tuple[str, ProviderResponse, dict[str, object]]
             ] = []
+            observations: list[ConsensusObservation] = []
             for invocation in invocations:
                 response = invocation.response
                 if response is None:
                     continue
+                provider_name = invocation.provider.name()
+                tokens_in = invocation.tokens_in
+                tokens_out = invocation.tokens_out
+                tokens: TokenUsage | None = None
+                if tokens_in is not None and tokens_out is not None:
+                    tokens = TokenUsage(prompt=tokens_in, completion=tokens_out)
+                    cost_estimate = estimate_cost(
+                        invocation.provider, tokens_in, tokens_out
+                    )
+                else:
+                    cost_estimate = None
+                latency_ms = invocation.latency_ms
+                if latency_ms is None:
+                    latency_ms = response.latency_ms
+                observations.append(
+                    ConsensusObservation(
+                        provider_id=provider_name,
+                        response=response,
+                        latency_ms=latency_ms,
+                        tokens=tokens,
+                        cost_estimate=cost_estimate,
+                    )
+                )
                 metadata: dict[str, object] = {
                     "invocation": invocation,
                     "attempt": invocation.attempt,
-                    "latency_ms": response.latency_ms,
+                    "latency_ms": latency_ms,
                     "tokens_in": invocation.tokens_in,
                     "tokens_out": invocation.tokens_out,
                 }
-                candidates.append(
-                    (invocation.provider.name(), response, metadata)
-                )
+                candidates.append((provider_name, response, metadata))
             if not candidates:
                 failure_details: list[dict[str, str]] = []
                 for invocation in invocations:
@@ -114,9 +137,8 @@ class ConsensusStrategy:
                     message = f"{message}: {detail_text}"
                 error = ParallelExecutionError(message, failures=failure_details)
                 raise error
-            responses_for_consensus = [response for _, response, _ in candidates]
             consensus = compute_consensus(
-                responses_for_consensus,
+                observations,
                 config=runner._config.consensus,
             )
             winner_name, _, winner_metadata = next(

--- a/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
@@ -6,6 +6,27 @@ from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, Toke
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner_config import ConsensusConfig, RunnerConfig, RunnerMode
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
+from tests.shadow._runner_test_helpers import _SuccessProvider
+
+
+def test_runner_consensus_all_candidates_exceed_cost_limit() -> None:
+    providers = [
+        _SuccessProvider("alpha", cost_usd=1.0),
+        _SuccessProvider("bravo", cost_usd=2.0),
+    ]
+    runner = Runner(
+        providers,
+        config=RunnerConfig(
+            mode=RunnerMode.CONSENSUS,
+            consensus=ConsensusConfig(strategy="majority", quorum=1, max_cost_usd=0.5),
+        ),
+    )
+    request = ProviderRequest(prompt="cost filter", model="demo-model")
+
+    with pytest.raises(ParallelExecutionError) as exc_info:
+        runner.run(request)
+
+    assert str(exc_info.value) == "no responses satisfied consensus constraints"
 
 
 def test_runner_consensus_failure_details(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a consensus-mode regression test that enforces the max_cost_usd constraint
- populate consensus observations with latency, token usage, and cost estimates before tallying votes

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68df08ba5e9c8321b9a73dcb3159e72d