### PR TITLE
Fix isinstance check in shadow latency metadata

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
@@ -28,7 +28,7 @@ def build_shadow_log_metadata(shadow_metrics: ShadowMetrics | None) -> dict[str,
     payload: Mapping[str, Any] = shadow_metrics.payload
     metadata: dict[str, Any] = {}
     latency = payload.get("shadow_latency_ms")
-    if isinstance(latency, (int, float)):
+    if isinstance(latency, int | float):
         metadata["shadow_latency_ms"] = int(latency)
     outcome_value: Any = payload.get("shadow_outcome")
     mapped_outcome: str | None = None


### PR DESCRIPTION
## Summary
- replace the tuple-based isinstance check for shadow latency with the modern union form to satisfy ruff rule UP038

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py -k shadow
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py --select UP038

------
https://chatgpt.com/codex/tasks/task_e_68e10ebd18cc83219f5106ccb487eae8