### PR TITLE
Fix async runner test imports

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import asyncio
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
-from src.llm_adapter.runner import AsyncRunner
+from src.llm_adapter.runner import AsyncRunner, ParallelAllResult
 from src.llm_adapter.runner_config import RunnerConfig, RunnerMode
 
 from .conftest import (
     _AsyncProbeProvider,
     _CapturingLogger,
 )
+from .parallel import *  # noqa: F401,F403
 
 
 def test_async_parallel_any_run_metric_uses_response_latency() -> None:
@@ -128,10 +129,8 @@ def test_async_parallel_any_returns_first_completion() -> None:
         assert isinstance(result, ProviderResponse)
         return result
 
-    response = asyncio.run(asyncio.wait_for(_execute(), timeout=0.2))
+    _ = asyncio.run(asyncio.wait_for(_execute(), timeout=0.2))
 
 # チェックリスト:
 # - [ ] 新規テストは ``projects/04-llm-adapter-shadow/tests/async_runner/parallel`` に追加する
 # - [ ] 互換性が不要になったらこのシムを削除する
-
-from .parallel import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- import ParallelAllResult directly in async runner tests and keep the compatibility shim in the import block
- silence an unused result assignment in the parallel-any test helper

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68e1499adf2c8321bfe8662918a7a98c