### PR TITLE
Adjust spacing before top-level functions in generate_ci_report

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -41,7 +41,6 @@ build_json_payload = ci_rendering.build_json_payload
 render_markdown = ci_rendering.render_markdown
 
 
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate CI reliability snapshot")
     parser.add_argument("--runs", type=Path, required=True, help="Path to runs.jsonl")


### PR DESCRIPTION
## Summary
- normalize the blank lines preceding `parse_args` and `update_index` so top-level functions use two-line spacing

## Testing
- ruff check tools/generate_ci_report.py

------
https://chatgpt.com/codex/tasks/task_e_68df20a01c5c8321aa9f8e5e1a29b274