### PR TITLE
Log run metrics for sequential fallback failures

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
+++ b/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
@@ -4,12 +4,17 @@ from typing import Any
 
 import pytest
 
+from src.llm_adapter.errors import TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner_config import RunnerConfig
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy
 
-from .conftest import _RecordingLogger, _SuccessfulProvider, _make_context
+from .conftest import (
+    _RecordingLogger,
+    _SuccessfulProvider,
+    _make_context,
+)
 
 
 def test_sequential_strategy_handles_successful_provider_result(
@@ -112,3 +117,73 @@ def test_sequential_run_metric_reports_response_latency(
     assert len(run_metric_events) == 1
     _, payload = run_metric_events[0]
     assert payload["latency_ms"] == 12
+
+
+def test_sequential_strategy_logs_error_metric_before_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    providers = [_SuccessfulProvider("primary"), _SuccessfulProvider("secondary")]
+    runner = Runner(providers, config=RunnerConfig())
+    strategy = SequentialStrategy()
+    logger = _RecordingLogger()
+    context = _make_context(runner, logger=logger)
+
+    success_response = ProviderResponse(
+        "ok",
+        latency_ms=8,
+        token_usage=TokenUsage(prompt=2, completion=3),
+    )
+
+    invocation_results = [
+        ProviderInvocationResult(
+            provider=providers[0],
+            attempt=1,
+            total_providers=2,
+            response=None,
+            error=TimeoutError("boom"),
+            latency_ms=7,
+            tokens_in=5,
+            tokens_out=1,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        ),
+        ProviderInvocationResult(
+            provider=providers[1],
+            attempt=2,
+            total_providers=2,
+            response=success_response,
+            error=None,
+            latency_ms=4,
+            tokens_in=2,
+            tokens_out=3,
+            shadow_metrics=None,
+            shadow_metrics_extra=None,
+            provider_call_logged=True,
+        ),
+    ]
+
+    def fake_invoke(
+        provider: Any,
+        request: ProviderRequest,
+        *,
+        attempt: int,
+        total_providers: int,
+        **_: Any,
+    ) -> ProviderInvocationResult:
+        result = invocation_results.pop(0)
+        assert result.provider is provider
+        assert result.attempt == attempt
+        assert result.total_providers == total_providers
+        return result
+
+    monkeypatch.setattr(runner, "_invoke_provider_sync", fake_invoke)
+
+    result = strategy.execute(context)
+
+    assert result is success_response
+    run_metric_events = [event for event in logger.events if event[0] == "run_metric"]
+    assert len(run_metric_events) == 2
+    _, failure_payload = run_metric_events[0]
+    assert failure_payload["provider_id"] == "primary"
+    assert failure_payload["outcome"] == "error"


### PR DESCRIPTION
## Summary
- add sync and async sequential tests that capture per-attempt run metrics when earlier providers fail
- emit run metrics for failed attempts in synchronous sequential execution using invocation metadata
- record error run metrics in async sequential strategy exception paths with measured latency

## Testing
- pytest projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68e1499118bc83218f50a69ad2a87979