### PR TITLE
fix: remove quoted type annotations in parallel any failure test

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_runner.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_runner.py
@@ -168,8 +168,8 @@ def test_parallel_any_populates_metrics_for_unscheduled_workers(
 def test_parallel_any_failure_summary_includes_all_failures(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    provider_config_factory: "ProviderConfigFactory",
-    task_factory: "TaskFactory",
+    provider_config_factory: ProviderConfigFactory,
+    task_factory: TaskFactory,
     budget_manager_factory,
 ) -> None:
     class SkipProvider(BaseProvider):


### PR DESCRIPTION
## Summary
- replace quoted type annotations with direct references in the parallel any runner failure test to satisfy ruff UP037

## Testing
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_runner.py --select UP037

------
https://chatgpt.com/codex/tasks/task_e_68e0ddc1dd408321a6374fae1f2b8e96