### PR TITLE
Ensure shadow async re-raises CancelledError after cleanup

### DIFF
--- a/projects/04-llm-adapter-shadow/src/llm_adapter/shadow_async.py
+++ b/projects/04-llm-adapter-shadow/src/llm_adapter/shadow_async.py
@@ -90,7 +90,6 @@ async def run_with_shadow_async(
         raise
 
     metrics: ShadowMetrics | None = None
-    cancelled_exc: asyncio.CancelledError | None = None
     if shadow_task is not None:
         try:
             shadow_payload = await asyncio.wait_for(shadow_task, timeout=10)
@@ -104,26 +103,23 @@ async def run_with_shadow_async(
                 else None
             )
             shadow_payload = _make_timeout_payload(shadow_name, duration_ms)
-        except asyncio.CancelledError as exc:  # pragma: no cover - defensive
+        except asyncio.CancelledError:  # pragma: no cover - defensive
             shadow_payload = _make_shadow_payload(provider_name=shadow_name)
-            cancelled_exc = exc
+            raise
+        finally:
+            if shadow_payload is None:
+                shadow_payload = _make_shadow_payload(provider_name=shadow_name)
 
-        if shadow_payload is None:
-            shadow_payload = _make_shadow_payload(provider_name=shadow_name)
-
-        metrics = _finalize_shadow_metrics(
-            metrics_path=metrics_path_str,
-            capture_metrics=capture_metrics,
-            logger=logger,
-            primary_provider_name=primary_async.name(),
-            primary_response=primary_res,
-            request=req,
-            shadow_payload=shadow_payload,
-            shadow_name=shadow_name,
-        )
-
-        if cancelled_exc is not None:
-            raise cancelled_exc
+            metrics = _finalize_shadow_metrics(
+                metrics_path=metrics_path_str,
+                capture_metrics=capture_metrics,
+                logger=logger,
+                primary_provider_name=primary_async.name(),
+                primary_response=primary_res,
+                request=req,
+                shadow_payload=shadow_payload,
+                shadow_name=shadow_name,
+            )
 
     if capture_metrics:
         return primary_res, metrics

--- a/projects/04-llm-adapter-shadow/tests/test_shadow_async.py
+++ b/projects/04-llm-adapter-shadow/tests/test_shadow_async.py
@@ -209,3 +209,45 @@ async def test_run_with_shadow_async_propagates_cancelled_error(
 
     with pytest.raises(asyncio.CancelledError):
         await run_with_shadow_async(primary, shadow, request)
+
+
+@pytest.mark.asyncio
+async def test_run_with_shadow_async_cancelled_error_finalizes_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = _DummyAsyncProvider(
+        "primary",
+        behaviour=lambda req: _immediate_response(
+            "primary", latency_ms=10, token_usage=TokenUsage(prompt=0, completion=0)
+        ),
+    )
+
+    async def _never_complete(_: ProviderRequest) -> ProviderResponse:
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    shadow = _DummyAsyncProvider("shadow", behaviour=_never_complete)
+
+    async def _cancel_and_raise(
+        awaitable: asyncio.Task[Any], timeout: float | None = None
+    ) -> Any:
+        awaitable.cancel()
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr("llm_adapter.shadow_async.asyncio.wait_for", _cancel_and_raise)
+
+    finalized_payload: dict[str, Any] | None = None
+
+    def _capture_finalize(**kwargs: Any) -> None:
+        nonlocal finalized_payload
+        finalized_payload = kwargs.get("shadow_payload")
+        return None
+
+    monkeypatch.setattr("llm_adapter.shadow_async._finalize_shadow_metrics", _capture_finalize)
+
+    request = ProviderRequest(prompt="hello", model="primary-model")
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_with_shadow_async(primary, shadow, request)
+
+    assert finalized_payload is not None


### PR DESCRIPTION
## Summary
- ensure the shadow async worker always re-raises asyncio.CancelledError after running cleanup
- finalize shadow metrics within a finally block so cleanup executes before propagation
- add regression coverage for cancellation to confirm metrics finalization occurs

## Testing
- pytest projects/04-llm-adapter-shadow/tests/test_shadow_async.py


------
https://chatgpt.com/codex/tasks/task_e_6902aa251a7c832180df11b0a626afdd