### PR TITLE
style: reorder metrics builder imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support/metrics_builder.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support/metrics_builder.py
@@ -6,10 +6,11 @@ from enum import Enum
 import os
 import re
 import uuid
+
 from ..config import ProviderConfig
 from ..datasets import GoldenTask
 from ..metrics.diff import compute_diff_rate
-from ..metrics.models import BudgetSnapshot, EvalMetrics, RunMetrics, hash_text, now_ts
+from ..metrics.models import BudgetSnapshot, EvalMetrics, hash_text, now_ts, RunMetrics
 from ..providers import ProviderResponse
 
 


### PR DESCRIPTION
## Summary
- reorder the metrics builder module imports so standard library dependencies precede local imports and satisfy lint expectations

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py -k metrics_builder
- ruff check projects/04-llm-adapter/adapter/core/compare_runner_support/metrics_builder.py --select I001


------
https://chatgpt.com/codex/tasks/task_e_68e13a97abd08321ac6c79bbf7e3768d