### PR TITLE
Fix shadow metrics test imports

### DIFF
--- a/tests/test_runner_shadow_metrics.py
+++ b/tests/test_runner_shadow_metrics.py
@@ -6,12 +6,9 @@ import contextlib
 from dataclasses import replace
 import logging
 from pathlib import Path
-import sys
 from types import SimpleNamespace
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "projects" / "04-llm-adapter"))
 
 from adapter.core.errors import RateLimitError
 from adapter.core.metrics import RunMetrics


### PR DESCRIPTION
## Summary
- rely on the shared pytest path configuration for the shadow metrics test
- tidy the test imports to follow standard/third-party/local grouping

## Testing
- ruff check tests/test_runner_shadow_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68e13a6a618c8321a78a1a1571fd57d1