### PR TITLE
Normalize errored outcomes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared.py
@@ -150,15 +150,13 @@ def log_provider_skipped(
 
 def _normalize_outcome(status: str) -> str:
     normalized = status.lower()
-    mapping = {
-        "ok": "success",
-        "success": "success",
-        "error": "error",
-        "failure": "error",
-        "skip": "skipped",
-        "skipped": "skipped",
-    }
-    return mapping.get(normalized, normalized)
+    if normalized in {"ok", "success"}:
+        return "success"
+    if normalized in {"error", "failure", "failed", "errored"}:
+        return "error"
+    if normalized in {"skip", "skipped"}:
+        return "skipped"
+    return normalized
 
 
 def log_provider_call(

--- a/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.llm_adapter.provider_spi import ProviderRequest
+from src.llm_adapter.runner_shared import log_provider_call
+
+
+class _DummyEventLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def emit(self, name: str, payload: dict[str, Any]) -> None:
+        self.events.append((name, payload))
+
+
+class _DummyProvider:
+    def name(self) -> str:
+        return "dummy"
+
+
+@pytest.mark.parametrize("status", ["errored", "Errored", "ERRORED"])
+def test_log_provider_call_normalizes_error_family_status(status: str) -> None:
+    event_logger = _DummyEventLogger()
+    provider = _DummyProvider()
+    request = ProviderRequest(model="test-model", prompt="hello")
+
+    log_provider_call(
+        event_logger,
+        request_fingerprint="fingerprint",
+        provider=provider,
+        request=request,
+        attempt=1,
+        total_providers=1,
+        status=status,
+        latency_ms=10,
+        tokens_in=1,
+        tokens_out=1,
+        error=Exception("boom"),
+        metadata={},
+        shadow_used=False,
+    )
+
+    assert event_logger.events, "expected provider_call event to be emitted"
+    _, payload = event_logger.events[-1]
+    assert payload["outcome"] == "error"


### PR DESCRIPTION
## Summary
- add a regression test ensuring provider_call normalizes errored statuses to the error outcome
- extend `_normalize_outcome` to treat error-family statuses via a shared set

## Testing
- `pytest projects/04-llm-adapter-shadow/tests/test_runner_shared.py`


------
https://chatgpt.com/codex/tasks/task_e_68df4a073ce08321917822817f9574b6