### PR TITLE
Update auto tie breaker test expectations

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py
@@ -95,7 +95,7 @@ def test_auto_tie_breaker_applies_latency_cost_and_order(
     }
     latency_breaker = AggregationController._resolve_tie_breaker(config, latency_lookup)
     assert latency_breaker and latency_breaker.break_tie(candidates).index == 0
-    assert latency_breaker.name in {"latency", "min_latency"}
+    assert latency_breaker.name == "min_latency"
 
     cost_lookup = {
         0: SingleRunResult(
@@ -109,7 +109,7 @@ def test_auto_tie_breaker_applies_latency_cost_and_order(
     }
     cost_breaker = AggregationController._resolve_tie_breaker(config, cost_lookup)
     assert cost_breaker and cost_breaker.break_tie(candidates).index == 1
-    assert cost_breaker.name in {"cost", "min_cost"}
+    assert cost_breaker.name == "min_cost"
 
     order_lookup = {
         0: SingleRunResult(


### PR DESCRIPTION
## Summary
- update the auto tie breaker test to assert the new `min_latency` and `min_cost` display names

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py::test_auto_tie_breaker_applies_latency_cost_and_order

------
https://chatgpt.com/codex/tasks/task_e_68df73fb66b08321ab591a3eec91e94e