### PR TITLE
Ensure ParallelExecutionError is treated as fatal

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/errors.py
@@ -7,7 +7,7 @@ Runner retry policy:
 """
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from enum import Enum
 
 
@@ -33,6 +33,22 @@ class AllFailedError(FatalError):
     def __init__(self, message: str, *, failures: Sequence[dict[str, str]] | None = None) -> None:
         super().__init__(message)
         self.failures: list[dict[str, str]] = list(failures or [])
+
+
+class ParallelExecutionError(FatalError):
+    """Raised when all parallel workers fail to produce a response."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failures: Sequence[Mapping[str, str]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        if failures is None:
+            self.failures: list[dict[str, str]] | None = None
+        else:
+            self.failures = [dict(detail) for detail in failures]
 
 
 class TimeoutError(RetryableError):
@@ -100,6 +116,7 @@ __all__ = [
     "SkipError",
     "FatalError",
     "AllFailedError",
+    "ParallelExecutionError",
     "ProviderSkip",
     "SkipReason",
     "ConfigError",

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/parallel_exec.py
@@ -1,7 +1,7 @@
 """Parallel execution helpers shared across runner implementations."""
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import (
     as_completed,
     FIRST_COMPLETED,
@@ -13,31 +13,13 @@ from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 from . import parallel_async as _parallel_async
+from .errors import ParallelExecutionError
 
 T = TypeVar("T")
 S = TypeVar("S")
 
 
 SyncWorker = Callable[[], T]
-
-
-class ParallelExecutionError(RuntimeError):
-    """Raised when all parallel workers fail to produce a response."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        failures: Sequence[Mapping[str, str]] | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.failures: list[dict[str, str]] | None
-        if failures is None:
-            self.failures = None
-        else:
-            self.failures = [dict(detail) for detail in failures]
-
-
 @dataclass(slots=True)
 class ParallelAllResult(Generic[T, S]):
     """Container capturing every result from ``run_parallel_all_*`` helpers."""

--- a/projects/04-llm-adapter-shadow/tests/sync_metrics/test_errors.py
+++ b/projects/04-llm-adapter-shadow/tests/sync_metrics/test_errors.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from src.llm_adapter.errors import AllFailedError, TimeoutError
+from src.llm_adapter.errors import AllFailedError, FatalError, TimeoutError
 from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, ProviderSPI
 from src.llm_adapter.runner_config import RunnerMode
+from src.llm_adapter.runner_shared.logging import error_family
 
 from ..parallel_helpers import _StaticProvider
 from .helpers import (
@@ -32,6 +33,14 @@ class _FailingProvider:
 
     def invoke(self, request: ProviderRequest) -> ProviderResponse:
         raise self._error
+
+
+
+
+def test_parallel_execution_error_is_fatal() -> None:
+    error = ParallelExecutionError("parallel boom")
+    assert isinstance(error, FatalError)
+    assert error_family(error) == "fatal"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a regression test asserting ParallelExecutionError is categorized as a fatal error
- move ParallelExecutionError into the shared errors module and expose it via parallel_exec
- ensure the fatal error classification continues to work when used by logging

## Testing
- pytest tests/sync_metrics/test_errors.py -k fatal -q

------
https://chatgpt.com/codex/tasks/task_e_68e0d96d30848321a5b0fe1d2d13a9e1