### PR TITLE
Fix setattr usage in test invoker

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py
@@ -205,7 +205,7 @@ def test_provider_call_event_contains_token_usage(
         cost_calls.append((tokens_in, tokens_out))
         return 12.34
 
-    setattr(provider, "estimate_cost", fake_estimate_cost)
+    provider.estimate_cost = fake_estimate_cost
 
     def fake_run_with_shadow(*args: Any, **kwargs: Any) -> ProviderResponse:
         assert kwargs["capture_metrics"] is False


### PR DESCRIPTION
## Summary
- replace setattr-based assignment with direct attribute assignment in the invoker test to avoid ruff B010

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sync_invocation/test_invoker.py

------
https://chatgpt.com/codex/tasks/task_e_68df9045549483218dd3328825a5c16f