### PR TITLE
Use importlib to load shadow async runner tests

### DIFF
--- a/tests/shadow/test_runner_async.py
+++ b/tests/shadow/test_runner_async.py
@@ -1,6 +1,7 @@
 """pytest shim to expose shadow async runner tests at the repository root."""
 from __future__ import annotations
 
+import importlib.util
 import pathlib
 import sys
 
@@ -18,5 +19,19 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 if not _REAL_TEST_PATH.exists():
     raise FileNotFoundError(f"Shadow async runner tests not found at {_REAL_TEST_PATH}")
 
-_SOURCE = _REAL_TEST_PATH.read_text(encoding="utf-8")
-exec(compile(_SOURCE, str(_REAL_TEST_PATH), "exec"), globals())
+_SPEC = importlib.util.spec_from_file_location(
+    "shadow.tests.test_runner_async", _REAL_TEST_PATH
+)
+if _SPEC is None or _SPEC.loader is None:
+    raise ImportError(f"Failed to load spec for {_REAL_TEST_PATH}")
+
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+for _name in dir(_MODULE):
+    if not _name.startswith("test_"):
+        continue
+    _value = getattr(_MODULE, _name)
+    if callable(_value):
+        globals()[_name] = _value


### PR DESCRIPTION
## Summary
- load the shadow async runner tests via `importlib.util.spec_from_file_location`
- export `test_` callables from the loaded module into the shim globals for pytest

## Testing
- ruff check tests/shadow/test_runner_async.py

------
https://chatgpt.com/codex/tasks/task_e_68e13a6b56cc8321a643fe11be2ebd6e