### PR TITLE
Handle failure status in CI flaky analyzer

### DIFF
--- a/projects/03-ci-flaky/src/analyzer.js
+++ b/projects/03-ci-flaky/src/analyzer.js
@@ -1,6 +1,6 @@
 import { listJsonlFiles, readJsonl } from './fs-utils.js';
 
-const FAILURE_STATUSES = new Set(['fail', 'error', 'errored']);
+const FAILURE_STATUSES = new Set(['fail', 'error', 'errored', 'failure']);
 
 function calculateImpact(avgDuration, baseline) {
   if (!avgDuration || !baseline) return 0;
@@ -23,7 +23,8 @@ function calculateRecency(perRunStats, runOrderLength, lambda) {
 
 export function isFailureStatus(status) {
   const value = typeof status === 'string' ? status : status?.status;
-  return FAILURE_STATUSES.has(value);
+  if (!value) return false;
+  return FAILURE_STATUSES.has(value.toLowerCase());
 }
 
 class AggregatedEntry {

--- a/tests/projects/test_ci_flaky_analyzer.mjs
+++ b/tests/projects/test_ci_flaky_analyzer.mjs
@@ -3,22 +3,24 @@ import { test } from 'node:test';
 
 import { computeAggregates, isFailureStatus } from '../../projects/03-ci-flaky/src/analyzer.js';
 
-test('errored attempts are treated as failures', () => {
-  assert.strictEqual(isFailureStatus({ status: 'errored' }), true);
+test('failure-like attempts are treated as failures', () => {
+  for (const status of ['errored', 'failure']) {
+    assert.strictEqual(isFailureStatus({ status }), true);
 
-  const runId = 'run-1';
-  const attempt = {
-    canonical_id: 'suite.class.test',
-    suite: 'suite',
-    class: 'class',
-    name: 'test',
-    status: 'errored',
-    duration_ms: 10,
-  };
-  const runs = new Map([[runId, { attempts: [attempt] }]]);
-  const runOrder = [runId];
+    const runId = `run-${status}`;
+    const attempt = {
+      canonical_id: 'suite.class.test',
+      suite: 'suite',
+      class: 'class',
+      name: 'test',
+      status,
+      duration_ms: 10,
+    };
+    const runs = new Map([[runId, { attempts: [attempt] }]]);
+    const runOrder = [runId];
 
-  const { results } = computeAggregates(runs, runOrder, {});
-  assert.equal(results.length, 1);
-  assert.equal(results[0].fails, 1);
+    const { results } = computeAggregates(runs, runOrder, {});
+    assert.equal(results.length, 1);
+    assert.equal(results[0].fails, 1);
+  }
 });


### PR DESCRIPTION
## Summary
- include the `failure` status in the CI analyzer failure set and normalize status values
- add a regression test ensuring failure-like attempts are counted as failures

## Testing
- node --test tests/projects/test_ci_flaky_analyzer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e13a83541083219cde17ba795f9567