### PR TITLE
Fix duplicate sequential failure run metrics

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
@@ -113,21 +113,22 @@ class _SequentialRunTracker:
             metadata_with_shadow = merged_metadata
         else:
             metadata_with_shadow = self._context.metadata
-        log_run_metric(
-            self._event_logger,
-            request_fingerprint=self._context.request_fingerprint,
-            request=self._context.request,
-            provider=provider,
-            status="error",
-            attempts=attempt,
-            latency_ms=latency_ms,
-            tokens_in=tokens_in,
-            tokens_out=tokens_out,
-            cost_usd=0.0,
-            error=error,
-            metadata=metadata_with_shadow,
-            shadow_used=self._context.shadow_used,
-        )
+        if not result.provider_call_logged:
+            log_run_metric(
+                self._event_logger,
+                request_fingerprint=self._context.request_fingerprint,
+                request=self._context.request,
+                provider=provider,
+                status="error",
+                attempts=attempt,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=0.0,
+                error=error,
+                metadata=metadata_with_shadow,
+                shadow_used=self._context.shadow_used,
+            )
         if isinstance(error, FatalError):
             if isinstance(error, AuthError | ConfigError):
                 if self._event_logger is not None:


### PR DESCRIPTION
## Summary
- add regression coverage for sequential failure logging when provider metrics are already recorded
- avoid emitting duplicate run metrics for sequential failures once provider_call_logged is true

## Testing
- pytest tests/sequential/test_failures.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68e17434e3508321b5fc98f58240faa7