### PR TITLE
Normalize failed status outcomes

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging/status.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_shared/logging/status.py
@@ -23,7 +23,7 @@ def error_family(error: Exception | None) -> str | None:
 def _normalize_outcome(status: str) -> str:
     normalized = status.lower()
     success_values = {"ok", "success"}
-    error_values = {"error", "errored", "failure"}
+    error_values = {"error", "errored", "failure", "fail", "failed"}
     skipped_values = {"skip", "skipped"}
     if normalized in success_values:
         return "success"

--- a/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
+++ b/projects/04-llm-adapter-shadow/tests/test_runner_shared.py
@@ -63,6 +63,33 @@ def test_log_provider_call_normalizes_errored_outcome(
     assert payload["outcome"] == "error"
 
 
+@pytest.mark.parametrize("status", ["failed", "fail"])
+def test_log_provider_call_normalizes_failed_status(
+    status: str, logger: _RecordingLogger, provider_request: ProviderRequest
+) -> None:
+    provider = _DummyProvider("dummy")
+
+    log_provider_call(
+        logger,
+        request_fingerprint="fingerprint",
+        provider=provider,
+        request=provider_request,
+        attempt=1,
+        total_providers=1,
+        status=status,
+        latency_ms=123,
+        tokens_in=10,
+        tokens_out=20,
+        error=None,
+        metadata={},
+        shadow_used=False,
+    )
+
+    _, payload = logger.events[-1]
+    assert payload["status"] == status
+    assert payload["outcome"] == "error"
+
+
 def test_log_provider_call_records_skip_outcome_from_skip_error(
     logger: _RecordingLogger, provider_request: ProviderRequest
 ) -> None:


### PR DESCRIPTION
## Summary
- add regression coverage ensuring failed provider statuses normalize to error outcomes
- treat "fail" and "failed" statuses as errors during outcome normalization

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_runner_shared.py -k normalize

------
https://chatgpt.com/codex/tasks/task_e_68e31a392000832182132f9874f5409f