### PR TITLE
Fix unused attempt variable in consensus strategy

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py
@@ -54,7 +54,7 @@ class ConsensusRunStrategy(ParallelStrategyBase):
             )
 
         observations: list[ConsensusObservation] = []
-        for attempt, provider, response, _ in successful_entries:
+        for _attempt, provider, response, _ in successful_entries:
             usage = response.token_usage
             tokens_in = usage.prompt
             tokens_out = usage.completion


### PR DESCRIPTION
## Summary
- rename the unused loop variable in the consensus strategy to avoid B007 violations

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py -k consensus
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/consensus.py --select B007


------
https://chatgpt.com/codex/tasks/task_e_68df646d3c7883218ff5851b966ebe41