### PR TITLE
chore: reorder imports in parallel test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_all.py
+++ b/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_all.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from pathlib import Path
 
 import pytest
@@ -14,13 +13,12 @@ from src.llm_adapter.runner import AsyncRunner, ParallelAllResult, Runner
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 
 from ..parallel_helpers import (
-    _RetryProbeProvider,
-    _StaticProvider,
     _install_recording_executor,
     _read_metrics,
+    _RetryProbeProvider,
+    _StaticProvider,
     _worker_for,
 )
-
 
 # --- ALL モードの戻り値 ---
 


### PR DESCRIPTION
## Summary
- reorder the imports in `test_parallel_all.py` to follow standard library, third-party, and local grouping
- remove the unused `time` import and ensure the helper imports are sorted

## Testing
- pytest projects/04-llm-adapter-shadow/tests/parallel/test_parallel_all.py
- ruff check projects/04-llm-adapter-shadow/tests/parallel/test_parallel_all.py --select I001,F401


------
https://chatgpt.com/codex/tasks/task_e_68df646bfce08321a7319fd42e865bd5