### PR TITLE
Fix type annotations in parallel executor failure tests

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_executor.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_executor.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
-from .helpers import _run_parallel_case
+from tests.compare_runner_parallel.conftest import (
+    ProviderConfigFactory,
+    RunMetricsFactory,
+    TaskFactory,
+)
 
-if TYPE_CHECKING:
-    from tests.compare_runner_parallel.conftest import (
-        ProviderConfigFactory,
-        RunMetricsFactory,
-        TaskFactory,
-    )
+from .helpers import _run_parallel_case
 
 
 def test_parallel_attempt_executor_parallel_any_mode(


### PR DESCRIPTION
## Summary
- import the fixture factory protocols directly for tests
- ensure test annotations use the concrete protocol names without quotes

## Testing
- `ruff check projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0e448b5708321b89c62fe1706489d