### PR TITLE
chore: tidy prometheus metric test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
+++ b/projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py
@@ -1,4 +1,5 @@
 """Tests for Prometheus metrics exporter status normalization."""
+
 from __future__ import annotations
 
 import sys


### PR DESCRIPTION
## Summary
- ensure the Prometheus metrics test module keeps its standard-library imports ordered
- run `ruff check` to verify that I001 and UP037 are resolved

## Testing
- `ruff check projects/04-llm-adapter-shadow/tests/test_metrics_prometheus.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0dd77adb883218a21acde7c205e8f