### PR TITLE
style: add spacing before weekly summary helpers

### DIFF
--- a/tools/weekly_summary/__init__.py
+++ b/tools/weekly_summary/__init__.py
@@ -106,6 +106,7 @@ def coerce_str(value: object | None) -> str | None:
         return str(value)
     return None
 
+
 def to_float(value: object) -> float | None:
     if value is None:
         return None


### PR DESCRIPTION
## Summary
- ensure there are always two blank lines before weekly_summary helper definitions after `coerce_str`

## Testing
- ruff check tools/weekly_summary/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68df645056948321af551b629b1a8d0c