### PR TITLE
Normalize CI failure status detection

### DIFF
--- a/projects/03-ci-flaky/src/analyzer.js
+++ b/projects/03-ci-flaky/src/analyzer.js
@@ -1,6 +1,6 @@
 import { listJsonlFiles, readJsonl } from './fs-utils.js';
 
-const FAILURE_STATUSES = new Set(['fail', 'error', 'errored', 'failure']);
+const FAILURE_STATUSES = new Set(['fail', 'failed', 'error', 'errored', 'failure']);
 
 function calculateImpact(avgDuration, baseline) {
   if (!avgDuration || !baseline) return 0;
@@ -23,8 +23,10 @@ function calculateRecency(perRunStats, runOrderLength, lambda) {
 
 export function isFailureStatus(status) {
   const value = typeof status === 'string' ? status : status?.status;
-  if (!value) return false;
-  return FAILURE_STATUSES.has(value.toLowerCase());
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  return FAILURE_STATUSES.has(normalized);
 }
 
 class AggregatedEntry {

--- a/tests/projects/test_ci_flaky_analyzer.mjs
+++ b/tests/projects/test_ci_flaky_analyzer.mjs
@@ -24,3 +24,10 @@ test('failure-like attempts are treated as failures', () => {
     assert.equal(results[0].fails, 1);
   }
 });
+
+test('isFailureStatus treats uppercase failure statuses as failures', () => {
+  for (const status of ['FAILED', 'ERROR']) {
+    assert.strictEqual(isFailureStatus(status), true);
+    assert.strictEqual(isFailureStatus({ status }), true);
+  }
+});


### PR DESCRIPTION
## Summary
- add regression coverage to ensure uppercase CI failure statuses are classified as failures
- normalize status inputs by trimming and lowercasing before matching the known failure set
- recognize the "failed" status alongside existing failure indicators

## Testing
- node --test tests/projects/test_ci_flaky_analyzer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e149883d408321be790c10b5f2b101