### PR TITLE
Avoid duplicate sequential error metrics when provider already logged

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_sync_sequential.py
@@ -113,21 +113,27 @@ class _SequentialRunTracker:
             metadata_with_shadow = merged_metadata
         else:
             metadata_with_shadow = self._context.metadata
-        log_run_metric(
-            self._event_logger,
-            request_fingerprint=self._context.request_fingerprint,
-            request=self._context.request,
-            provider=provider,
-            status="error",
-            attempts=attempt,
-            latency_ms=latency_ms,
-            tokens_in=tokens_in,
-            tokens_out=tokens_out,
-            cost_usd=0.0,
-            error=error,
-            metadata=metadata_with_shadow,
-            shadow_used=self._context.shadow_used,
+        should_log_metric = not (
+            result.provider_call_logged
+            and tokens_in is None
+            and tokens_out is None
         )
+        if should_log_metric:
+            log_run_metric(
+                self._event_logger,
+                request_fingerprint=self._context.request_fingerprint,
+                request=self._context.request,
+                provider=provider,
+                status="error",
+                attempts=attempt,
+                latency_ms=latency_ms,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                cost_usd=0.0,
+                error=error,
+                metadata=metadata_with_shadow,
+                shadow_used=self._context.shadow_used,
+            )
         if isinstance(error, FatalError):
             if isinstance(error, AuthError | ConfigError):
                 if self._event_logger is not None:


### PR DESCRIPTION
## Summary
- avoid emitting per-provider run metrics in the sequential strategy when a provider invocation already logged the call and produced no token counts, preventing duplicate failure metrics

## Testing
- pytest -vv --maxfail=1 --durations=20 --disable-socket tests

------
https://chatgpt.com/codex/tasks/task_e_68e1759c5dc883219a152e848f14d3df