### PR TITLE
Adjust blank lines in weekly summary module

### DIFF
--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -31,7 +31,6 @@ __all__ = [
 ]
 
 
-
 def aggregate_status(runs: Iterable[dict[str, object]]) -> tuple[int, int, int]:
     from tools.ci_metrics import normalize_status  # local import to avoid cycle
 
@@ -123,7 +122,6 @@ def to_float(value: object) -> float | None:
         except ValueError:
             return None
     return None
-
 
 
 def format_percentage(value: float | None) -> str:


### PR DESCRIPTION
## Summary
- reduce extra blank lines before top-level functions in the weekly summary module to match spacing convention

## Testing
- `ruff check tools/weekly_summary/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68df20a35bbc8321a9fb4163ac115a59