### PR TITLE
Handle errored attempts in timeout classification

### DIFF
--- a/projects/03-ci-flaky/src/classification.js
+++ b/projects/03-ci-flaky/src/classification.js
@@ -1,5 +1,7 @@
 import crypto from 'node:crypto';
 
+import { isFailureStatus } from './analyzer.js';
+
 const MESSAGE_PATTERNS = {
   timeout: /timeout|timed out|Exceeded.*time|Time limit/i,
   parsing: /syntax error|unexpected token|parse error|JSON\.parse|invalid json|xml parse/i,
@@ -36,7 +38,7 @@ export function applyTimeoutClassification(attempts, suiteDurations, factor) {
     thresholds.set(suite, pct95 * factor);
   }
   for (const attempt of attempts) {
-    if (!['fail', 'error'].includes(attempt.status)) continue;
+    if (!isFailureStatus(attempt)) continue;
     if (attempt.failure_kind && attempt.failure_kind !== 'nondeterministic') continue;
     const threshold = thresholds.get(attempt.suite);
     if (!threshold) continue;

--- a/tests/projects/test_ci_flaky_classification.mjs
+++ b/tests/projects/test_ci_flaky_classification.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import { applyTimeoutClassification } from '../../projects/03-ci-flaky/src/classification.js';
+
+test('timeout classification upgrades errored attempts', () => {
+  const attempts = [
+    {
+      suite: 'suite-a',
+      status: 'errored',
+      duration_ms: 5000,
+      failure_kind: 'nondeterministic',
+    },
+  ];
+  const suiteDurations = new Map([
+    ['suite-a', [1000, 2000, 3000, 4000, 4500]],
+  ]);
+
+  applyTimeoutClassification(attempts, suiteDurations, 1.1);
+
+  assert.strictEqual(attempts[0].failure_kind, 'timeout');
+});


### PR DESCRIPTION
## Summary
- add a node:test suite to cover timeout classification with errored attempts
- reuse the shared failure status helper so timeout classification upgrades errored attempts

## Testing
- node --test tests/projects/test_ci_flaky_classification.mjs

------
https://chatgpt.com/codex/tasks/task_e_68df1e4a54448321916900e01bb8484d