### PR TITLE
Add retries logging for provider call events

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging.py
@@ -168,6 +168,7 @@ def log_provider_call(
         "completion": completion_tokens,
         "total": prompt_tokens + completion_tokens,
     }
+    retries = max(0, attempt - 1)
     shadow_metadata = _extract_shadow_metadata(metadata)
 
     event_logger.emit(
@@ -180,6 +181,7 @@ def log_provider_call(
             "provider_id": provider_name,
             "model": provider_model(provider, allow_private=allow_private_model),
             "attempt": attempt,
+            "retries": retries,
             "total_providers": total_providers,
             "status": status,
             "outcome": _normalize_outcome(status),

--- a/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
@@ -120,6 +120,31 @@ def test_log_provider_call_includes_shadow_metadata(
     assert payload["shadow_outcome"] == "success"
 
 
+def test_log_provider_call_records_retries(
+    logger: _RecordingLogger, provider_request: ProviderRequest
+) -> None:
+    provider = _DummyProvider("dummy")
+
+    log_provider_call(
+        logger,
+        request_fingerprint="fingerprint",
+        provider=provider,
+        request=provider_request,
+        attempt=3,
+        total_providers=1,
+        status="ok",
+        latency_ms=123,
+        tokens_in=10,
+        tokens_out=20,
+        error=None,
+        metadata={},
+        shadow_used=False,
+    )
+
+    _, payload = logger.events[-1]
+    assert payload["retries"] == 2
+
+
 def test_log_run_metric_includes_shadow_metadata(
     logger: _RecordingLogger, provider_request: ProviderRequest
 ) -> None:


### PR DESCRIPTION
## Summary
- add unit test covering retries field when logging provider calls
- compute retries from attempt count and include in provider_call payload

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_shared.py::test_log_provider_call_records_retries

------
https://chatgpt.com/codex/tasks/task_e_68e0dda79c8c8321b506fe48ad9c8d41