### PR TITLE
Reorder imports in regression summary metrics module

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
@@ -1,11 +1,12 @@
 """Regression summary HTML generation for metrics reports."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 import html
 from pathlib import Path
 
-from .data import SUCCESS_STATUSES, load_baseline_expectations
+from .data import load_baseline_expectations, SUCCESS_STATUSES
 from .utils import coerce_optional_float, latest_metrics_by_key
 
 


### PR DESCRIPTION
## Summary
- reorder regression summary metrics imports to satisfy Ruff sorting

## Testing
- pytest projects/04-llm-adapter/tools/report/tests/test_regression_summary.py (fails: file or directory not found)
- ruff check projects/04-llm-adapter/tools/report/metrics/regression_summary.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e13a99cf5c83219c7a45c2ea5ef2ff