### PR TITLE
Remove duplicate async parallel latency test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -89,46 +89,6 @@ def test_async_runner_parallel_any_logs_cancelled_providers() -> None:
     assert run_metrics["fast"]["status"] == "ok"
     assert run_metrics["slow"]["status"] == "error"
     assert run_metrics["slow"]["error_type"] == "CancelledError"
-
-
-def test_async_parallel_any_run_metric_uses_response_latency() -> None:
-    class _FixedLatencyAsyncProvider:
-        def __init__(self, name: str, latency_ms: int) -> None:
-            self._name = name
-            self._latency_ms = latency_ms
-
-        def name(self) -> str:
-            return self._name
-
-        def capabilities(self) -> set[str]:
-            return set()
-
-        async def invoke_async(self, request: ProviderRequest) -> ProviderResponse:
-            return ProviderResponse(
-                text=f"{self._name}:{request.prompt}",
-                latency_ms=self._latency_ms,
-                token_usage=TokenUsage(prompt=1, completion=1),
-                model=request.model,
-            )
-
-    fixed_latency = 321
-    provider = _FixedLatencyAsyncProvider("fixed", latency_ms=fixed_latency)
-    logger = _CapturingLogger()
-    runner = AsyncRunner(
-        [provider],
-        logger=logger,
-        config=RunnerConfig(mode=RunnerMode.PARALLEL_ANY, max_concurrency=1),
-    )
-    request = ProviderRequest(prompt="latency", model="parallel-any-latency")
-
-    response = asyncio.run(runner.run_async(request))
-
-    assert response.latency_ms == fixed_latency
-    run_metrics = logger.of_type("run_metric")
-    assert len(run_metrics) == 1
-    assert run_metrics[0]["latency_ms"] == fixed_latency
-
-
 def test_async_parallel_any_returns_first_completion() -> None:
     slow = _AsyncProbeProvider("slow", delay=0.1, text="slow")
     fast = _AsyncProbeProvider("fast", delay=0.01, text="fast")


### PR DESCRIPTION
## Summary
- remove the redundant latency metric test from the async parallel runner suite to avoid duplicate coverage

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py -k latency

------
https://chatgpt.com/codex/tasks/task_e_68e0ddbc05588321a1f6752b399708ba