### PR TITLE
Sort imports in sequential failure tests

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sequential/test_failures.py
+++ b/projects/04-llm-adapter-shadow/tests/sequential/test_failures.py
@@ -10,7 +10,7 @@ from src.llm_adapter.runner_config import RunnerConfig
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy
 
-from .conftest import _FailingProvider, _RecordingLogger, _make_context
+from .conftest import _FailingProvider, _make_context, _RecordingLogger
 
 
 def test_sequential_raises_all_failed_error_with_cause() -> None:


### PR DESCRIPTION
## Summary
- reorder the sequential failure test imports to follow standard library, third-party, and local grouping with alphabetical sorting

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sequential/test_failures.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1499b3a7483218734338fcb30a01d