### PR TITLE
Fix ruff spacing warning in generate_ci_report

### DIFF
--- a/tools/generate_ci_report.py
+++ b/tools/generate_ci_report.py
@@ -18,7 +18,6 @@ def _ensure_repo_root_on_path() -> None:
         sys.path.insert(0, repo_root_str)
 
 
-
 def _import_module(name: str) -> ModuleType:
     try:
         return importlib.import_module(name)


### PR DESCRIPTION
## Summary
- reduce the blank lines between helper functions in `tools/generate_ci_report.py` to satisfy ruff's E303 rule

## Testing
- ruff check tools/generate_ci_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d9497d2c8321892f9215e583a81f