### PR TITLE
Add regression test and support success status in metrics

### DIFF
--- a/projects/04-llm-adapter/tests/test_metrics_modules.py
+++ b/projects/04-llm-adapter/tests/test_metrics_modules.py
@@ -70,6 +70,36 @@ def test_compute_overview_and_comparison_table() -> None:
     ]
 
 
+def test_compute_overview_handles_success_status() -> None:
+    metrics = [
+        {
+            "provider": "openai",
+            "model": "gpt",
+            "prompt_id": "p2",
+            "latency_ms": 150,
+            "cost_usd": 0.1,
+            "status": "success",
+        }
+    ]
+
+    overview = data_mod.compute_overview(metrics)
+    assert overview["success_rate"] == 100.0
+
+    table = data_mod.build_comparison_table(metrics)
+    assert table == [
+        {
+            "provider": "openai",
+            "model": "gpt",
+            "prompt_id": "p2",
+            "attempts": 1,
+            "ok_rate": 100.0,
+            "avg_latency": 150.0,
+            "avg_cost": 0.1,
+            "avg_diff_rate": None,
+        }
+    ]
+
+
 def test_failure_summary_and_alerts() -> None:
     metrics = [
         {"failure_kind": "timeout"},

--- a/projects/04-llm-adapter/tools/report/metrics/data.py
+++ b/projects/04-llm-adapter/tools/report/metrics/data.py
@@ -10,6 +10,9 @@ from statistics import mean, median
 from .utils import coerce_optional_float
 
 
+SUCCESS_STATUSES = {"ok", "success"}
+
+
 def load_metrics(path: Path) -> list[Mapping[str, object]]:
     """Load metrics from a JSON Lines file if it exists."""
 
@@ -40,7 +43,11 @@ def compute_overview(metrics: Sequence[Mapping[str, object]]) -> dict[str, objec
         }
     latencies = [float(m.get("latency_ms", 0)) for m in metrics]
     costs = [float(m.get("cost_usd", 0.0)) for m in metrics]
-    successes = sum(1 for m in metrics if m.get("status") == "ok")
+    successes = sum(
+        1
+        for m in metrics
+        if str(m.get("status", "")).lower() in SUCCESS_STATUSES
+    )
     return {
         "total": total,
         "success_rate": round(successes / total * 100, 2),
@@ -63,7 +70,11 @@ def build_comparison_table(
     table: list[dict[str, object]] = []
     for (provider, model, prompt_id), rows in sorted(groups.items()):
         attempts = len(rows)
-        ok_count = sum(1 for row in rows if row.get("status") == "ok")
+        ok_count = sum(
+            1
+            for row in rows
+            if str(row.get("status", "")).lower() in SUCCESS_STATUSES
+        )
         avg_latency = mean(float(row.get("latency_ms", 0)) for row in rows)
         avg_cost = mean(float(row.get("cost_usd", 0.0)) for row in rows)
         diff_rates: list[float] = []


### PR DESCRIPTION
## Summary
- add a regression test ensuring compute_overview and build_comparison_table treat `status="success"` as successful
- recognise both "ok" and "success" statuses when computing success counts and rates

## Testing
- pytest projects/04-llm-adapter/tests/test_metrics_modules.py -k success

------
https://chatgpt.com/codex/tasks/task_e_68df905cc0608321a437d2e08800578b