### PR TITLE
Fix judge imports to satisfy lint rules

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py
@@ -1,8 +1,9 @@
 """Judge loading and invocation helpers for consensus evaluation."""
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 import importlib
-from typing import Any, Callable, cast, Mapping, Sequence
+from typing import Any, cast
 
 # Local imports (alphabetical)
 from ..consensus_candidates import _Candidate


### PR DESCRIPTION
## Summary
- import Callable, Mapping, and Sequence for the parallel judge from collections.abc to match modern typing guidance
- verify the file passes ruff checks for import sorting and typing updates

## Testing
- ruff check projects/04-llm-adapter-shadow/src/llm_adapter/runner_parallel/judge.py --select I001,UP035

------
https://chatgpt.com/codex/tasks/task_e_68e1d815fff48321b2efecb27c53ed78