### PR TITLE
Preserve original exception context in parallel runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py
@@ -126,7 +126,7 @@ class ParallelAllStrategy:
                 raise fatal from None
             failures = _collect_parallel_failures(results)
             exc.failures = failures if failures else None
-            raise exc
+            raise
         finally:
             runner._log_parallel_results(
                 results,


### PR DESCRIPTION
## Summary
- ensure ParallelExecutionError re-raises without losing the original traceback in ParallelAllStrategy

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68df46331428832196dc2c3172cc2ce1