### PR TITLE
chore: tidy metrics data imports

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/data.py
+++ b/projects/04-llm-adapter/tools/report/metrics/data.py
@@ -1,4 +1,5 @@
 """Data loading and aggregation helpers for metrics reports."""
+
 from __future__ import annotations
 
 from collections import Counter


### PR DESCRIPTION
## Summary
- add the required blank line between the module docstring and imports in `metrics/data.py`
- keep the metrics data import block grouped per the project's style guide

## Testing
- `pytest projects/04-llm-adapter/tools/report/tests/test_metrics_report.py`
- `ruff check projects/04-llm-adapter/tools/report/metrics/data.py --select I001`


------
https://chatgpt.com/codex/tasks/task_e_68e0f1dd3f4083218aaacceac3d3f4f2