### PR TITLE
Fix logging import spacing in runner_shared logging shim

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 # NOTE: 新構成へ移行済みの場合、このファイルの利用箇所を削除してください。
-
 from .logging.base import MetricsPath, resolve_event_logger
 from .logging.events import log_provider_call, log_provider_skipped, log_run_metric
 from .logging.status import error_family


### PR DESCRIPTION
## Summary
- remove the stray blank line between the comment and logging imports to satisfy import-order linting

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging.py --select I001

------
https://chatgpt.com/codex/tasks/task_e_68e1d8170df083219befef1a0fbfe1bc