### PR TITLE
Sort relative imports in parse command

### DIFF
--- a/projects/03-ci-flaky/src/commands/parse.js
+++ b/projects/03-ci-flaky/src/commands/parse.js
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { createFailureSignature } from '../classification.js';
 import { isFailureStatus } from '../analyzer.js';
+import { createFailureSignature } from '../classification.js';
 import { loadConfig, resolveConfigPaths } from '../config.js';
 import { ensureDir } from '../fs-utils.js';
 import { parseJUnitFile, parseJUnitStream } from '../junit-parser.js';

--- a/tests/projects/test_ci_flaky_junit_parser.mjs
+++ b/tests/projects/test_ci_flaky_junit_parser.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 import { Readable } from 'node:stream';
 import { test } from 'node:test';
 
-import { parseJUnitStream } from '../../projects/03-ci-flaky/src/junit-parser.js';
 import { isFailureStatus } from '../../projects/03-ci-flaky/src/analyzer.js';
+import { parseJUnitStream } from '../../projects/03-ci-flaky/src/junit-parser.js';
 
 test('parseJUnitStream treats errored status attribute as a failure', async () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- reorder relative imports in the parse command to satisfy lint sorting rules
- align test import order with lint requirements

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68df1ded80788321bd2ffe1861835aa0