### PR TITLE
Sort standard library imports in parallel any test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py
+++ b/projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py
@@ -1,12 +1,10 @@
-# ruff: noqa: I001
 from __future__ import annotations
-
-import threading
-import time
 
 from collections.abc import Sequence
 from concurrent.futures import Future
 from pathlib import Path
+import threading
+import time
 from typing import Any
 
 import pytest


### PR DESCRIPTION
## Summary
- reorder the standard library imports in `projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py`
- drop the ruff I001 ignore so the file follows the configured import order

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/parallel/test_parallel_any.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b34b032083219ff6d13b9dec7ead