### PR TITLE
Fix runtime imports in parallel-all executor failure tests

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_all_executor.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_all_executor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_all_executor.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_all_executor.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
-from .helpers import _run_parallel_case
+from tests.compare_runner_parallel.conftest import (
+    ProviderConfigFactory,
+    RunMetricsFactory,
+    TaskFactory,
+)
 
-if TYPE_CHECKING:
-    from tests.compare_runner_parallel.conftest import (
-        ProviderConfigFactory,
-        RunMetricsFactory,
-        TaskFactory,
-    )
+from .helpers import _run_parallel_case
 
 
 def test_parallel_attempt_executor_parallel_all_mode(


### PR DESCRIPTION
## Summary
- import the compare-runner parallel fixture factories at runtime to avoid quoted annotations
- organize imports to satisfy linting in the parallel-all executor failure tests

## Testing
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_all_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e449fd748321919de505cf742351