### PR TITLE
Normalize consume_cases errored status

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_consume_cases.py
@@ -1,0 +1,41 @@
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_consume_cases() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "consume_cases.py"
+    spec = util.spec_from_file_location("consume_cases", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("failed to load consume_cases module")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+consume_cases = _load_consume_cases()
+_build_metrics = consume_cases._build_metrics
+_format_text = consume_cases._format_text
+
+
+def test_build_metrics_normalizes_errored_status() -> None:
+    cases = {
+        "suite": "demo-suite",
+        "cases": [
+            {"id": "case-1"},
+        ],
+    }
+    attempts = [
+        {
+            "name": "case-1 first attempt",
+            "status": "errored",
+        }
+    ]
+
+    metrics = _build_metrics(cases, attempts)
+
+    assert metrics["status_breakdown"].get("error") == 1
+    assert "errored" not in metrics["status_breakdown"]
+
+    text = _format_text(metrics)
+    assert "error: 1" in text

--- a/projects/04-llm-adapter-shadow/tools/consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tools/consume_cases.py
@@ -56,6 +56,14 @@ def _attempt_case_id(attempt: Mapping[str, Any]) -> str | None:
     return prefix.strip() or None
 
 
+def _normalize_status(raw_status: str) -> str:
+    normalized = raw_status.strip().lower()
+    alias_map = {
+        "errored": "error",
+    }
+    return alias_map.get(normalized, normalized)
+
+
 def _build_metrics(
     cases: Mapping[str, Any], attempts: list[Mapping[str, Any]]
 ) -> MutableMapping[str, Any]:
@@ -70,7 +78,8 @@ def _build_metrics(
     failed_ids: list[str] = []
 
     for attempt in attempts:
-        status = str(attempt.get("status", "unknown")).lower()
+        raw_status = str(attempt.get("status", "unknown"))
+        status = _normalize_status(raw_status)
         statuses[status] += 1
         case_id = _attempt_case_id(attempt)
         if case_id:


### PR DESCRIPTION
## Summary
- add unit coverage for consume_cases metrics to validate error alias handling
- normalize errored status aliases to error before aggregating metrics

## Testing
- python -m pytest projects/04-llm-adapter-shadow/tests/test_consume_cases.py

------
https://chatgpt.com/codex/tasks/task_e_68df1a3346e88321af24c16a4a4f99c8