### PR TITLE
chore: sort budgeting test imports

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py
@@ -4,15 +4,15 @@ from types import SimpleNamespace
 
 import pytest
 
-from adapter.core.errors import TimeoutError
 from adapter.core.datasets import GoldenTask
-from adapter.core.metrics import BudgetSnapshot
-from adapter.core.metrics import RunMetrics
+from adapter.core.errors import TimeoutError
+from adapter.core.metrics import BudgetSnapshot, RunMetrics
 from adapter.core.models import ProviderConfig
 from adapter.core.providers import BaseProvider, ProviderFactory, ProviderResponse
 from adapter.core.runner_api import RunnerConfig
 from adapter.core.runner_execution import RunnerExecution
 from adapter.core.runners import CompareRunner
+
 from ._sys_path import BudgetManager
 from .conftest import ProviderConfigFactory, RunMetricsFactory, TaskFactory
 


### PR DESCRIPTION
## Summary
- reorder the adapter.core imports in the budgeting test to match the desired sequence
- combine adapter.core.metrics imports into a single line and separate relative imports

## Testing
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ede28948321aeb4c3c4223ec588