### PR TITLE
Normalize failed status to error

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/metrics_otlp.py
@@ -21,7 +21,7 @@ def _normalized_status(record: Mapping[str, Any]) -> str | None:
     normalized = str(raw).lower()
     if normalized in {"ok", "success"}:
         return "success"
-    if normalized in {"error", "errored", "failure"}:
+    if normalized in {"error", "errored", "failure", "failed", "fail"}:
         return "error"
     if normalized in {"skip", "skipped"}:
         return "skipped"


### PR DESCRIPTION
## Summary
- add regression test covering normalization of failed status values for OTLP metrics exporter
- align `_normalized_status` to map failed/fail variants into the error bucket

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_metrics_otlp.py -k failed

------
https://chatgpt.com/codex/tasks/task_e_68e0dd99ae0883218724b4dad299f53a