### PR TITLE
Fix async runner run metric error type on failures

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -196,7 +196,7 @@ class AsyncRunner:
             tokens_in=None,
             tokens_out=None,
             cost_usd=0.0,
-            error=failure_error,
+            error=last_err or failure_error,
             metadata=metadata,
             shadow_used=shadow_used,
         )

--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py
@@ -151,6 +151,11 @@ def test_async_runner_emits_failure_event() -> None:
     assert event["providers"] == ["flaky"]
     assert event["last_error_type"] == "TimeoutError"
 
+    run_metric_events = logger.of_type("run_metric")
+    assert len(run_metric_events) == 1
+    run_metric = run_metric_events[0]
+    assert run_metric["error_type"] == "TimeoutError"
+
 def test_async_runner_run_metric_uses_response_latency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- extend the async runner failure event test to validate the error type logged by run_metric
- ensure run_metric records the actual exception when all providers fail

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py::test_async_runner_emits_failure_event

------
https://chatgpt.com/codex/tasks/task_e_68e0b360c2ac83218c1873f3afcbf284