### PR TITLE
Fix weekly summary success normalization

### DIFF
--- a/projects/04-llm-adapter-shadow/tools/weekly_summary.py
+++ b/projects/04-llm-adapter-shadow/tools/weekly_summary.py
@@ -37,6 +37,7 @@ _ERROR_OUTCOME_VALUES = {
     "failure",
     "exception",
 }
+_SUCCESS_OUTCOME_VALUES = {"ok", "success"}
 
 
 def _load_records(path: Path) -> Iterable[dict[str, Any]]:
@@ -63,14 +64,18 @@ def _normalize_outcome(record: Mapping[str, Any]) -> str:
             continue
         if normalized in _ERROR_OUTCOME_VALUES:
             return "error"
+        candidate = normalized
         if _STATUS_NORMALIZE_OUTCOME is not None:
             mapped = _STATUS_NORMALIZE_OUTCOME(normalized)
-            if mapped in {"success", "error", "skipped"}:
-                return mapped
-            return mapped
-        if normalized in {"ok", "success"}:
+            if isinstance(mapped, str):
+                candidate = mapped.strip().lower()
+                if not candidate:
+                    continue
+        if candidate in _ERROR_OUTCOME_VALUES:
+            return "error"
+        if candidate in _SUCCESS_OUTCOME_VALUES:
             return "success"
-        return normalized
+        return candidate
     return "unknown"
 
 


### PR DESCRIPTION
## Summary
- add a regression test ensuring run metrics with status="ok" are counted as successes even when the shared normalizer returns "ok"
- normalize outcomes from the shared status helper so that "ok" is treated as a success while preserving error handling

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_weekly_summary_tool.py -k ok


------
https://chatgpt.com/codex/tasks/task_e_68e1d836b428832190387b18b8483c03