### PR TITLE
Normalize failure statuses in consume_cases

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/test_consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tests/test_consume_cases.py
@@ -62,3 +62,26 @@ def test_build_metrics_normalizes_failed_status() -> None:
 
     text = _format_text(metrics)
     assert "fail: 1" in text
+
+
+def test_build_metrics_normalizes_failure_status() -> None:
+    cases = {
+        "suite": "demo-suite",
+        "cases": [
+            {"id": "case-1"},
+        ],
+    }
+    attempts = [
+        {
+            "name": "case-1 first attempt",
+            "status": "failure",
+        }
+    ]
+
+    metrics = _build_metrics(cases, attempts)
+
+    assert metrics["status_breakdown"].get("fail") == 1
+    assert "failure" not in metrics["status_breakdown"]
+
+    text = _format_text(metrics)
+    assert "fail: 1" in text

--- a/projects/04-llm-adapter-shadow/tools/consume_cases.py
+++ b/projects/04-llm-adapter-shadow/tools/consume_cases.py
@@ -56,14 +56,16 @@ def _attempt_case_id(attempt: Mapping[str, Any]) -> str | None:
     return prefix.strip() or None
 
 
+_STATUS_ALIASES: dict[str, str] = {
+    "errored": "error",
+    "failed": "fail",
+    "failure": "fail",
+}
+
+
 def _normalize_status(raw_status: str) -> str:
     normalized = raw_status.strip().lower()
-    alias_map = {
-        "errored": "error",
-        "failed": "fail",
-        "failure": "fail",
-    }
-    return alias_map.get(normalized, normalized)
+    return _STATUS_ALIASES.get(normalized, normalized)
 
 
 def _build_metrics(


### PR DESCRIPTION
## Summary
- add a regression test ensuring consume_cases treats a `failure` status as `fail`
- expose the status alias map as a module-level constant for clarity

## Testing
- `pytest projects/04-llm-adapter-shadow/tests/test_consume_cases.py -k failed`


------
https://chatgpt.com/codex/tasks/task_e_68e0f18ed8308321a4008a22e763a047