### PR TITLE
Fix exception re-raise in parallel runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_any.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_any.py
@@ -178,7 +178,7 @@ class ParallelAnyStrategy:
                 raise fatal from None
             failures = _collect_parallel_failures(results)
             exc.failures = failures if failures else None
-            raise exc
+            raise
         finally:
             if cancelled_slots:
                 runner._apply_cancelled_results(


### PR DESCRIPTION
## Summary
- re-raise `ParallelExecutionError` without resetting the traceback in the sync parallel-any runner

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_parallel_any.py

------
https://chatgpt.com/codex/tasks/task_e_68df4632c7208321b6223d6428707458