### PR TITLE
Sort imports in parallel consensus test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py
@@ -12,14 +12,13 @@ from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import Runner
 from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 from src.llm_adapter.runner_parallel import (
-    ConsensusConfig,
     _normalize_candidate_text,
     compute_consensus,
+    ConsensusConfig,
 )
 from src.llm_adapter.shadow import run_with_shadow
 
 from ..parallel_helpers import _StaticProvider
-
 
 # --- コンセンサス/シャドー計測 ---
 


### PR DESCRIPTION
## Summary
- reorder imports in the parallel consensus test module to follow category grouping

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68df9042f8b48321a9938f8672c7ec0b