### PR TITLE
Fix import order in Prometheus metrics test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-import types
+from types import SimpleNamespace
 from typing import Any
 
 from pytest import MonkeyPatch
@@ -36,7 +36,7 @@ class _MetricStub:
 
 
 def test_prometheus_metrics_normalizes_errored_status(monkeypatch: MonkeyPatch) -> None:
-    stub_module = types.SimpleNamespace(Counter=_MetricStub, Histogram=_MetricStub)
+    stub_module = SimpleNamespace(Counter=_MetricStub, Histogram=_MetricStub)
     monkeypatch.setitem(sys.modules, "prometheus_client", stub_module)
 
     exporter = PrometheusMetricsExporter(namespace="test")


### PR DESCRIPTION
## Summary
- reorder standard library imports in the Prometheus metrics test to follow Ruff's grouping rules
- use SimpleNamespace directly after importing it from types for clarity

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py --select I001,UP037

------
https://chatgpt.com/codex/tasks/task_e_68e0ddbd13488321871addb1a8c0f369