### PR TITLE
Fix async shadow metadata propagation

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -88,6 +88,8 @@ class AsyncRunner:
 
         shadow = shadow or getattr(self._config, "shadow_provider", None)
         shadow_async = ensure_async_provider(shadow) if shadow is not None else None
+        shadow_used = shadow is not None
+        shadow_provider_id = shadow.name() if shadow is not None else None
 
         max_attempts = self._config.max_attempts
         providers: Sequence[tuple[ProviderSPI | AsyncProviderSPI, AsyncProviderSPI]]
@@ -100,6 +102,8 @@ class AsyncRunner:
         metadata.setdefault("run_id", metadata.get("trace_id") or request_fingerprint)
         metadata["mode"] = mode.value
         metadata["providers"] = [provider.name() for provider, _ in providers]
+        metadata["shadow_used"] = shadow_used
+        metadata["shadow_provider_id"] = shadow_provider_id
 
         async def _invoke(
             attempt_index: int,
@@ -194,7 +198,7 @@ class AsyncRunner:
             cost_usd=0.0,
             error=failure_error,
             metadata=metadata,
-            shadow_used=shadow is not None,
+            shadow_used=shadow_used,
         )
         if last_err is not None:
             if mode == RunnerMode.CONSENSUS or total_providers <= 1:

--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_shadow.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_shadow.py
@@ -93,6 +93,12 @@ def test_async_shadow_exec_records_metrics(tmp_path: Path) -> None:
     payloads = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
     diff_event = next(item for item in payloads if item["event"] == "shadow_diff")
     call_event = next(item for item in payloads if item["event"] == "provider_call")
+    run_metric_event = next(
+        item for item in payloads if item.get("event") == "run_metric"
+    )
+
+    assert call_event["shadow_provider_id"] == "shadow"
+    assert run_metric_event["shadow_provider_id"] == "shadow"
 
     assert diff_event["primary_provider"] == "primary"
     assert diff_event["shadow_provider"] == "shadow"


### PR DESCRIPTION
## Summary
- extend async shadow metrics test to ensure shadow provider id is recorded in provider and run metrics
- propagate shadow provider metadata in the async runner to match the sync runner behavior

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_shadow.py

------
https://chatgpt.com/codex/tasks/task_e_68df4a155be48321a70e1d81cf6ec518