### PR TITLE
Ensure async runner propagates AllFailedError

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -9,7 +9,7 @@ from typing import Any
 from ._event_loop import ensure_socket_free_event_loop_policy
 from .errors import AllFailedError
 from .observability import EventLogger
-from .parallel_exec import ParallelAllResult
+from .parallel_exec import ParallelAllResult, ParallelExecutionError
 from .provider_spi import (
     AsyncProviderSPI,
     ensure_async_provider,
@@ -197,6 +197,8 @@ class AsyncRunner:
             shadow_used=shadow_used,
         )
         if last_err is not None:
+            if isinstance(last_err, ParallelExecutionError):
+                raise last_err
             raise failure_error from last_err
         raise failure_error
 

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -7,7 +7,7 @@ import time
 from typing import Any
 
 from ._event_loop import ensure_socket_free_event_loop_policy
-from .errors import FatalError
+from .errors import AllFailedError
 from .observability import EventLogger
 from .parallel_exec import ParallelAllResult
 from .provider_spi import (
@@ -40,10 +40,6 @@ from .shadow import DEFAULT_METRICS_PATH, ShadowMetrics
 from .utils import content_hash, elapsed_ms
 
 ensure_socket_free_event_loop_policy()
-
-
-class AllFailedError(FatalError):
-    """Raised when all providers fail to produce a response."""
 
 
 class AsyncRunner:
@@ -201,8 +197,6 @@ class AsyncRunner:
             shadow_used=shadow_used,
         )
         if last_err is not None:
-            if mode == RunnerMode.CONSENSUS or total_providers <= 1:
-                raise last_err
             raise failure_error from last_err
         raise failure_error
 


### PR DESCRIPTION
## Summary
- add async runner regression test covering AllFailedError propagation on failure
- reuse AllFailedError from the shared errors module inside the async runner and raise it consistently

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py


------
https://chatgpt.com/codex/tasks/task_e_68e0f194792c832195f44efb54da2e8c