### PR TITLE
chore: drop quoted annotations in consensus test

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py
@@ -78,7 +78,7 @@ def test_majority_vote_uses_json_equality_when_schema_present() -> None:
 
 
 def test_auto_tie_breaker_applies_latency_cost_and_order(
-    run_metrics_factory: "RunMetricsFactory",
+    run_metrics_factory: RunMetricsFactory,
 ) -> None:
     config = RunnerConfig(mode="consensus")
     candidates = [_candidate(0, "same"), _candidate(1, "same")]
@@ -132,8 +132,8 @@ def _register_provider(monkeypatch: pytest.MonkeyPatch, name: str, cls: type[Bas
 
 def _run_consensus(
     tmp_path: Path,
-    provider_config_factory: "ProviderConfigFactory",
-    task_factory: "TaskFactory",
+    provider_config_factory: ProviderConfigFactory,
+    task_factory: TaskFactory,
     budget_manager_factory,
     provider_specs: list[tuple[str, str, str]],
     *,
@@ -157,8 +157,8 @@ def _run_consensus(
 def test_consensus_majority_and_judge_tiebreak(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    provider_config_factory: "ProviderConfigFactory",
-    task_factory: "TaskFactory",
+    provider_config_factory: ProviderConfigFactory,
+    task_factory: TaskFactory,
     budget_manager_factory,
 ) -> None:
     class ConsensusProvider(BaseProvider):


### PR DESCRIPTION
## Summary
- replace string-based type annotations in the consensus test with direct references

## Testing
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/test_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68df9047c2b483218d16a1a8aa79cf3e