### PR TITLE
chore: tidy runner_parallel import layout

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
@@ -1,5 +1,4 @@
 """Parallel runner consensus utilities."""
-
 from __future__ import annotations
 
 from ..runner_config import ConsensusConfig


### PR DESCRIPTION
## Summary
- remove the blank line so the `__future__` import sits directly under the module docstring
- confirm the existing import ordering already matches Ruff's expectations

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e14998cf848321968c95dbfe6fa1e5