### PR TITLE
Reorder runner_parallel imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
@@ -1,14 +1,15 @@
 """Parallel runner consensus utilities."""
+
 from __future__ import annotations
 
 from ..runner_config import ConsensusConfig
 from .consensus import (
-    ConsensusObservation,
-    ConsensusResult,
-    compute_consensus,
-    invoke_consensus_judge,
     _Candidate,
     _normalize_candidate_text,
+    compute_consensus,
+    ConsensusObservation,
+    ConsensusResult,
+    invoke_consensus_judge,
     validate_consensus_schema,
 )
 from .observations import _normalize_observations


### PR DESCRIPTION
## Summary
- reorder the runner_parallel import block to follow standard sorting
- add the expected blank line after the module docstring

## Testing
- `pytest projects/04-llm-adapter-shadow/tests/test_runner_consensus.py`
- `ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py --select I001`


------
https://chatgpt.com/codex/tasks/task_e_68e13a9485088321938ac3682a62db81