### PR TITLE
Reorder metrics imports for ruff I001

### DIFF
--- a/projects/04-llm-adapter/adapter/core/__init__.py
+++ b/projects/04-llm-adapter/adapter/core/__init__.py
@@ -26,10 +26,10 @@ from .metrics.diff import compute_diff_rate  # noqa: F401
 from .metrics.models import (  # noqa: F401
     BudgetSnapshot,
     EvalMetrics,
-    RunMetric,
-    RunMetrics,
     hash_text,
     now_ts,
+    RunMetric,
+    RunMetrics,
 )
 from .providers import ProviderFactory  # noqa: F401
 from .runners import CompareRunner  # noqa: F401


### PR DESCRIPTION
## Summary
- reorder the metrics models imports in adapter.core __init__ to match ruff expectations

## Testing
- ruff check projects/04-llm-adapter/adapter/core/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e149720da08321af9c03270eccf45b