### PR TITLE
Ensure parallel any metrics use provider latency

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_any.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_any.py
@@ -54,6 +54,12 @@ class ParallelAnyRunStrategy(ParallelStrategyBase):
         tokens_in = usage.prompt
         tokens_out = usage.completion
         cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+        response_latency_ms = getattr(response, "latency_ms", None)
+        latency_ms = (
+            int(response_latency_ms)
+            if response_latency_ms is not None
+            else elapsed_ms(context.run_started)
+        )
         log_run_metric(
             context.event_logger,
             request_fingerprint=context.request_fingerprint,
@@ -61,7 +67,7 @@ class ParallelAnyRunStrategy(ParallelStrategyBase):
             provider=provider,
             status="ok",
             attempts=attempt_index,
-            latency_ms=elapsed_ms(context.run_started),
+            latency_ms=latency_ms,
             tokens_in=tokens_in,
             tokens_out=tokens_out,
             cost_usd=cost_usd,

--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -7,7 +7,7 @@ import pytest
 
 from src.llm_adapter.errors import RateLimitError, TimeoutError
 from src.llm_adapter.parallel_exec import ParallelExecutionError
-from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_async import AllFailedError
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
@@ -18,6 +18,48 @@ from .conftest import (
     _FakeClock,
     _patch_runner_sleep,
 )
+
+
+def test_async_parallel_any_run_metric_uses_response_latency() -> None:
+    class _FixedLatencyProvider:
+        def __init__(self, name: str, latency_ms: int) -> None:
+            self._name = name
+            self._latency_ms = latency_ms
+
+        def name(self) -> str:
+            return self._name
+
+        def capabilities(self) -> set[str]:
+            return set()
+
+        async def invoke_async(self, request: ProviderRequest) -> ProviderResponse:
+            return ProviderResponse(
+                text=f"{self._name}:{request.prompt}",
+                latency_ms=self._latency_ms,
+                token_usage=TokenUsage(prompt=1, completion=1),
+                model=request.model,
+            )
+
+    latency_ms = 4321
+    provider = _FixedLatencyProvider("fixed", latency_ms=latency_ms)
+    logger = _CapturingLogger()
+    runner = AsyncRunner(
+        [provider],
+        logger=logger,
+        config=RunnerConfig(mode=RunnerMode.PARALLEL_ANY, max_concurrency=1),
+    )
+    request = ProviderRequest(prompt="hi", model="latency-check")
+
+    response = asyncio.run(runner.run_async(request))
+
+    assert response.latency_ms == latency_ms
+    run_metrics = [
+        event
+        for event in logger.of_type("run_metric")
+        if event.get("provider") == provider.name()
+    ]
+    assert len(run_metrics) == 1
+    assert run_metrics[0]["latency_ms"] == latency_ms
 
 
 def test_async_runner_parallel_any_logs_cancelled_providers() -> None:


### PR DESCRIPTION
## Summary
- add a regression test for ParallelAny ensuring run_metric latency matches ProviderResponse.latency_ms
- update ParallelAnyRunStrategy to prefer response latency when logging run metrics

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py::test_async_parallel_any_run_metric_uses_response_latency

------
https://chatgpt.com/codex/tasks/task_e_68e0ba1468108321ab2a0282f0ccc6c7