### PR TITLE
Normalize spacing between runner methods

### DIFF
--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -184,7 +184,6 @@ class CompareRunner:
                 error_message,
             )
 
-
     def _run_provider_call(
         self,
         provider_config: ProviderConfig,
@@ -284,6 +283,4 @@ class CompareRunner:
             batch=batch,
             default_judge_config=default_judge_config,
         )
-
-
 


### PR DESCRIPTION
## Summary
- collapse extra blank lines between CompareRunner methods to follow PEP 8 spacing rules

## Testing
- ruff check projects/04-llm-adapter/adapter/core/runners.py

------
https://chatgpt.com/codex/tasks/task_e_68df20a277608321ae86d10820c91fe6