### PR TITLE
Reorder runner_shared exports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py
@@ -17,6 +17,9 @@ from .logging import (
 from .rate_limiter import RateLimiter, resolve_rate_limiter
 
 __all__ = [
+    "asyncio",
+    "threading",
+    "time",
     "MetricsPath",
     "resolve_event_logger",
     "error_family",
@@ -27,7 +30,4 @@ __all__ = [
     "log_run_metric",
     "RateLimiter",
     "resolve_rate_limiter",
-    "asyncio",
-    "threading",
-    "time",
 ]


### PR DESCRIPTION
## Summary
- reorder the exported symbols in runner_shared to place standard library modules before local helpers

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0ddbbf6248321b487f8d482fef299