### PR TITLE
Fix import grouping in async runner parallel test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
+++ b/projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+
 from src.llm_adapter.errors import TimeoutError
 from src.llm_adapter.provider_spi import ProviderRequest, ProviderResponse, TokenUsage
 from src.llm_adapter.runner import AsyncRunner, ParallelAllResult


### PR DESCRIPTION
## Summary
- insert a blank line after the asyncio import in the parallel async runner test to separate standard library and local imports

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/async_runner/test_parallel.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1d817f25c8321b645b393310e13f1