### PR TITLE
Remove unused imports from async runner parallel tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
-
-import pytest
-
-from src.llm_adapter.errors import RateLimitError, TimeoutError
-from src.llm_adapter.parallel_exec import ParallelExecutionError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
-from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
-from src.llm_adapter.runner_async import AllFailedError
-from src.llm_adapter.runner_config import BackoffPolicy, RunnerConfig, RunnerMode
+from src.llm_adapter.runner import AsyncRunner
+from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 
 from .conftest import (
     _AsyncProbeProvider,
     _CapturingLogger,
-    _FakeClock,
-    _patch_runner_sleep,
 )
 
 


### PR DESCRIPTION
## Summary
- remove unused imports from the async runner parallel test shim module

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
- ruff check projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py --select F401

------
https://chatgpt.com/codex/tasks/task_e_68e13a95de448321ba09a16682f094f5