### PR TITLE
chore: sort parallel state imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/parallel_state.py
+++ b/projects/04-llm-adapter/adapter/core/parallel_state.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from .config import ProviderConfig
 from .datasets import GoldenTask
-from .metrics.models import BudgetSnapshot, EvalMetrics, RunMetrics, now_ts
+from .metrics.models import BudgetSnapshot, EvalMetrics, now_ts, RunMetrics
 from .providers import BaseProvider
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用


### PR DESCRIPTION
## Summary
- reorder the imports in `parallel_state.py` to satisfy standard/typing/local grouping
- ensure the metrics import members follow the expected order

## Testing
- `pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py -k parallel_state`
- `ruff check projects/04-llm-adapter/adapter/core/parallel_state.py --select I001`


------
https://chatgpt.com/codex/tasks/task_e_68e13a9878a88321bfe788e4756a9ec5