### PR TITLE
Ensure parallel any run metrics use response latency

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_any.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_modes/parallel_any.py
@@ -54,6 +54,12 @@ class ParallelAnyRunStrategy(ParallelStrategyBase):
         tokens_in = usage.prompt
         tokens_out = usage.completion
         cost_usd = estimate_cost(provider, tokens_in, tokens_out)
+        response_latency = getattr(response, "latency_ms", None)
+        latency_ms = (
+            int(response_latency)
+            if response_latency is not None
+            else elapsed_ms(context.run_started)
+        )
         log_run_metric(
             context.event_logger,
             request_fingerprint=context.request_fingerprint,
@@ -61,7 +67,7 @@ class ParallelAnyRunStrategy(ParallelStrategyBase):
             provider=provider,
             status="ok",
             attempts=attempt_index,
-            latency_ms=elapsed_ms(context.run_started),
+            latency_ms=latency_ms,
             tokens_in=tokens_in,
             tokens_out=tokens_out,
             cost_usd=cost_usd,

--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -7,7 +7,7 @@ import pytest
 
 from src.llm_adapter.errors import RateLimitError, TimeoutError
 from src.llm_adapter.parallel_exec import ParallelExecutionError
-from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse
+from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_async import AllFailedError
 from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
@@ -47,6 +47,44 @@ def test_async_runner_parallel_any_logs_cancelled_providers() -> None:
     assert run_metrics["fast"]["status"] == "ok"
     assert run_metrics["slow"]["status"] == "error"
     assert run_metrics["slow"]["error_type"] == "CancelledError"
+
+
+def test_async_parallel_any_run_metric_uses_response_latency() -> None:
+    class _FixedLatencyAsyncProvider:
+        def __init__(self, name: str, latency_ms: int) -> None:
+            self._name = name
+            self._latency_ms = latency_ms
+
+        def name(self) -> str:
+            return self._name
+
+        def capabilities(self) -> set[str]:
+            return set()
+
+        async def invoke_async(self, request: ProviderRequest) -> ProviderResponse:
+            return ProviderResponse(
+                text=f"{self._name}:{request.prompt}",
+                latency_ms=self._latency_ms,
+                token_usage=TokenUsage(prompt=1, completion=1),
+                model=request.model,
+            )
+
+    fixed_latency = 321
+    provider = _FixedLatencyAsyncProvider("fixed", latency_ms=fixed_latency)
+    logger = _CapturingLogger()
+    runner = AsyncRunner(
+        [provider],
+        logger=logger,
+        config=RunnerConfig(mode=RunnerMode.PARALLEL_ANY, max_concurrency=1),
+    )
+    request = ProviderRequest(prompt="latency", model="parallel-any-latency")
+
+    response = asyncio.run(runner.run_async(request))
+
+    assert response.latency_ms == fixed_latency
+    run_metrics = logger.of_type("run_metric")
+    assert len(run_metrics) == 1
+    assert run_metrics[0]["latency_ms"] == fixed_latency
 
 
 def test_async_parallel_any_returns_first_completion() -> None:


### PR DESCRIPTION
## Summary
- add regression test covering run_metric latency reporting in async parallel-any runner
- update ParallelAnyRunStrategy to prefer provider response latency when logging metrics

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py::test_async_parallel_any_run_metric_uses_response_latency

------
https://chatgpt.com/codex/tasks/task_e_68e0ba118784832192f71582ae169314