### PR TITLE
Fix ParallelAllResult re-export for async runner shim

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/parallel/__init__.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/parallel/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from src.llm_adapter.runner import ParallelAllResult as _ParallelAllResult
+
 from .test_parallel_all import *  # noqa: F401,F403
 from .test_parallel_any_failures import *  # noqa: F401,F403
 from .test_parallel_any_metrics import *  # noqa: F401,F403
 
-__all__ = []
+ParallelAllResult = _ParallelAllResult
+
+__all__ = ["ParallelAllResult"]
 __all__ += [name for name in globals() if name.startswith("test_")]


### PR DESCRIPTION
## Summary
- re-export ParallelAllResult from the async runner parallel shim so legacy tests import it correctly

## Testing
- pytest -q projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68e1568cc2f083218d06fb342134e38e