### PR TITLE
refactor: split runner shared helpers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
@@ -1,0 +1,36 @@
+"""Shared runner helpers re-exported for backward compatibility."""
+from __future__ import annotations
+
+from .costs import estimate_cost
+from .logging import (
+    MetricsPath,
+    error_family,
+    log_provider_call,
+    log_provider_skipped,
+    log_run_metric,
+    resolve_event_logger,
+)
+from .rate_limiter import (
+    RateLimiter,
+    asyncio,
+    provider_model,
+    resolve_rate_limiter,
+    threading,
+    time,
+)
+
+__all__ = [
+    "MetricsPath",
+    "resolve_event_logger",
+    "error_family",
+    "estimate_cost",
+    "provider_model",
+    "log_provider_skipped",
+    "log_provider_call",
+    "log_run_metric",
+    "RateLimiter",
+    "resolve_rate_limiter",
+    "time",
+    "asyncio",
+    "threading",
+]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/costs.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/costs.py
@@ -1,0 +1,43 @@
+"""Cost estimation helpers shared across runners."""
+from __future__ import annotations
+
+_COST_CACHE_ATTR = "_llm_adapter_cost_cache"
+
+
+def _get_cached_cost(provider: object, tokens_in: int, tokens_out: int) -> float | None:
+    try:
+        cached_tokens, cached_value = getattr(provider, _COST_CACHE_ATTR)
+    except AttributeError:
+        return None
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+    if cached_tokens == (tokens_in, tokens_out):
+        try:
+            return float(cached_value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            return None
+    return None
+
+
+def estimate_cost(provider: object, tokens_in: int, tokens_out: int) -> float:
+    cached = _get_cached_cost(provider, tokens_in, tokens_out)
+    if cached is not None:
+        return cached
+    if hasattr(provider, "estimate_cost"):
+        estimator = provider.estimate_cost
+        if callable(estimator):
+            try:
+                value = float(estimator(tokens_in, tokens_out))
+            except Exception:  # pragma: no cover - defensive guard
+                return 0.0
+            try:
+                setattr(provider, _COST_CACHE_ATTR, ((tokens_in, tokens_out), value))
+            except Exception:  # pragma: no cover - defensive guard
+                pass
+            return value
+    return 0.0
+
+
+__all__ = [
+    "estimate_cost",
+]

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/rate_limiter.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/rate_limiter.py
@@ -1,0 +1,41 @@
+"""Rate limiter utilities and provider metadata helpers."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .. import rate_limiter as _rate_limiter
+
+if TYPE_CHECKING:
+    from ..provider_spi import AsyncProviderSPI, ProviderSPI
+
+RateLimiter = _rate_limiter.RateLimiter
+resolve_rate_limiter = _rate_limiter.resolve_rate_limiter
+time = _rate_limiter.time
+asyncio = _rate_limiter.asyncio
+threading = _rate_limiter.threading
+
+
+def provider_model(
+    provider: ProviderSPI | AsyncProviderSPI | object,
+    *,
+    allow_private: bool = False,
+) -> str | None:
+    """Return the model identifier exposed by the provider if available."""
+    attrs = ["model"]
+    if allow_private:
+        attrs.append("_model")
+    for attr in attrs:
+        value = getattr(provider, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+__all__ = [
+    "RateLimiter",
+    "resolve_rate_limiter",
+    "time",
+    "asyncio",
+    "threading",
+    "provider_model",
+]


### PR DESCRIPTION
## Summary
- split `llm_adapter.runner_shared` into a package with focused `rate_limiter`, `costs`, and `logging` modules
- re-export the original runner shared API from `runner_shared.__init__` to keep callers unchanged

## Testing
- `pytest projects/04-llm-adapter-shadow/tests -k runner_shared`
- `mypy src/llm_adapter/runner_shared/logging.py src/llm_adapter/runner_shared/costs.py src/llm_adapter/runner_shared/rate_limiter.py src/llm_adapter/runner_shared/__init__.py` *(fails: projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py:75: Name "observations" already defined on line 56)*

------
https://chatgpt.com/codex/tasks/task_e_68df4a0a4a1883218fb9a439f7c0109c