### PR TITLE
chore: sort imports in parallel any tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py
+++ b/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import threading
-import time
 from collections.abc import Sequence
 from concurrent.futures import Future
 from pathlib import Path
+import threading
+import time
 from typing import Any
 
 import pytest
@@ -17,16 +17,14 @@ from src.llm_adapter.runner import Runner
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
 
 from ..parallel_helpers import (
-    RecordingLogger,
-    _RetryProbeProvider,
-    _StaticProvider,
     _install_recording_executor,
     _read_metrics,
+    _RetryProbeProvider,
+    _StaticProvider,
+    RecordingLogger,
 )
 
-
 # --- ANY のキャンセル/再試行 ---
-
 
 def test_run_parallel_any_sync_cancels_pending_futures(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- sort the imports in `projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py` per Ruff

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py


------
https://chatgpt.com/codex/tasks/task_e_68df90430d708321abad6686c4c8f1d9