### PR TITLE
Ensure per-provider failure metrics include identifiers

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -185,21 +185,6 @@ class AsyncRunner:
                 },
             )
         failure_error = AllFailedError("All providers failed to produce a result")
-        log_run_metric(
-            event_logger,
-            request_fingerprint=request_fingerprint,
-            request=request,
-            provider=None,
-            status="error",
-            attempts=attempt_count,
-            latency_ms=elapsed_ms(run_started),
-            tokens_in=None,
-            tokens_out=None,
-            cost_usd=0.0,
-            error=last_err or failure_error,
-            metadata=metadata,
-            shadow_used=shadow_used,
-        )
         if last_err is not None:
             if mode == RunnerMode.CONSENSUS or total_providers <= 1:
                 raise last_err

--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async_support.py
@@ -118,6 +118,7 @@ class AsyncProviderInvoker:
                 response = cast(ProviderResponse, response_only)
         except RateLimitError as err:
             enriched_metadata = _with_shadow_metadata(metadata)
+            latency_ms = elapsed_ms(attempt_started)
             log_run_metric(
                 event_logger,
                 request_fingerprint=request_fingerprint,
@@ -125,9 +126,9 @@ class AsyncProviderInvoker:
                 provider=provider,
                 status="error",
                 attempts=attempt,
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 cost_usd=0.0,
                 error=err,
                 metadata=enriched_metadata,
@@ -141,9 +142,9 @@ class AsyncProviderInvoker:
                 attempt=attempt,
                 total_providers=total_providers,
                 status="error",
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 error=err,
                 metadata=metadata,
                 shadow_used=shadow is not None,
@@ -152,6 +153,7 @@ class AsyncProviderInvoker:
             raise
         except RetryableError as err:
             enriched_metadata = _with_shadow_metadata(metadata)
+            latency_ms = elapsed_ms(attempt_started)
             log_run_metric(
                 event_logger,
                 request_fingerprint=request_fingerprint,
@@ -159,9 +161,9 @@ class AsyncProviderInvoker:
                 provider=provider,
                 status="error",
                 attempts=attempt,
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 cost_usd=0.0,
                 error=err,
                 metadata=enriched_metadata,
@@ -175,9 +177,9 @@ class AsyncProviderInvoker:
                 attempt=attempt,
                 total_providers=total_providers,
                 status="error",
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 error=err,
                 metadata=metadata,
                 shadow_used=shadow is not None,
@@ -186,6 +188,7 @@ class AsyncProviderInvoker:
             raise
         except SkipError as err:
             enriched_metadata = _with_shadow_metadata(metadata)
+            latency_ms = elapsed_ms(attempt_started)
             if isinstance(err, ProviderSkip):
                 log_provider_skipped(
                     event_logger,
@@ -203,9 +206,9 @@ class AsyncProviderInvoker:
                 provider=provider,
                 status="error",
                 attempts=attempt,
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 cost_usd=0.0,
                 error=err,
                 metadata=enriched_metadata,
@@ -219,9 +222,9 @@ class AsyncProviderInvoker:
                 attempt=attempt,
                 total_providers=total_providers,
                 status="error",
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 error=err,
                 metadata=metadata,
                 shadow_used=shadow is not None,
@@ -230,6 +233,7 @@ class AsyncProviderInvoker:
             raise
         except FatalError as err:
             enriched_metadata = _with_shadow_metadata(metadata)
+            latency_ms = elapsed_ms(attempt_started)
             log_run_metric(
                 event_logger,
                 request_fingerprint=request_fingerprint,
@@ -237,9 +241,9 @@ class AsyncProviderInvoker:
                 provider=provider,
                 status="error",
                 attempts=attempt,
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 cost_usd=0.0,
                 error=err,
                 metadata=enriched_metadata,
@@ -253,9 +257,9 @@ class AsyncProviderInvoker:
                 attempt=attempt,
                 total_providers=total_providers,
                 status="error",
-                latency_ms=elapsed_ms(attempt_started),
-                tokens_in=None,
-                tokens_out=None,
+                latency_ms=latency_ms,
+                tokens_in=0,
+                tokens_out=0,
                 error=err,
                 metadata=metadata,
                 shadow_used=shadow is not None,

--- a/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_async_failures.py
@@ -30,7 +30,12 @@ async def test_all_failed_error_is_raised_and_wrapped() -> None:
         await runner.run_async(request, shadow_metrics_path="unused.jsonl")
 
     assert isinstance(excinfo.value.__cause__, RetriableError)
-    run_event = logger.of_type("run_metric")[0]
+    run_events = logger.of_type("run_metric")
+    assert run_events, "expected run_metric events to be emitted"
+    for event in run_events:
+        assert isinstance(event["provider_id"], str)
+        assert event["provider_id"], "provider_id should not be empty"
+    run_event = run_events[0]
     assert run_event["status"] == "error"
     assert run_event["run_id"] == run_event["request_fingerprint"]
     assert run_event["mode"] == "sequential"


### PR DESCRIPTION
## Summary
- strengthen async and sequential failure tests to require provider identifiers on run_metric events
- emit per-attempt failure metrics with zero-token fallbacks in sequential and async runners
- remove aggregate failure run_metric logging so provider-level metrics are preserved

## Testing
- pytest -k "all_failed_error or sequential_strategy_all_failed" projects/04-llm-adapter-shadow/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e31a3f51408321b412120677e05478