### PR TITLE
Sort local imports in compare runner support

### DIFF
--- a/projects/04-llm-adapter/adapter/core/compare_runner_support.py
+++ b/projects/04-llm-adapter/adapter/core/compare_runner_support.py
@@ -9,7 +9,10 @@ from .budgets import BudgetManager
 from .compare_runner_support.metrics_builder import RunMetricsBuilder
 from .config import ProviderConfig
 from .metrics.models import BudgetSnapshot
-from .providers import BaseProvider, ProviderFactory
+from .providers import (
+    BaseProvider,
+    ProviderFactory,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - 型補完用
     from src.llm_adapter.provider_spi import ProviderResponse as JudgeProviderResponse


### PR DESCRIPTION
## Summary
- ensure the compare runner support module keeps its local imports alphabetized and grouped

## Testing
- ruff check projects/04-llm-adapter/adapter/core/compare_runner_support.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e149740ff08321a2c849bfb788ee8a