### PR TITLE
style: reformat parallel consensus test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py
+++ b/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py
@@ -6,7 +6,10 @@ from typing import cast
 
 import pytest
 
-from src.llm_adapter.parallel_exec import ParallelExecutionError, run_parallel_any_sync
+from src.llm_adapter.parallel_exec import (
+    ParallelExecutionError,
+    run_parallel_any_sync,
+)
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
 from src.llm_adapter.providers.mock import MockProvider
 from src.llm_adapter.runner import Runner


### PR DESCRIPTION
## Summary
- group the parallel consensus test imports by standard library, third-party, and local modules
- expand the parallel execution import for consistent multi-line formatting

## Testing
- pytest projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py
- ruff check projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py --select I001
- pytest projects/04-llm-adapter-shadow/tests/parallel/test_parallel_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68e0aaa3d6b48321b5b9c0bb852ac43f