### PR TITLE
Add explicit budget manager factory typing to budgeting tests

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,6 +13,7 @@ from adapter.core.providers import BaseProvider, ProviderFactory, ProviderRespon
 from adapter.core.runner_api import RunnerConfig
 from adapter.core.runner_execution import RunnerExecution
 from adapter.core.runners import CompareRunner
+from ._sys_path import BudgetManager
 from .conftest import ProviderConfigFactory, RunMetricsFactory, TaskFactory
 
 
@@ -132,7 +134,7 @@ def test_runner_config_dataclass_initializes_helpers(
     tmp_path: Path,
     provider_config_factory: ProviderConfigFactory,
     task_factory: TaskFactory,
-    budget_manager_factory,
+    budget_manager_factory: Callable[[], BudgetManager],
 ) -> None:
     token_bucket_args: list[int | None] = []
     schema_args: list[Path | None] = []
@@ -184,7 +186,7 @@ def test_run_metrics_records_error_type_and_attempts(
     tmp_path: Path,
     provider_config_factory: ProviderConfigFactory,
     task_factory: TaskFactory,
-    budget_manager_factory,
+    budget_manager_factory: Callable[[], BudgetManager],
 ) -> None:
     class FlakyProvider(BaseProvider):
         def __init__(self, config: ProviderConfig) -> None:


### PR DESCRIPTION
## Summary
- import `BudgetManager` for budgeting tests and use it directly in fixture annotations
- annotate the `budget_manager_factory` parameters with `Callable[[], BudgetManager]` to avoid quoted types

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py --select UP037

------
https://chatgpt.com/codex/tasks/task_e_68e0f1dd462c8321bf4ad94f5b7de2c8