### PR TITLE
Sort imports in consensus async runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from ..parallel_exec import ParallelExecutionError, run_parallel_all_async
-from ..runner_parallel import ConsensusObservation, compute_consensus
+from ..runner_parallel import compute_consensus, ConsensusObservation
 from ..runner_shared import estimate_cost, log_run_metric
 from ..utils import content_hash, elapsed_ms
 from .base import ParallelStrategyBase


### PR DESCRIPTION
## Summary
- reorder consensus strategy imports to comply with Ruff isort grouping

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68df163ce840832187d3dcb0f1735367