### PR TITLE
Document missing backend targets

### DIFF
--- a/docs/backend_path_issue.md
+++ b/docs/backend_path_issue.md
@@ -1,0 +1,12 @@
+# Backend Path Investigation
+
+- 実行コマンド: `pytest backend/tests/test_db_schema.py -k crops`
+  - 結果: テスト対象ファイルが存在せずエラー終了。
+- 実行コマンド: `black backend/app/routes/crops.py`
+  - 結果: 対象ファイルが存在せずエラー終了。
+- 実行コマンド: `black --check backend/app/routes/crops.py`
+  - 結果: 対象ファイルが存在せずエラー終了。
+- 実行コマンド: `pytest backend/tests/test_db_schema.py -k crops`
+  - 結果: 初回同様にファイル未存在エラー。
+
+リポジトリ内で `backend/tests/test_db_schema.py` および `backend/app/routes/crops.py` を確認できませんでした。


### PR DESCRIPTION
## Summary
- add documentation detailing the missing backend test and route paths referenced in automation steps

## Testing
- pytest backend/tests/test_db_schema.py -k crops
- black backend/app/routes/crops.py
- black --check backend/app/routes/crops.py
- pytest backend/tests/test_db_schema.py -k crops

------
https://chatgpt.com/codex/tasks/task_e_68df863d98a4832183bf6dc15014d75f