### PR TITLE
Handle success statuses in regression summary

### DIFF
--- a/projects/04-llm-adapter/tests/test_metrics_modules.py
+++ b/projects/04-llm-adapter/tests/test_metrics_modules.py
@@ -163,6 +163,31 @@ def test_build_regression_summary_and_weekly_summary(tmp_path: Path) -> None:
     assert "| Rank | Failure Kind | Count |" in content
 
 
+def test_build_regression_summary_treats_success_status_as_pass(
+    tmp_path: Path,
+) -> None:
+    golden_dir = tmp_path / "golden"
+    baseline_dir = golden_dir / "baseline"
+    baseline_dir.mkdir(parents=True)
+    (baseline_dir / "expectations.json").write_text(
+        "[{\"provider\": \"p\", \"model\": \"m\", \"prompt_id\": \"id\", \"max_diff_rate\": 1.0}]",
+        encoding="utf-8",
+    )
+    metrics = [
+        {
+            "provider": "p",
+            "model": "m",
+            "prompt_id": "id",
+            "status": "success",
+            "eval": {"diff_rate": 0.1},
+            "ts": "2024-01-01T00:00:00Z",
+        }
+    ]
+    regression_html = regression_mod.build_regression_summary(metrics, golden_dir)
+    assert "<td>PASS</td>" in regression_html
+    assert "最新ステータス" not in regression_html
+
+
 @pytest.mark.parametrize(
     "golden_dir, expected",
     [

--- a/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 import html
 from pathlib import Path
 
-from .data import load_baseline_expectations
+from .data import SUCCESS_STATUSES, load_baseline_expectations
 from .utils import coerce_optional_float, latest_metrics_by_key
 
 
@@ -59,9 +59,11 @@ def build_regression_summary(
         result = "MISSING"
         detail = "最新結果がありません。"
         if latest is not None:
-            latest_status = str(latest.get("status", "-"))
+            latest_status_value = str(latest.get("status", "-"))
+            latest_status = latest_status_value
             latest_diff = _extract_diff_rate(latest)
-            if latest_status != "ok":
+            status_normalized = latest_status_value.lower()
+            if status_normalized not in SUCCESS_STATUSES:
                 result = "FAIL"
                 detail = f"最新ステータス: {latest_status}"
             elif latest_diff is None:


### PR DESCRIPTION
## Summary
- add a regression test to ensure success statuses are treated as passing in regression summaries
- reuse the shared success status set when determining regression summary results

## Testing
- pytest projects/04-llm-adapter/tests/test_metrics_modules.py -k regression_summary

------
https://chatgpt.com/codex/tasks/task_e_68e0d960d4008321b1815ead76647ffd