### PR TITLE
docs: document local import ordering in judge

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping, Sequence
 import importlib
 from typing import Any, cast
 
+# Local imports (alphabetical)
 from ..consensus_candidates import _Candidate
 from ..provider_spi import ProviderResponse
 


### PR DESCRIPTION
## Summary
- document that the local imports in the parallel judge stay alphabetized

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1496e881c83219f1803008f2244a2