### PR TITLE
Sort typing import order in parallel coordinator base

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel/coordinators/base.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/coordinators/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from enum import Enum
 from threading import Event
-from typing import TYPE_CHECKING, cast
+from typing import cast, TYPE_CHECKING
 
 from ...config import ProviderConfig
 from ...datasets import GoldenTask


### PR DESCRIPTION
## Summary
- reorder typing import names to follow ruff import sorting expectations in the parallel coordinator base module

## Testing
- ruff check projects/04-llm-adapter/adapter/core/parallel/coordinators/base.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0ddc0b9f08321803ed47613b003a8