### PR TITLE
Reorder conftest imports in sequential metrics test

### DIFF
--- a/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
+++ b/projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py
@@ -11,9 +11,9 @@ from src.llm_adapter.runner_sync import ProviderInvocationResult, Runner
 from src.llm_adapter.runner_sync_modes import SequentialStrategy
 
 from .conftest import (
+    _make_context,
     _RecordingLogger,
     _SuccessfulProvider,
-    _make_context,
 )
 
 


### PR DESCRIPTION
## Summary
- reorder the conftest imports in the sequential metrics test to follow the desired order

## Testing
- ruff check projects/04-llm-adapter-shadow/tests/sequential/test_metrics.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1d817b6b08321807ca9d43478c29c