### PR TITLE
Handle failure status normalization in CI metrics

### DIFF
--- a/tests/test_generate_ci_report.py
+++ b/tests/test_generate_ci_report.py
@@ -45,6 +45,20 @@ def test_aggregate_status_counts_passed_status() -> None:
     assert errors == 0
 
 
+def test_aggregate_status_counts_failure_status() -> None:
+    runs = [
+        {"status": "fail"},
+        {"status": "failure"},
+        {"status": "pass"},
+    ]
+
+    passes, fails, errors = aggregate_status(runs)
+
+    assert passes == 1
+    assert fails == 2
+    assert errors == 0
+
+
 def test_compute_last_updated(sample_runs: list[dict[str, object]]) -> None:
     assert compute_last_updated(sample_runs) == "2024-06-02T09:00:00Z"
 

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -11,7 +11,7 @@ from tools import weekly_summary
 from tools.weekly_summary import coerce_str, load_runs
 
 PASS_STATUSES = {"pass", "passed"}
-FAIL_STATUSES = {"fail", "failed"}
+FAIL_STATUSES = {"fail", "failed", "failure"}
 ERROR_STATUSES = {"error", "errored"}
 
 


### PR DESCRIPTION
## Summary
- add a regression test ensuring aggregate_status counts runs reporting status="failure"
- extend CI metrics normalization so "failure" maps to the failure bucket

## Testing
- pytest tests/test_generate_ci_report.py -k aggregate_status


------
https://chatgpt.com/codex/tasks/task_e_68e10ecb1b648321be431fb1613f82db