### PR TITLE
docs: clarify typing mapping alias usage

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
@@ -19,7 +19,7 @@ from .runner_shared import log_provider_call, log_provider_skipped, RateLimiter
 from .shadow import run_with_shadow_async, ShadowMetrics
 from .utils import elapsed_ms
 
-TypingMapping = Mapping
+TypingMapping = Mapping  # Backwards-compatible alias for typing.Mapping
 
 
 def build_shadow_log_metadata(shadow_metrics: ShadowMetrics | None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- document the purpose of the `TypingMapping` alias in the async runner support module

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py -k support
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py --select I001,UP035
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py -k support

------
https://chatgpt.com/codex/tasks/task_e_68e0f1daf62c8321823ab37b57e11f8a