### PR TITLE
Fix sequential run metrics latency reporting

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
@@ -51,6 +51,11 @@ class _SequentialRunTracker:
         tokens_in = result.tokens_in if result.tokens_in is not None else 0
         tokens_out = result.tokens_out if result.tokens_out is not None else 0
         cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+        latency_ms = (
+            result.latency_ms
+            if result.latency_ms is not None
+            else response.latency_ms
+        )
         log_run_metric(
             self._event_logger,
             request_fingerprint=self._context.request_fingerprint,
@@ -58,7 +63,7 @@ class _SequentialRunTracker:
             provider=provider,
             status="ok",
             attempts=attempt,
-            latency_ms=elapsed_ms(self._context.run_started),
+            latency_ms=latency_ms,
             tokens_in=tokens_in,
             tokens_out=tokens_out,
             cost_usd=cost_usd,

--- a/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_sequential.py
@@ -191,6 +191,53 @@ def test_sequential_strategy_handles_successful_provider_result(
     assert payload["tokens_out"] == 4
 
 
+def test_sequential_run_metric_reports_response_latency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    providers = [_SuccessfulProvider("primary")]
+    runner = Runner(providers, config=RunnerConfig())
+    strategy = SequentialStrategy()
+    logger = _RecordingLogger()
+    context = _make_context(runner, logger=logger)
+
+    response = ProviderResponse("ok", latency_ms=12, token_usage=TokenUsage(prompt=0, completion=0))
+
+    def fake_invoke(
+        provider: Any,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        **_: Any,
+    ) -> ProviderInvocationResult:
+        return ProviderInvocationResult(
+            provider=provider,
+            attempt=attempt,
+            total_providers=total_providers,
+            response=response,
+            error=None,
+            latency_ms=None,
+            tokens_in=0,
+            tokens_out=0,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        )
+
+    monkeypatch.setattr(runner, "_invoke_provider_sync", fake_invoke)
+    monkeypatch.setattr(
+        "src.llm_adapter.runner_sync_sequential.elapsed_ms", lambda _: 99,
+    )
+
+    result = strategy.execute(context)
+
+    assert result is response
+    run_metric_events = [event for event in logger.events if event[0] == "run_metric"]
+    assert len(run_metric_events) == 1
+    _, payload = run_metric_events[0]
+    assert payload["latency_ms"] == 12
+
+
 def test_sequential_strategy_all_failed_logs_once(monkeypatch: pytest.MonkeyPatch) -> None:
     providers = [_FailingProvider("primary", TimeoutError("slow")), _FailingProvider("secondary", TimeoutError("boom"))]
     runner = Runner(providers, config=RunnerConfig())


### PR DESCRIPTION
## Summary
- add a sequential runner test that verifies run_metric events report provider latency
- update the sequential run tracker to forward the provider response latency to run_metric

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py::test_sequential_run_metric_reports_response_latency


------
https://chatgpt.com/codex/tasks/task_e_68df64615f3c83218a657612509708a1