### PR TITLE
Fix import order in fallback event test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sequential/test_fallback_events.py
+++ b/projects/04-llm-adapter-shadow/tests/sequential/test_fallback_events.py
@@ -10,7 +10,7 @@ from src.llm_adapter.runner_config import RunnerConfig
 from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy
 
-from .conftest import _FailingProvider, _RecordingLogger, _make_context
+from .conftest import _FailingProvider, _make_context, _RecordingLogger
 
 
 def test_sequential_strategy_emits_fallback_for_auth_error(


### PR DESCRIPTION
## Summary
- reorder the conftest imports in the sequential fallback events test to satisfy import sorting

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sequential/test_fallback_events.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e14970639c8321a5a6b7937b078d84