### PR TITLE
Reorder imports in compare runner test

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_runner_mode.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_runner_mode.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -30,8 +31,8 @@ class _RunnerMode(str, Enum):
 def test_compare_runner_normalizes_enum_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    provider_config_factory: "ProviderConfigFactory",
-    task_factory: "TaskFactory",
+    provider_config_factory: ProviderConfigFactory,
+    task_factory: TaskFactory,
     budget_manager_factory,
 ) -> None:
     provider_config = provider_config_factory(tmp_path, name="p1", provider="p1", model="m1")


### PR DESCRIPTION
## Summary
- reorder imports in the compare runner mode test to follow standard/third-party/local grouping
- replace quoted type annotations with direct references and source Sequence from collections.abc

## Testing
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/test_runner_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68df904a7bdc8321ad196216023184ff