### PR TITLE
Sort parallel coordinator shim imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
+++ b/projects/04-llm-adapter/adapter/core/parallel/coordinators.py
@@ -7,15 +7,14 @@ from __future__ import annotations
 # - ``coordinators/all.py``: ``ParallelAll`` 固有の並列制御ロジック。
 # - ``coordinators/any.py``: ``ParallelAny`` 固有の逐次確定ロジック。
 # 既存 import 互換性のため、従来のシンボルを再エクスポートします。
-
 from .coordinators import (
-    ProviderFailureSummary,
+    _is_parallel_any_mode,
+    _normalize_mode_value,
     _ParallelAllCoordinator,
     _ParallelAnyCoordinator,
     _ParallelCoordinatorBase,
-    _is_parallel_any_mode,
-    _normalize_mode_value,
     build_cancelled_result,
+    ProviderFailureSummary,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- alphabetize the re-exported coordinator imports for the parallel shim module

## Testing
- ruff check projects/04-llm-adapter/adapter/core/parallel/coordinators.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e0ddbdc7a483218c44ede158bead82