### PR TITLE
fix: sort flaky junit imports

### DIFF
--- a/projects/03-ci-flaky/src/commands/parse.js
+++ b/projects/03-ci-flaky/src/commands/parse.js
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { createFailureSignature } from '../classification.js';
 import { isFailureStatus } from '../analyzer.js';
+import { createFailureSignature } from '../classification.js';
 import { loadConfig, resolveConfigPaths } from '../config.js';
 import { ensureDir } from '../fs-utils.js';
 import { parseJUnitFile, parseJUnitStream } from '../junit-parser.js';

--- a/tests/projects/test_ci_flaky_junit_parser.mjs
+++ b/tests/projects/test_ci_flaky_junit_parser.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 import { Readable } from 'node:stream';
 import { test } from 'node:test';
 
-import { parseJUnitStream } from '../../projects/03-ci-flaky/src/junit-parser.js';
 import { isFailureStatus } from '../../projects/03-ci-flaky/src/analyzer.js';
+import { parseJUnitStream } from '../../projects/03-ci-flaky/src/junit-parser.js';
 
 test('parseJUnitStream treats errored status attribute as a failure', async () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- sort relative imports in the flaky junit parser test file
- align relative import order in the parse command to match lint rules

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68df1dee8d308321b72f41cc79eb0c1d