### PR TITLE
chore: normalize spacing between sync runner classes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -55,8 +55,6 @@ class SyncRunStrategy(Protocol):
     ): ...
 
 
-
-
 class ParallelAllStrategy:
     def execute(
         self, context: SyncRunContext


### PR DESCRIPTION
## Summary
- trim surplus blank lines between sync runner strategy definitions
- keep class declarations separated by two blank lines for style consistency

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68df20a25e148321954ec9fea509e343