### PR TITLE
Add cost estimate logging for provider call events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -156,6 +156,10 @@ def log_provider_call(
     provider_name = _provider_name(provider)
     prompt_tokens = int(tokens_in) if tokens_in is not None else 0
     completion_tokens = int(tokens_out) if tokens_out is not None else 0
+    if tokens_in is None or tokens_out is None:
+        cost_estimate = 0.0
+    else:
+        cost_estimate = estimate_cost(provider, prompt_tokens, completion_tokens)
     token_usage = {
         "prompt": prompt_tokens,
         "completion": completion_tokens,
@@ -178,6 +182,7 @@ def log_provider_call(
             "tokens_in": tokens_in,
             "tokens_out": tokens_out,
             "token_usage": token_usage,
+            "cost_estimate": cost_estimate,
             "error_type": type(error).__name__ if error is not None else None,
             "error_message": str(error) if error is not None else None,
             "error_family": error_family(error),


### PR DESCRIPTION
## Summary
- compute cost estimates for provider_call events using provider estimators and default to zero when tokens are unavailable
- extend the invoker test to stub an estimator and verify the logged cost_estimate payload

## Testing
- pytest projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py

------
https://chatgpt.com/codex/tasks/task_e_68df200c8d2483218c7eef2a6a786eab