### PR TITLE
Fix blank line spacing in generate_ci_report

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -67,7 +67,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-
 def update_index(index_path: Path, *, today: dt.date) -> None:
     index_lines = [
         "---",


### PR DESCRIPTION
## Summary
- adjust spacing between top-level functions in tools/generate_ci_report.py to satisfy Ruff E303

## Testing
- ruff check tools/generate_ci_report.py

------
https://chatgpt.com/codex/tasks/task_e_68df4632fd2083219a23249547c969f8