### PR TITLE
Refine runner parallel imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py
@@ -10,11 +10,10 @@ from __future__ import annotations
 from .parallel_exec import ParallelExecutionError
 from .runner_config import ConsensusConfig
 from .runner_parallel.consensus import (
-    ConsensusObservation,
-    ConsensusResult,
-    _Candidate,
     _normalize_candidate_text,
     compute_consensus,
+    ConsensusObservation,
+    ConsensusResult,
     invoke_consensus_judge,
     validate_consensus_schema,
 )


### PR DESCRIPTION
## Summary
- reorder the shim's imports in `runner_parallel` to follow Ruff's grouping rules
- drop the unused `_Candidate` import from the consensus helper re-export

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel.py --select I001,F401 --fix
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ebe0d308321953d41dc8931372a