### PR TITLE
Expose runner mode normalizer

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runner_api.py
+++ b/projects/04-llm-adapter/adapter/core/runner_api.py
@@ -173,10 +173,15 @@ def run_batch(provider_specs: Iterable[str], prompts_path: str) -> int:
     )
 
 
+def _normalize_mode(value: RunnerMode | str) -> RunnerMode:
+    return RunnerConfigBuilder._normalize_mode(value)
+
+
 __all__ = [
     "BackoffPolicy",
     "RunnerMode",
     "RunnerConfig",
+    "_normalize_mode",
     "default_budgets_path",
     "default_metrics_path",
     "run_batch",


### PR DESCRIPTION
## Summary
- re-export RunnerConfigBuilder._normalize_mode via adapter.core.runner_api
- add the helper to the module export list so tests can import it

## Testing
- pytest projects/04-llm-adapter/tests/test_runner_mode_enum.py

------
https://chatgpt.com/codex/tasks/task_e_68df14639f4c83219edfe9bb2f0e5455