### PR TITLE
Fix checklist comments in async runner tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -105,11 +105,8 @@ def test_async_parallel_any_returns_first_completion() -> None:
 
     response = asyncio.run(asyncio.wait_for(_execute(), timeout=0.2))
 
-チェックリスト:
-- [ ] 新規テストは ``projects/04-llm-adapter-shadow/tests/async_runner/parallel`` に追加する
-- [ ] 互換性が不要になったらこのシムを削除する
-"""
-
-from __future__ import annotations
+# チェックリスト:
+# - [ ] 新規テストは ``projects/04-llm-adapter-shadow/tests/async_runner/parallel`` に追加する
+# - [ ] 互換性が不要になったらこのシムを削除する
 
 from .parallel import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- comment the maintenance checklist so the shim module parses correctly
- retain the shim import for the relocated parallel tests

## Testing
- pytest -vv -s --maxfail=1 --durations=20 --disable-socket tests/async_runner/test_parallel.py


------
https://chatgpt.com/codex/tasks/task_e_68e0e78033fc8321b4d4cb7db039bf83