### PR TITLE
Format prompt runner with black

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/prompt_runner.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_runner.py
@@ -79,7 +79,9 @@ async def _process_prompt(
                 output_tokens=0,
                 latency_ms=latency_ms,
             )
-            metric = RunMetric.from_resp(config, stub, prompt, cost_usd=0.0, error=friendly)
+            metric = RunMetric.from_resp(
+                config, stub, prompt, cost_usd=0.0, error=friendly
+            )
             return PromptResult(
                 index=index,
                 prompt=prompt,
@@ -143,7 +145,9 @@ async def execute_prompts(
     semaphore = asyncio.Semaphore(max(1, concurrency))
     tasks = [
         asyncio.create_task(
-            _process_prompt(idx, prompt, provider, config, limiter, semaphore, lang, classify_error)
+            _process_prompt(
+                idx, prompt, provider, config, limiter, semaphore, lang, classify_error
+            )
         )
         for idx, prompt in enumerate(prompts)
     ]


### PR DESCRIPTION
## Summary
- format the prompt runner module with black for consistent style

## Testing
- pytest projects/04-llm-adapter/tests/test_cli_runner_config.py
- black --check projects/04-llm-adapter/adapter/cli/prompt_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68df1c9ab1688321bddc0d85941c51f6