### PR TITLE
chore: organize helper imports

### DIFF
--- a/projects/04-llm-adapter/tests/compare_runner_parallel/failures/helpers.py
+++ b/projects/04-llm-adapter/tests/compare_runner_parallel/failures/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from pathlib import Path
 import sys
-from typing import TYPE_CHECKING, cast
+from typing import cast, TYPE_CHECKING
 
 import pytest
 


### PR DESCRIPTION
## Summary
- reorder typing imports in the failure helpers to satisfy Ruff's import sorting

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/failures/test_parallel_any_executor.py
- ruff check projects/04-llm-adapter/tests/compare_runner_parallel/failures/helpers.py --select I001


------
https://chatgpt.com/codex/tasks/task_e_68e13a9982c08321b92c661763dea28f