### PR TITLE
Fix parse command to treat errored attempts as failures

### DIFF
--- a/tests/projects/test_ci_flaky_parse.mjs
+++ b/tests/projects/test_ci_flaky_parse.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert';
+import { test, mock } from 'node:test';
+
+const CONFIG = {
+  paths: {
+    input: '<stdin>',
+    store: '/tmp/store.jsonl',
+  },
+  timeout_factor: 1,
+};
+
+test('runParse counts errored attempts as failures', async (t) => {
+  const logs = [];
+  const warnings = [];
+  const errors = [];
+
+  t.after(() => {
+    mock.restoreAll();
+  });
+
+  mock.method(console, 'log', (message) => {
+    logs.push(String(message));
+  });
+  mock.method(console, 'warn', (message) => {
+    warnings.push(String(message));
+  });
+  mock.method(console, 'error', (message) => {
+    errors.push(String(message));
+  });
+
+  const appendAttempts = mock.fn(() => {});
+
+  const { runParse } = await import('../../projects/03-ci-flaky/src/commands/parse.js');
+
+  await runParse(
+    { stdin: true, run_id: 'run-123', timestamp: '2024-01-01T00:00:00.000Z' },
+    {
+      resolveConfigPath: () => '/tmp/config.json',
+      loadConfig: () => ({ config: CONFIG }),
+      resolveConfigPaths: () => CONFIG,
+      ensureDir: () => {},
+      parseJUnitStream: async () => ({
+        attempts: [
+          {
+            canonical_id: 'suite.class.test',
+            suite: 'suite',
+            class: 'class',
+            name: 'test',
+            status: 'errored',
+            duration_ms: 25,
+            failure_details: 'stack',
+            failure_message: 'boom',
+            system_out: ['out'],
+            system_err: ['err'],
+          },
+        ],
+      }),
+      parseJUnitFile: async () => ({ attempts: [] }),
+      appendAttempts,
+    },
+  );
+
+  assert.strictEqual(appendAttempts.mock.callCount(), 1);
+  assert.ok(
+    logs.some((line) => /Stored 1 attempts \(fails=1\)\./.test(line)),
+    `Expected stored output to include fails=1, got: ${logs.join('\n')}`,
+  );
+  assert.deepStrictEqual(warnings, []);
+  assert.deepStrictEqual(errors, []);
+});


### PR DESCRIPTION
## Summary
- add a node:test that exercises runParse with stubbed dependencies to ensure errored attempts increment the fail count
- update the parse command to allow dependency overrides for testing and count failures using the shared analyzer logic

## Testing
- node --test tests/projects/test_ci_flaky_parse.mjs
- node --test tests/projects/test_ci_flaky_analyzer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68df10652ce48321b1fe8edb18acfb6b