### PR TITLE
Sort imports in sequential metrics test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
+++ b/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
@@ -9,7 +9,7 @@ from src.llm_adapter.runner_config import RunnerConfig
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy
 
-from .conftest import _RecordingLogger, _SuccessfulProvider, _make_context
+from .conftest import _make_context, _RecordingLogger, _SuccessfulProvider
 
 
 def test_sequential_strategy_handles_successful_provider_result(


### PR DESCRIPTION
## Summary
- reorder local test imports so that they follow the preferred standard library, third-party, and local grouping

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1499d6078832195b0dcb9d751b4cb