### PR TITLE
Sort runner_parallel judge imports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
@@ -5,8 +5,12 @@ from collections.abc import Callable, Mapping, Sequence
 import importlib
 from typing import Any, cast
 
-from ..consensus_candidates import _Candidate
-from ..provider_spi import ProviderResponse
+from ..consensus_candidates import (
+    _Candidate,
+)
+from ..provider_spi import (
+    ProviderResponse,
+)
 
 
 def _load_judge(path: str) -> Callable[[Sequence[ProviderResponse]], Any]:


### PR DESCRIPTION
## Summary
- ensure the runner_parallel judge module orders its relative imports alphabetically
- format the relative imports using parenthesized blocks for consistency with other modules

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1496dfe488321bd15e6fac8c1df17