### PR TITLE
Ensure async sequential run metrics report provider latency

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/sequential.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/sequential.py
@@ -51,6 +51,10 @@ class SequentialRunStrategy:
                     if not shadow_metadata
                     else dict(context.metadata, **shadow_metadata)
                 )
+                latency_ms = getattr(response, "latency_ms", None)
+                if latency_ms is None:
+                    latency_ms = elapsed_ms(context.run_started)
+
                 log_run_metric(
                     context.event_logger,
                     request_fingerprint=context.request_fingerprint,
@@ -58,7 +62,7 @@ class SequentialRunStrategy:
                     provider=provider,
                     status="ok",
                     attempts=attempt_index,
-                    latency_ms=elapsed_ms(context.run_started),
+                    latency_ms=latency_ms,
                     tokens_in=tokens_in,
                     tokens_out=tokens_out,
                     cost_usd=cost_usd,


### PR DESCRIPTION
## Summary
- add an async sequential regression test that ensures run_metric latency matches the provider response latency
- update the sequential async run strategy to forward response latency to log_run_metric, falling back to elapsed time only when unavailable

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py::test_async_runner_run_metric_uses_response_latency
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py::test_async_runner_strategy_selection
- pytest projects/04-llm-adapter-shadow/tests/test_runner_sequential.py::test_sequential_run_metric_reports_response_latency


------
https://chatgpt.com/codex/tasks/task_e_68e0aa891618832190d5c5b8d2b331e4