### PR TITLE
Refactor adapter core metrics into dedicated modules

### DIFF
--- a/projects/04-llm-adapter/adapter/cli/prompt_runner.py
+++ b/projects/04-llm-adapter/adapter/cli/prompt_runner.py
@@ -9,7 +9,8 @@ from typing import cast
 
 from adapter.core import providers as provider_module
 from adapter.core.config import ProviderConfig
-from adapter.core.metrics import estimate_cost, RunMetric
+from adapter.core.metrics.costs import estimate_cost
+from adapter.core.metrics.models import RunMetric
 
 from .utils import _sanitize_message, LOGGER
 

--- a/projects/04-llm-adapter/adapter/core/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/__init__.py
@@ -21,16 +21,15 @@ from .config import (  # noqa: F401
     ProviderConfig,
 )
 from .datasets import GoldenTask, load_golden_tasks  # noqa: F401
-from .metrics import (  # noqa: F401
+from .metrics.costs import compute_cost_usd, estimate_cost  # noqa: F401
+from .metrics.diff import compute_diff_rate  # noqa: F401
+from .metrics.models import (  # noqa: F401
     BudgetSnapshot,
-    compute_cost_usd,
-    compute_diff_rate,
-    estimate_cost,
     EvalMetrics,
-    hash_text,
-    now_ts,
     RunMetric,
     RunMetrics,
+    hash_text,
+    now_ts,
 )
 from .providers import ProviderFactory  # noqa: F401
 from .runners import CompareRunner  # noqa: F401

--- a/projects/04-llm-adapter/adapter/core/aggregation_controller.py
+++ b/projects/04-llm-adapter/adapter/core/aggregation_controller.py
@@ -14,7 +14,7 @@ from .aggregation_selector import (
     AggregationSelector,
     JudgeProviderFactory,
 )
-from .metrics import hash_text
+from .metrics.models import hash_text
 from .runner_execution import SingleRunResult
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用

--- a/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_finalizer.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import compute_diff_rate, RunMetrics
+from .metrics.diff import compute_diff_rate
+from .metrics.models import RunMetrics
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用

--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -13,13 +13,13 @@ import uuid
 from .budgets import BudgetManager
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import (
+from .metrics.diff import compute_diff_rate
+from .metrics.models import (
     BudgetSnapshot,
-    compute_diff_rate,
     EvalMetrics,
+    RunMetrics,
     hash_text,
     now_ts,
-    RunMetrics,
 )
 from .providers import BaseProvider, ProviderFactory, ProviderResponse
 

--- a/projects/04-llm-adapter/adapter/core/execution/compare_task_runner.py
+++ b/projects/04-llm-adapter/adapter/core/execution/compare_task_runner.py
@@ -8,7 +8,7 @@ import typing
 from ..config import ProviderConfig
 from ..datasets import GoldenTask
 from ..errors import AllFailedError
-from ..metrics import RunMetrics
+from ..metrics.models import RunMetrics
 from ..providers import BaseProvider, ProviderFactory
 from ..runner_execution import RunnerExecution, SingleRunResult
 

--- a/projects/04-llm-adapter/adapter/core/metrics.py
+++ b/projects/04-llm-adapter/adapter/core/metrics.py
@@ -1,294 +1,74 @@
-"""メトリクス関連ユーティリティ。"""
+"""メトリクス関連ユーティリティのレガシー互換シム。"""
+
+# このファイルは分割済みモジュールへの案内用（チェックリスト完了で削除）
+# - [ ] adapter.core.metrics.models を直接 import している
+# - [ ] adapter.core.metrics.update を直接 import している
+# - [ ] adapter.core.metrics.costs を直接 import している
+# - [ ] adapter.core.metrics.diff を直接 import している
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, UTC
-import hashlib
-from statistics import median
-from typing import Any, Literal, Protocol, TYPE_CHECKING
-
-from pydantic import BaseModel, Field
-
-if TYPE_CHECKING:  # pragma: no cover - 循環参照の回避
-    from .config import ProviderConfig
-    from .execution.shadow_runner import ShadowRunnerResult
-    from .providers import ProviderResponse
+import importlib.util
+from pathlib import Path
+import sys
 
 
-class RunMetric(BaseModel):
-    """シンプルなランメトリクス表現。"""
-
-    provider: str
-    model: str
-    endpoint: str
-    latency_ms: int
-    input_tokens: int
-    output_tokens: int
-    cost_usd: float = 0.0
-    status: str = "ok"
-    error: str | None = None
-    prompt_sha256: str = Field(..., description="content hash without secrets")
-
-    @classmethod
-    def from_resp(
-        cls,
-        cfg: ProviderConfig,
-        resp: ProviderResponse,
-        prompt: str,
-        *,
-        cost_usd: float = 0.0,
-        error: str | None = None,
-    ) -> RunMetric:
-        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
-        return cls(
-            provider=cfg.provider,
-            model=cfg.model,
-            endpoint=(cfg.endpoint or "responses"),
-            latency_ms=int(resp.latency_ms),
-            input_tokens=int(resp.input_tokens),
-            output_tokens=int(resp.output_tokens),
-            cost_usd=float(cost_usd),
-            status="error" if error else "ok",
-            error=error,
-            prompt_sha256=digest,
-        )
+def _load_submodule(module_name: str):
+    qualified_name = f"{__name__}.{module_name}"
+    module_path = Path(__file__).with_name("metrics") / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(qualified_name, module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - importguard
+        raise ModuleNotFoundError(qualified_name)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[qualified_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-@dataclass
-class EvalMetrics:
-    """評価結果。"""
+_models = _load_submodule("models")
+_update = _load_submodule("update")
+_costs = _load_submodule("costs")
+_diff = _load_submodule("diff")
 
-    exact_match: bool | None = None
-    diff_rate: float | None = None
-    len_tokens: int | None = None
+sys.modules[f"{__name__}.models"] = _models
+sys.modules[f"{__name__}.update"] = _update
+sys.modules[f"{__name__}.costs"] = _costs
+sys.modules[f"{__name__}.diff"] = _diff
 
+RunMetric = _models.RunMetric
+RunMetrics = _models.RunMetrics
+EvalMetrics = _models.EvalMetrics
+BudgetSnapshot = _models.BudgetSnapshot
+now_ts = _models.now_ts
+hash_text = _models.hash_text
 
-@dataclass
-class BudgetSnapshot:
-    """予算情報。"""
+finalize_run_metrics = _update.finalize_run_metrics
+apply_shadow_metrics = _update.apply_shadow_metrics
+ProviderCallResult = _update.ProviderCallResult
 
-    run_budget_usd: float
-    hit_stop: bool
+compute_cost_usd = _costs.compute_cost_usd
+estimate_cost = _costs.estimate_cost
 
+tokenize = _diff.tokenize
+levenshtein_distance = _diff.levenshtein_distance
+compute_diff_rate = _diff.compute_diff_rate
+summarize_diff_rates = _diff.summarize_diff_rates
 
-@dataclass
-class RunMetrics:
-    """JSONL へ書き出す 1 行のメトリクス。"""
+__all__ = [
+    "RunMetric",
+    "RunMetrics",
+    "EvalMetrics",
+    "BudgetSnapshot",
+    "now_ts",
+    "hash_text",
+    "finalize_run_metrics",
+    "apply_shadow_metrics",
+    "ProviderCallResult",
+    "compute_cost_usd",
+    "estimate_cost",
+    "tokenize",
+    "levenshtein_distance",
+    "compute_diff_rate",
+    "summarize_diff_rates",
+]
 
-    ts: str
-    run_id: str
-    provider: str
-    model: str
-    mode: str
-    prompt_id: str
-    prompt_name: str
-    seed: int
-    temperature: float
-    top_p: float
-    max_tokens: int
-    input_tokens: int
-    output_tokens: int
-    latency_ms: int
-    cost_usd: float
-    status: str
-    failure_kind: str | None
-    error_message: str | None
-    output_text: str | None
-    output_hash: str | None
-    error_type: str | None = None
-    providers: list[str] = field(default_factory=list)
-    token_usage: dict[str, int] = field(default_factory=dict)
-    attempts: int = 0
-    retries: int = 0
-    outcome: Literal["success", "skip", "error"] = "success"
-    shadow_provider_id: str | None = None
-    shadow_latency_ms: int | None = None
-    shadow_status: str | None = None
-    shadow_error_message: str | None = None
-    shadow_outcome: Literal["success", "skip", "error"] | None = None
-    eval: EvalMetrics = field(default_factory=EvalMetrics)
-    budget: BudgetSnapshot = field(default_factory=lambda: BudgetSnapshot(0.0, False))
-    ci_meta: Mapping[str, Any] = field(default_factory=dict)
-    cost_estimate: float | None = None
-
-    def __post_init__(self) -> None:
-        if self.cost_estimate is None:
-            self.cost_estimate = self.cost_usd
-
-    def to_json_dict(self) -> dict[str, Any]:
-        payload: dict[str, Any] = asdict(self)
-        payload["cost_estimate"] = (
-            self.cost_estimate if self.cost_estimate is not None else self.cost_usd
-        )
-        payload["eval"] = {k: v for k, v in payload["eval"].items() if v is not None}
-        return payload
-
-
-class ProviderCallResult(Protocol):
-    error: Exception | None
-    retries: int
-
-
-def finalize_run_metrics(
-    run_metrics: RunMetrics,
-    *,
-    attempt_index: int,
-    provider_result: ProviderCallResult,
-    response: ProviderResponse,
-    status: str,
-    failure_kind: str | None,
-    error_message: str | None,
-    schema_error: str | None,
-    shadow_result: ShadowRunnerResult | None,
-    fallback_shadow_id: str | None,
-    active_provider_ids: Sequence[str],
-    current_attempt_index: int,
-) -> None:
-    provider_ids: list[str] = []
-    for provider_id in active_provider_ids:
-        if provider_id not in provider_ids:
-            provider_ids.append(provider_id)
-    run_metrics.providers = provider_ids
-    usage = response.token_usage
-    prompt_tokens = int(getattr(usage, "prompt", response.input_tokens))
-    completion_tokens = int(getattr(usage, "completion", response.output_tokens))
-    total_tokens = int(getattr(usage, "total", prompt_tokens + completion_tokens))
-    run_metrics.token_usage = {
-        "prompt": prompt_tokens,
-        "completion": completion_tokens,
-        "total": total_tokens,
-    }
-    run_metrics.attempts = attempt_index + 1
-    run_metrics.error_type = (
-        type(provider_result.error).__name__ if provider_result.error else None
-    )
-    run_metrics.retries = max(current_attempt_index, 0) + max(
-        provider_result.retries - 1, 0
-    )
-    if schema_error:
-        run_metrics.status = status
-        run_metrics.failure_kind = failure_kind
-        run_metrics.error_message = error_message
-    run_metrics.outcome = _resolve_outcome(run_metrics.status)
-    apply_shadow_metrics(run_metrics, shadow_result, fallback_shadow_id)
-
-
-def apply_shadow_metrics(
-    run_metrics: RunMetrics,
-    shadow_result: ShadowRunnerResult | None,
-    fallback_shadow_id: str | None,
-) -> None:
-    if shadow_result is None:
-        if fallback_shadow_id is not None:
-            run_metrics.shadow_provider_id = fallback_shadow_id
-        return
-    provider_id = shadow_result.provider_id or fallback_shadow_id
-    if provider_id is not None:
-        run_metrics.shadow_provider_id = provider_id
-    if shadow_result.latency_ms is not None:
-        run_metrics.shadow_latency_ms = int(shadow_result.latency_ms)
-    if shadow_result.status is not None:
-        run_metrics.shadow_status = shadow_result.status
-        run_metrics.shadow_outcome = _resolve_outcome(shadow_result.status)
-    if shadow_result.error_message is not None:
-        run_metrics.shadow_error_message = shadow_result.error_message
-
-
-def _resolve_outcome(status: str) -> Literal["success", "skip", "error"]:
-    if status == "ok":
-        return "success"
-    if status == "skip":
-        return "skip"
-    return "error"
-
-
-def now_ts() -> str:
-    """UTC ISO 時刻を返す。"""
-
-    return datetime.now(UTC).isoformat()
-
-
-def hash_text(text: str) -> str:
-    """SHA-256 ハッシュを `sha256:...` 形式で返す。"""
-
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
-    return f"sha256:{digest}"
-
-
-def _cost_for_tokens(tokens: int, price_per_thousand: float) -> float:
-    return (tokens / 1000.0) * price_per_thousand
-
-
-def compute_cost_usd(
-    prompt_tokens: int,
-    completion_tokens: int,
-    prompt_price: float,
-    completion_price: float,
-) -> float:
-    """トークン数と単価からコストを算出する。"""
-
-    prompt_cost = _cost_for_tokens(prompt_tokens, prompt_price)
-    completion_cost = _cost_for_tokens(completion_tokens, completion_price)
-    return round(prompt_cost + completion_cost, 6)
-
-
-def estimate_cost(config: ProviderConfig, input_tokens: int, output_tokens: int) -> float:
-    """プロバイダ設定に基づいて概算コストを算出する。"""
-
-    pricing = config.pricing
-    input_per_million = float(pricing.input_per_million or 0.0)
-    output_per_million = float(pricing.output_per_million or 0.0)
-    if input_per_million or output_per_million:
-        cost = (input_tokens / 1_000_000.0) * input_per_million
-        cost += (output_tokens / 1_000_000.0) * output_per_million
-        return round(cost, 6)
-    prompt_price = float(pricing.prompt_usd or 0.0)
-    completion_price = float(pricing.completion_usd or 0.0)
-    return compute_cost_usd(input_tokens, output_tokens, prompt_price, completion_price)
-
-
-def tokenize(text: str) -> list[str]:
-    """簡易トークン化。"""
-
-    return text.split()
-
-
-def levenshtein_distance(a: Sequence[str], b: Sequence[str]) -> int:
-    """レーベンシュタイン距離。"""
-
-    if not a:
-        return len(b)
-    if not b:
-        return len(a)
-    prev_row = list(range(len(b) + 1))
-    for i, token_a in enumerate(a, start=1):
-        current_row = [i]
-        for j, token_b in enumerate(b, start=1):
-            insert_cost = current_row[j - 1] + 1
-            delete_cost = prev_row[j] + 1
-            replace_cost = prev_row[j - 1] + (0 if token_a == token_b else 1)
-            current_row.append(min(insert_cost, delete_cost, replace_cost))
-        prev_row = current_row
-    return prev_row[-1]
-
-
-def compute_diff_rate(output_a: str, output_b: str) -> float:
-    """差分率を 0..1 で返す。"""
-
-    tokens_a = tokenize(output_a)
-    tokens_b = tokenize(output_b)
-    if not tokens_a and not tokens_b:
-        return 0.0
-    distance = levenshtein_distance(tokens_a, tokens_b)
-    return distance / max(len(tokens_a), len(tokens_b))
-
-
-def summarize_diff_rates(diff_rates: Iterable[float]) -> float:
-    """中央値を返す。空の場合は 0。"""
-
-    data = list(diff_rates)
-    if not data:
-        return 0.0
-    return float(median(data))

--- a/projects/04-llm-adapter/adapter/core/metrics/costs.py
+++ b/projects/04-llm-adapter/adapter/core/metrics/costs.py
@@ -1,0 +1,42 @@
+"""コスト計算ユーティリティ。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+def _cost_for_tokens(tokens: int, price_per_thousand: float) -> float:
+    return (tokens / 1000.0) * price_per_thousand
+
+
+def compute_cost_usd(
+    prompt_tokens: int,
+    completion_tokens: int,
+    prompt_price: float,
+    completion_price: float,
+) -> float:
+    """トークン数と単価からコストを算出する。"""
+
+    prompt_cost = _cost_for_tokens(prompt_tokens, prompt_price)
+    completion_cost = _cost_for_tokens(completion_tokens, completion_price)
+    return round(prompt_cost + completion_cost, 6)
+
+
+def estimate_cost(config: "ProviderConfig", input_tokens: int, output_tokens: int) -> float:
+    """プロバイダ設定に基づいて概算コストを算出する。"""
+
+    pricing = config.pricing
+    input_per_million = float(pricing.input_per_million or 0.0)
+    output_per_million = float(pricing.output_per_million or 0.0)
+    if input_per_million or output_per_million:
+        cost = (input_tokens / 1_000_000.0) * input_per_million
+        cost += (output_tokens / 1_000_000.0) * output_per_million
+        return round(cost, 6)
+
+    prompt_price = float(pricing.prompt_usd or 0.0)
+    completion_price = float(pricing.completion_usd or 0.0)
+    return compute_cost_usd(input_tokens, output_tokens, prompt_price, completion_price)
+
+
+if TYPE_CHECKING:  # pragma: no cover - 循環参照の回避
+    from ..config import ProviderConfig

--- a/projects/04-llm-adapter/adapter/core/metrics/diff.py
+++ b/projects/04-llm-adapter/adapter/core/metrics/diff.py
@@ -1,0 +1,52 @@
+"""差分計測ユーティリティ。"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from statistics import median
+
+
+def tokenize(text: str) -> list[str]:
+    """簡易トークン化。"""
+
+    return text.split()
+
+
+def levenshtein_distance(a: Sequence[str], b: Sequence[str]) -> int:
+    """レーベンシュタイン距離。"""
+
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    prev_row = list(range(len(b) + 1))
+    for i, token_a in enumerate(a, start=1):
+        current_row = [i]
+        for j, token_b in enumerate(b, start=1):
+            insert_cost = current_row[j - 1] + 1
+            delete_cost = prev_row[j] + 1
+            replace_cost = prev_row[j - 1] + (0 if token_a == token_b else 1)
+            current_row.append(min(insert_cost, delete_cost, replace_cost))
+        prev_row = current_row
+    return prev_row[-1]
+
+
+def compute_diff_rate(output_a: str, output_b: str) -> float:
+    """差分率を 0..1 で返す。"""
+
+    tokens_a = tokenize(output_a)
+    tokens_b = tokenize(output_b)
+    if not tokens_a and not tokens_b:
+        return 0.0
+    distance = levenshtein_distance(tokens_a, tokens_b)
+    return distance / max(len(tokens_a), len(tokens_b))
+
+
+def summarize_diff_rates(diff_rates: Iterable[float]) -> float:
+    """中央値を返す。空の場合は 0。"""
+
+    data = list(diff_rates)
+    if not data:
+        return 0.0
+    return float(median(data))

--- a/projects/04-llm-adapter/adapter/core/metrics/models.py
+++ b/projects/04-llm-adapter/adapter/core/metrics/models.py
@@ -1,0 +1,138 @@
+"""メトリクスのモデルおよびシリアライズ関連。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+import hashlib
+from typing import Any, Literal, TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+
+class RunMetric(BaseModel):
+    """シンプルなランメトリクス表現。"""
+
+    provider: str
+    model: str
+    endpoint: str
+    latency_ms: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float = 0.0
+    status: str = "ok"
+    error: str | None = None
+    prompt_sha256: str = Field(..., description="content hash without secrets")
+
+    @classmethod
+    def from_resp(
+        cls,
+        cfg: "ProviderConfig",
+        resp: "ProviderResponse",
+        prompt: str,
+        *,
+        cost_usd: float = 0.0,
+        error: str | None = None,
+    ) -> "RunMetric":
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+        return cls(
+            provider=cfg.provider,
+            model=cfg.model,
+            endpoint=(cfg.endpoint or "responses"),
+            latency_ms=int(resp.latency_ms),
+            input_tokens=int(resp.input_tokens),
+            output_tokens=int(resp.output_tokens),
+            cost_usd=float(cost_usd),
+            status="error" if error else "ok",
+            error=error,
+            prompt_sha256=digest,
+        )
+
+
+@dataclass
+class EvalMetrics:
+    """評価結果。"""
+
+    exact_match: bool | None = None
+    diff_rate: float | None = None
+    len_tokens: int | None = None
+
+
+@dataclass
+class BudgetSnapshot:
+    """予算情報。"""
+
+    run_budget_usd: float
+    hit_stop: bool
+
+
+@dataclass
+class RunMetrics:
+    """JSONL へ書き出す 1 行のメトリクス。"""
+
+    ts: str
+    run_id: str
+    provider: str
+    model: str
+    mode: str
+    prompt_id: str
+    prompt_name: str
+    seed: int
+    temperature: float
+    top_p: float
+    max_tokens: int
+    input_tokens: int
+    output_tokens: int
+    latency_ms: int
+    cost_usd: float
+    status: str
+    failure_kind: str | None
+    error_message: str | None
+    output_text: str | None
+    output_hash: str | None
+    error_type: str | None = None
+    providers: list[str] = field(default_factory=list)
+    token_usage: dict[str, int] = field(default_factory=dict)
+    attempts: int = 0
+    retries: int = 0
+    outcome: Literal["success", "skip", "error"] = "success"
+    shadow_provider_id: str | None = None
+    shadow_latency_ms: int | None = None
+    shadow_status: str | None = None
+    shadow_error_message: str | None = None
+    shadow_outcome: Literal["success", "skip", "error"] | None = None
+    eval: EvalMetrics = field(default_factory=EvalMetrics)
+    budget: BudgetSnapshot = field(default_factory=lambda: BudgetSnapshot(0.0, False))
+    ci_meta: Mapping[str, Any] = field(default_factory=dict)
+    cost_estimate: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.cost_estimate is None:
+            self.cost_estimate = self.cost_usd
+
+    def to_json_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = asdict(self)
+        payload["cost_estimate"] = (
+            self.cost_estimate if self.cost_estimate is not None else self.cost_usd
+        )
+        payload["eval"] = {k: v for k, v in payload["eval"].items() if v is not None}
+        return payload
+
+
+def now_ts() -> str:
+    """UTC ISO 時刻を返す。"""
+
+    return datetime.now(UTC).isoformat()
+
+
+def hash_text(text: str) -> str:
+    """SHA-256 ハッシュを `sha256:...` 形式で返す。"""
+
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+if TYPE_CHECKING:  # pragma: no cover - 型チェック用
+    from ..config import ProviderConfig
+    from ..providers import ProviderResponse

--- a/projects/04-llm-adapter/adapter/core/metrics/update.py
+++ b/projects/04-llm-adapter/adapter/core/metrics/update.py
@@ -1,0 +1,94 @@
+"""実行メトリクスの更新ロジック。"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, Protocol, TYPE_CHECKING
+
+from .models import RunMetrics
+
+
+class ProviderCallResult(Protocol):
+    error: Exception | None
+    retries: int
+
+
+def finalize_run_metrics(
+    run_metrics: RunMetrics,
+    *,
+    attempt_index: int,
+    provider_result: ProviderCallResult,
+    response: "ProviderResponse",
+    status: str,
+    failure_kind: str | None,
+    error_message: str | None,
+    schema_error: str | None,
+    shadow_result: "ShadowRunnerResult" | None,
+    fallback_shadow_id: str | None,
+    active_provider_ids: Sequence[str],
+    current_attempt_index: int,
+) -> None:
+    provider_ids: list[str] = []
+    for provider_id in active_provider_ids:
+        if provider_id not in provider_ids:
+            provider_ids.append(provider_id)
+    run_metrics.providers = provider_ids
+
+    usage = response.token_usage
+    prompt_tokens = int(getattr(usage, "prompt", response.input_tokens))
+    completion_tokens = int(getattr(usage, "completion", response.output_tokens))
+    total_tokens = int(getattr(usage, "total", prompt_tokens + completion_tokens))
+    run_metrics.token_usage = {
+        "prompt": prompt_tokens,
+        "completion": completion_tokens,
+        "total": total_tokens,
+    }
+
+    run_metrics.attempts = attempt_index + 1
+    run_metrics.error_type = (
+        type(provider_result.error).__name__ if provider_result.error else None
+    )
+    run_metrics.retries = max(current_attempt_index, 0) + max(provider_result.retries - 1, 0)
+
+    if schema_error:
+        run_metrics.status = status
+        run_metrics.failure_kind = failure_kind
+        run_metrics.error_message = error_message
+
+    run_metrics.outcome = _resolve_outcome(run_metrics.status)
+    apply_shadow_metrics(run_metrics, shadow_result, fallback_shadow_id)
+
+
+def apply_shadow_metrics(
+    run_metrics: RunMetrics,
+    shadow_result: "ShadowRunnerResult" | None,
+    fallback_shadow_id: str | None,
+) -> None:
+    if shadow_result is None:
+        if fallback_shadow_id is not None:
+            run_metrics.shadow_provider_id = fallback_shadow_id
+        return
+
+    provider_id = shadow_result.provider_id or fallback_shadow_id
+    if provider_id is not None:
+        run_metrics.shadow_provider_id = provider_id
+    if shadow_result.latency_ms is not None:
+        run_metrics.shadow_latency_ms = int(shadow_result.latency_ms)
+    if shadow_result.status is not None:
+        run_metrics.shadow_status = shadow_result.status
+        run_metrics.shadow_outcome = _resolve_outcome(shadow_result.status)
+    if shadow_result.error_message is not None:
+        run_metrics.shadow_error_message = shadow_result.error_message
+
+
+def _resolve_outcome(status: str) -> Literal["success", "skip", "error"]:
+    if status == "ok":
+        return "success"
+    if status == "skip":
+        return "skip"
+    return "error"
+
+
+if TYPE_CHECKING:  # pragma: no cover - 循環参照の回避
+    from ..execution.shadow_runner import ShadowRunnerResult
+    from ..providers import ProviderResponse

--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics import BudgetSnapshot, EvalMetrics, now_ts, RunMetrics
+from .metrics.models import BudgetSnapshot, EvalMetrics, RunMetrics, now_ts
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用

--- a/projects/04-llm-adapter/adapter/core/runner_execution.py
+++ b/projects/04-llm-adapter/adapter/core/runner_execution.py
@@ -19,7 +19,9 @@ from .config import ProviderConfig
 from .datasets import GoldenTask
 from .errors import RateLimitError, RetryableError
 from .execution.guards import _SchemaValidator, _TokenBucket
-from .metrics import BudgetSnapshot, estimate_cost, finalize_run_metrics, RunMetrics
+from .metrics.costs import estimate_cost
+from .metrics.models import BudgetSnapshot, RunMetrics
+from .metrics.update import finalize_run_metrics
 from .providers import BaseProvider, ProviderResponse
 from .runner_execution_attempts import (
     ParallelAttemptExecutor,

--- a/projects/04-llm-adapter/adapter/core/runners.py
+++ b/projects/04-llm-adapter/adapter/core/runners.py
@@ -19,7 +19,7 @@ from .compare_runner_support import (
 from .config import ProviderConfig
 from .datasets import GoldenTask
 from .execution.compare_task_runner import run_tasks
-from .metrics import BudgetSnapshot, RunMetrics
+from .metrics.models import BudgetSnapshot, RunMetrics
 from .providers import BaseProvider, ProviderResponse
 from .runner_execution import (
     _SchemaValidator,

--- a/projects/04-llm-adapter/tests/test_metrics_modules.py
+++ b/projects/04-llm-adapter/tests/test_metrics_modules.py
@@ -13,6 +13,10 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 metrics_mod = importlib.import_module("adapter.core.metrics")
+metrics_models_mod = importlib.import_module("adapter.core.metrics.models")
+metrics_update_mod = importlib.import_module("adapter.core.metrics.update")
+metrics_costs_mod = importlib.import_module("adapter.core.metrics.costs")
+metrics_diff_mod = importlib.import_module("adapter.core.metrics.diff")
 data_mod = importlib.import_module("tools.report.metrics.data")
 regression_mod = importlib.import_module("tools.report.metrics.regression_summary")
 weekly_mod = importlib.import_module("tools.report.metrics.weekly_summary")
@@ -231,3 +235,15 @@ def test_run_metrics_to_json_dict_includes_cost_estimate() -> None:
     payload_with_estimate = run_with_estimate.to_json_dict()
     assert payload_with_estimate["cost_usd"] == pytest.approx(0.5)
     assert payload_with_estimate["cost_estimate"] == pytest.approx(0.75)
+
+
+def test_metrics_module_reexports_public_api() -> None:
+    assert metrics_mod.RunMetric is metrics_models_mod.RunMetric
+    assert metrics_mod.RunMetrics is metrics_models_mod.RunMetrics
+    assert metrics_mod.EvalMetrics is metrics_models_mod.EvalMetrics
+    assert metrics_mod.finalize_run_metrics is metrics_update_mod.finalize_run_metrics
+    assert metrics_mod.apply_shadow_metrics is metrics_update_mod.apply_shadow_metrics
+    assert metrics_mod.compute_cost_usd is metrics_costs_mod.compute_cost_usd
+    assert metrics_mod.estimate_cost is metrics_costs_mod.estimate_cost
+    assert metrics_mod.tokenize is metrics_diff_mod.tokenize
+    assert metrics_mod.compute_diff_rate is metrics_diff_mod.compute_diff_rate


### PR DESCRIPTION
## Summary
- extract metrics models, update logic, cost helpers, and diff utilities into adapter.core.metrics package modules
- leave adapter.core.metrics shim that re-exports the public API with migration checklist guidance
- update adapter imports to use the new modules and extend metrics tests to cover re-exports

## Testing
- pytest projects/04-llm-adapter/tests/test_metrics_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d961ad68832197ae1bdb1e38487c