### PR TITLE
Normalize errored statuses in weekly summary tool

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
+++ b/projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py
@@ -108,3 +108,41 @@ def test_weekly_summary_generates_expected_markdown(tmp_path: Path) -> None:
     )
 
     assert output_path.read_text(encoding="utf-8") == expected
+
+
+def test_weekly_summary_normalizes_errored_status(tmp_path: Path) -> None:
+    input_path = tmp_path / "runs-metrics.jsonl"
+    output_path = tmp_path / "summary.md"
+
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "event": "run_metric",
+                "outcome": "success",
+                "latency_ms": 120,
+            },
+            {
+                "event": "run_metric",
+                "status": "success",
+                "latency_ms": 180,
+            },
+            {
+                "event": "run_metric",
+                "status": "errored",
+                "latency_ms": 250,
+            },
+            {
+                "event": "run_metric",
+                "outcome": "error",
+                "latency_ms": 300,
+            },
+        ],
+    )
+
+    main = _load_main()
+    main(["--input", str(input_path), "--output", str(output_path)])
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "| error | 2 |" in output
+    assert "errored" not in output

--- a/projects/04-llm-adapter-shadow/tools/weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tools/weekly_summary.py
@@ -21,6 +21,15 @@ class Summary:
     diff_kinds: Counter[str]
 
 
+_ERROR_OUTCOME_VALUES = {
+    "error",
+    "errored",
+    "failed",
+    "failure",
+    "exception",
+}
+
+
 def _load_records(path: Path) -> Iterable[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as handle:
         for line in handle:
@@ -36,12 +45,16 @@ def _load_records(path: Path) -> Iterable[dict[str, Any]]:
 
 
 def _normalize_outcome(record: Mapping[str, Any]) -> str:
-    outcome = record.get("outcome")
-    if isinstance(outcome, str) and outcome.strip():
-        return outcome.strip().lower()
-    status = record.get("status")
-    if isinstance(status, str) and status.strip():
-        return status.strip().lower()
+    for field in ("outcome", "status"):
+        value = record.get(field)
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower()
+        if not normalized:
+            continue
+        if normalized in _ERROR_OUTCOME_VALUES:
+            return "error"
+        return normalized
     return "unknown"
 
 


### PR DESCRIPTION
## Summary
- add coverage to ensure `errored` run metrics are summarized under `error`
- normalize outcome and status fields against a shared set of error variants

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py -k errored

------
https://chatgpt.com/codex/tasks/task_e_68df238740cc832193e8520002ed1b72