### PR TITLE
Reorder consensus exports

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py
@@ -15,13 +15,13 @@ from .consensus import (
 from .observations import _normalize_observations
 
 __all__ = [
-    "ConsensusObservation",
-    "ConsensusResult",
     "ConsensusConfig",
-    "compute_consensus",
-    "invoke_consensus_judge",
     "_Candidate",
     "_normalize_candidate_text",
+    "compute_consensus",
+    "ConsensusObservation",
+    "ConsensusResult",
+    "invoke_consensus_judge",
     "validate_consensus_schema",
     "_normalize_observations",
 ]


### PR DESCRIPTION
## Summary
- reorder the consensus export list to match the intended import ordering

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/__init__.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e14969bcf083218f83c14341ed6231