### PR TITLE
chore: tidy compare runner support imports

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -6,10 +6,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from .budgets import BudgetManager
+from .compare_runner_support.metrics_builder import RunMetricsBuilder
 from .config import ProviderConfig
 from .metrics.models import BudgetSnapshot
-from .providers import BaseProvider, ProviderFactory, ProviderResponse
-from .compare_runner_support.metrics_builder import RunMetricsBuilder
+from .providers import BaseProvider, ProviderFactory
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse


### PR DESCRIPTION
## Summary
- reorder standard library and local imports in compare_runner_support
- drop the unused ProviderResponse import to satisfy lint

## Testing
- pytest projects/04-llm-adapter/tests/compare_runner_parallel/test_budgeting.py -k support
- ruff check projects/04-llm-adapter/adapter/core/compare_runner_support.py --select I001,F401


------
https://chatgpt.com/codex/tasks/task_e_68e13a96b5ec8321a6cff13d8ef3d43c