### PR TITLE
refactor: reorder imports in judge runner

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
@@ -1,9 +1,8 @@
 """Judge loading and invocation helpers for consensus evaluation."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
 import importlib
-from typing import Any, cast
+from typing import Any, Callable, cast, Mapping, Sequence
 
 from ..consensus_candidates import _Candidate
 from ..provider_spi import ProviderResponse


### PR DESCRIPTION
## Summary
- reorder the judge runner imports to separate standard library, typing, and local modules
- rely on typing-provided collection aliases so the import block satisfies linting rules

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e14999838c8321b5eee885e001e151