### PR TITLE
Fix import order in metrics data module

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/data.py
+++ b/projects/04-llm-adapter/tools/report/metrics/data.py
@@ -2,11 +2,7 @@
 from __future__ import annotations
 
 from collections import Counter
-
-# isort: split
 from collections.abc import Mapping, Sequence
-
-# isort: split
 import json
 from pathlib import Path
 from statistics import mean, median


### PR DESCRIPTION
## Summary
- reorder standard library imports in metrics data helper to follow Ruff guidelines

## Testing
- ruff check projects/04-llm-adapter/tools/report/metrics/data.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0ddc2ecec8321a0d2bbfdc8d3a351