### PR TITLE
Fix import order in regression summary data import

### DIFF
--- a/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
+++ b/projects/04-llm-adapter/tools/report/metrics/regression_summary.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 import html
 from pathlib import Path
 
-from .data import SUCCESS_STATUSES, load_baseline_expectations
+from .data import load_baseline_expectations, SUCCESS_STATUSES
 from .utils import coerce_optional_float, latest_metrics_by_key
 
 


### PR DESCRIPTION
## Summary
- reorder the data module import in regression_summary.py so load_baseline_expectations precedes SUCCESS_STATUSES to satisfy Ruff import sorting

## Testing
- ruff check projects/04-llm-adapter/tools/report/metrics/regression_summary.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e14977aff483218834911b2da75aa1