### PR TITLE
Ensure AsyncRunner uses shared AllFailedError

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/runner_async.py
@@ -7,7 +7,7 @@ import time
 from typing import Any
 
 from ._event_loop import ensure_socket_free_event_loop_policy
-from .errors import FatalError
+from .errors import AllFailedError, FatalError
 from .observability import EventLogger
 from .parallel_exec import ParallelAllResult
 from .provider_spi import (
@@ -40,10 +40,6 @@ from .shadow import DEFAULT_METRICS_PATH, ShadowMetrics
 from .utils import content_hash, elapsed_ms
 
 ensure_socket_free_event_loop_policy()
-
-
-class AllFailedError(FatalError):
-    """Raised when all providers fail to produce a response."""
 
 
 class AsyncRunner:


### PR DESCRIPTION
## Summary
- ensure AsyncRunner reuses the shared llm_adapter.errors.AllFailedError class
- add regression test verifying AsyncRunner raises the shared AllFailedError when all providers fail

## Testing
- pytest projects/04-llm-adapter-shadow/tests/async_runner/test_basic.py::test_async_runner_raises_shared_all_failed_error

------
https://chatgpt.com/codex/tasks/task_e_68de08dca3fc83218d7a40ed479162a9