### PR TITLE
Fix import order in flaky config test

### DIFF
--- a/tests/projects/test_ci_flaky_config_modules.mjs
+++ b/tests/projects/test_ci_flaky_config_modules.mjs
@@ -1,5 +1,5 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
+import test from 'node:test';
 
 const MODULE_BASE = '../../projects/03-ci-flaky/src/config';
 


### PR DESCRIPTION
## Summary
- sort builtin imports alphabetically in the flaky config test to satisfy ESLint

## Testing
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68e1ca90fe00832191446b3e0fdc70d4