### PR TITLE
Reorder imports in consensus judge helper

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
@@ -5,8 +5,8 @@ from collections.abc import Callable, Mapping, Sequence
 import importlib
 from typing import Any, cast
 
-from ..provider_spi import ProviderResponse
 from ..consensus_candidates import _Candidate
+from ..provider_spi import ProviderResponse
 
 
 def _load_judge(path: str) -> Callable[[Sequence[ProviderResponse]], Any]:


### PR DESCRIPTION
## Summary
- reorder the runner_parallel judge module imports to group standard library, typing, and local symbols

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py -k judge
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py --select I001


------
https://chatgpt.com/codex/tasks/task_e_68e13a95da788321bad38aacadc43d20