### PR TITLE
Fix parallel_any success detection

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -95,8 +95,14 @@ class ParallelAnyState:
         build_summary: _BuildSummary,
         error_factory: Callable[[str], Exception],
     ) -> None:
+        if self._winner_index is not None:
+            return
         success_found = any(
-            result is not None and getattr(result.metrics, "status", None) == "ok"
+            result is not None
+            and (
+                getattr(result.metrics, "status", None) == "ok"
+                or getattr(result.metrics, "outcome", None) == "success"
+            )
             for result in results
         )
         if success_found:

--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_failures.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_failures.py
@@ -51,7 +51,13 @@ def test_parallel_any_stops_after_first_success(
         budget_manager_factory(),
         tmp_path / "metrics_any.jsonl",
     )
-    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel_any", max_concurrency=2))
+    try:
+        results = runner.run(
+            repeat=1,
+            config=RunnerConfig(mode="parallel_any", max_concurrency=2),
+        )
+    except (errors.ParallelExecutionError, _parallel_shim.ParallelExecutionError) as exc:
+        pytest.fail(f"ParallelExecutionError was raised unexpectedly: {exc}")
     assert {metric.model: metric.status for metric in results} == {"fast": "ok", "slow": "skip"}
     assert calls == ["fast"]
 
@@ -86,7 +92,13 @@ def test_parallel_any_cancels_pending_workers(
         budget_manager_factory(),
         tmp_path / "metrics_cancel.jsonl",
     )
-    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel_any", max_concurrency=2))
+    try:
+        results = runner.run(
+            repeat=1,
+            config=RunnerConfig(mode="parallel_any", max_concurrency=2),
+        )
+    except (errors.ParallelExecutionError, _parallel_shim.ParallelExecutionError) as exc:
+        pytest.fail(f"ParallelExecutionError was raised unexpectedly: {exc}")
 
     assert {metric.model: metric.status for metric in results} == {"fast": "ok", "slow": "skip"}
     slow_metric = next(metric for metric in results if metric.model == "slow")
@@ -134,7 +146,13 @@ def test_parallel_any_populates_metrics_for_unscheduled_workers(
         budget_manager_factory(),
         tmp_path / "metrics_unscheduled.jsonl",
     )
-    results = runner.run(repeat=1, config=RunnerConfig(mode="parallel_any", max_concurrency=2))
+    try:
+        results = runner.run(
+            repeat=1,
+            config=RunnerConfig(mode="parallel_any", max_concurrency=2),
+        )
+    except (errors.ParallelExecutionError, _parallel_shim.ParallelExecutionError) as exc:
+        pytest.fail(f"ParallelExecutionError was raised unexpectedly: {exc}")
 
     metrics_by_model = {metric.model: metric for metric in results}
     assert WinnerProvider.calls == 1


### PR DESCRIPTION
## Summary
- add explicit assertions so the parallel_any regression tests fail if a ParallelExecutionError is raised
- ensure ParallelAnyState.finalize exits early when a winner is registered and treat outcome-based successes as valid

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_failures.py -k "parallel_any"


------
https://chatgpt.com/codex/tasks/task_e_68df73fb565c8321a8437feb4ae36042