### PR TITLE
Fix Prometheus metrics test import order and typing

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
@@ -1,10 +1,9 @@
 """Tests for Prometheus metrics exporter status normalization."""
 from __future__ import annotations
 
-from typing import Any
-
 import sys
 import types
+from typing import Any
 
 from pytest import MonkeyPatch
 
@@ -12,7 +11,7 @@ from src.llm_adapter.metrics import PrometheusMetricsExporter
 
 
 class _LabelStub:
-    def __init__(self, metric: "_MetricStub", labels: dict[str, Any]) -> None:
+    def __init__(self, metric: _MetricStub, labels: dict[str, Any]) -> None:
         self._metric = metric
         self._labels = labels
 


### PR DESCRIPTION
## Summary
- reorder the Prometheus metrics test standard library imports to satisfy Ruff
- update the label stub metric annotation to refer directly to `_MetricStub`

## Testing
- `ruff check projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0d94ac5d483219e7a81d3c210255b