### PR TITLE
Update estimate_cost signature to use ProviderConfig type

### DIFF
--- a/projects/04-llm-adapter/adapter/core/metrics/costs.py
+++ b/projects/04-llm-adapter/adapter/core/metrics/costs.py
@@ -22,7 +22,7 @@ def compute_cost_usd(
     return round(prompt_cost + completion_cost, 6)
 
 
-def estimate_cost(config: "ProviderConfig", input_tokens: int, output_tokens: int) -> float:
+def estimate_cost(config: ProviderConfig, input_tokens: int, output_tokens: int) -> float:
     """プロバイダ設定に基づいて概算コストを算出する。"""
 
     pricing = config.pricing


### PR DESCRIPTION
## Summary
- update estimate_cost to accept ProviderConfig directly to resolve ruff UP037 warning

## Testing
- ruff check projects/04-llm-adapter/adapter/core/metrics/costs.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f181f2f4832195843808f3bc8eb9