### PR TITLE
Format doctor.py with Black

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/doctor.py
+++ b/projects/04-llm-adapter/adapter/cli/doctor.py
@@ -25,7 +25,11 @@ def _doctor_check_python(lang: str) -> tuple[str, str, str]:
     if version >= required:
         detail = f"Python {platform.python_version()}"
         return "doctor_name_python", "ok", detail
-    return "doctor_name_python", "fail", _msg(lang, "doctor_fix_python", required="3.10")
+    return (
+        "doctor_name_python",
+        "fail",
+        _msg(lang, "doctor_fix_python", required="3.10"),
+    )
 
 
 def _doctor_check_os(lang: str) -> tuple[str, str, str]:


### PR DESCRIPTION
## Summary
- apply Black formatting to the doctor CLI helper

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py
- black --check projects/04-llm-adapter/adapter/cli/doctor.py

------
https://chatgpt.com/codex/tasks/task_e_68df1c9b6c248321a6068cacce4fc139