### PR TITLE
Add timeout classification coverage for errored attempts

### DIFF
--- a/projects/03-ci-flaky/src/classification.js
+++ b/projects/03-ci-flaky/src/classification.js
@@ -36,7 +36,7 @@ export function applyTimeoutClassification(attempts, suiteDurations, factor) {
     thresholds.set(suite, pct95 * factor);
   }
   for (const attempt of attempts) {
-    if (!['fail', 'error'].includes(attempt.status)) continue;
+    if (!['fail', 'error', 'errored'].includes(attempt.status)) continue;
     if (attempt.failure_kind && attempt.failure_kind !== 'nondeterministic') continue;
     const threshold = thresholds.get(attempt.suite);
     if (!threshold) continue;

--- a/tests/projects/test_ci_flaky_classification.mjs
+++ b/tests/projects/test_ci_flaky_classification.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyTimeoutClassification } from '../../projects/03-ci-flaky/src/classification.js';
+
+test('applyTimeoutClassification marks errored attempts as timeout when exceeding threshold', () => {
+  const attempts = [
+    {
+      status: 'errored',
+      suite: 'ci-suite',
+      duration_ms: 5_000,
+      failure_kind: 'nondeterministic',
+    },
+  ];
+
+  const suiteDurations = new Map([
+    ['ci-suite', [1_000, 1_100, 1_200, 1_300, 1_400]],
+  ]);
+
+  applyTimeoutClassification(attempts, suiteDurations, 2);
+
+  assert.equal(attempts[0].failure_kind, 'timeout');
+});


### PR DESCRIPTION
## Summary
- add a node:test suite verifying timeout classification covers errored attempts
- extend timeout classification to treat errored statuses as failures

## Testing
- node --test tests/projects/test_ci_flaky_classification.mjs

------
https://chatgpt.com/codex/tasks/task_e_68df1e5daf2483218828c78517991330