### PR TITLE
Format _parallel_shim with black

### DIFF
--- a/projects/04-llm-adapter/adapter/core/_parallel_shim.py
+++ b/projects/04-llm-adapter/adapter/core/_parallel_shim.py
@@ -52,4 +52,3 @@ __all__ = [
     "run_parallel_all_sync",
     "run_parallel_any_sync",
 ]
-


### PR DESCRIPTION
## Summary
- format adapter/core/_parallel_shim.py using black

## Testing
- pytest projects/04-llm-adapter/tests/test_compare_runner_parallel.py *(fails: existing assertion and ParallelExecutionError)*
- black --check projects/04-llm-adapter/adapter/core/_parallel_shim.py


------
https://chatgpt.com/codex/tasks/task_e_68df46f81b5c8321a2af5621eda75c6f