### PR TITLE
Refactor runner_shared imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
@@ -1,16 +1,20 @@
 """Shared helpers for runner modules."""
 from __future__ import annotations
 
+import asyncio
+import threading
+import time
+
 from .costs import estimate_cost, provider_model
 from .logging import (
-    MetricsPath,
     error_family,
     log_provider_call,
     log_provider_skipped,
     log_run_metric,
+    MetricsPath,
     resolve_event_logger,
 )
-from .rate_limiter import RateLimiter, asyncio, resolve_rate_limiter, threading, time
+from .rate_limiter import RateLimiter, resolve_rate_limiter
 
 __all__ = [
     "MetricsPath",


### PR DESCRIPTION
## Summary
- import standard-library modules directly in `runner_shared.__init__` and re-export them via `__all__`
- reorder local imports to satisfy Ruff's isort rules

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0b4098504832184ce9a6689bae907