### PR TITLE
fix: sort coordinator imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel/coordinators/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/coordinators/__init__.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from ...parallel_state import ProviderFailureSummary, build_cancelled_result
+from ...parallel_state import build_cancelled_result, ProviderFailureSummary
 from .all import _ParallelAllCoordinator
 from .any import _ParallelAnyCoordinator
-from .base import _ParallelCoordinatorBase, _is_parallel_any_mode, _normalize_mode_value
+from .base import _is_parallel_any_mode, _normalize_mode_value, _ParallelCoordinatorBase
 
 __all__ = [
     "ProviderFailureSummary",


### PR DESCRIPTION
## Summary
- reorder the parallel coordinator imports to follow Ruff's import grouping

## Testing
- ruff check projects/04-llm-adapter/adapter/core/parallel/coordinators/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0ddbf1c008321afc465bf0f59d1e3